### PR TITLE
Add option to exclude run destination info from JUnit report

### DIFF
--- a/XCTestHTMLReport/XCTestHTMLReport/Classes/Models/JUnitReport.swift
+++ b/XCTestHTMLReport/XCTestHTMLReport/Classes/Models/JUnitReport.swift
@@ -126,21 +126,23 @@ extension JUnitReport.TestResult: XMLRepresentable
 
 extension JUnitReport
 {
-    init(summary: Summary)
+    init(summary: Summary, includeRunDestinationInfo: Bool)
     {
         name = "All"
-        suites = summary.runs.map { JUnitReport.TestSuite(run: $0) }
+        suites = summary.runs.map { JUnitReport.TestSuite(run: $0, includeRunDestinationInfo: includeRunDestinationInfo) }
     }
 }
 
 extension JUnitReport.TestCase
 {
-    init(run: Run, test: Test)
+    init(run: Run, test: Test, includeRunDestinationInfo: Bool)
     {
         let components = test.identifier.components(separatedBy: "/")
         time = test.duration
         name = components.last ?? ""
-        classname = (components.first ?? "") + " - " + run.runDestination.deviceInfo
+
+        let baseClassname = components.first ?? ""
+        classname = includeRunDestinationInfo ? baseClassname + " - " + run.runDestination.deviceInfo : baseClassname
 
         switch test.status {
         case .failure:
@@ -171,11 +173,12 @@ extension JUnitReport.TestResult
 
 extension JUnitReport.TestSuite
 {
-    init(run: Run)
+    init(run: Run, includeRunDestinationInfo: Bool)
     {
-        name = (run.testSummaries.first?.testName ?? "") + " - " + run.runDestination.deviceInfo
+        let baseName = run.testSummaries.first?.testName ?? ""
+        name = includeRunDestinationInfo ? baseName + " - " + run.runDestination.deviceInfo : baseName
         tests = run.numberOfTests
-        cases = run.allTests.map { JUnitReport.TestCase(run: run, test: $0) }
+        cases = run.allTests.map { JUnitReport.TestCase(run: run, test: $0, includeRunDestinationInfo: includeRunDestinationInfo) }
     }
 }
 

--- a/XCTestHTMLReport/XCTestHTMLReport/Classes/Models/Summary.swift
+++ b/XCTestHTMLReport/XCTestHTMLReport/Classes/Models/Summary.swift
@@ -63,7 +63,7 @@ extension Summary: HTML
 
 extension Summary: JUnitRepresentable
 {
-    var junit: JUnitReport {
-        return JUnitReport(summary: self)
+    func junit(includeRunDestinationInfo: Bool) -> JUnitReport {
+        return JUnitReport(summary: self, includeRunDestinationInfo: includeRunDestinationInfo)
     }
 }

--- a/XCTestHTMLReport/XCTestHTMLReport/Classes/Protocols/JUnitRepresentable.swift
+++ b/XCTestHTMLReport/XCTestHTMLReport/Classes/Protocols/JUnitRepresentable.swift
@@ -10,5 +10,5 @@ import Foundation
 
 protocol JUnitRepresentable
 {
-    var junit: JUnitReport { get }
+    func junit(includeRunDestinationInfo: Bool) -> JUnitReport
 }

--- a/XCTestHTMLReport/XCTestHTMLReport/Classes/main.swift
+++ b/XCTestHTMLReport/XCTestHTMLReport/Classes/main.swift
@@ -20,13 +20,17 @@ var help = BlockArgument("h", "", required: false, helpMessage: "Print usage and
 var verbose = BlockArgument("v", "", required: false, helpMessage: "Provide additional logs") {
     Logger.verbose = true
 }
+var includeRunDestinationInfo = true
+var runDestinationInfo = BlockArgument("e", "exclude-run-destination-info", required: false, helpMessage: "Removes the run destination info from the generated XML") {
+    includeRunDestinationInfo = false
+}
 var junitEnabled = false
 var junit = BlockArgument("j", "junit", required: false, helpMessage: "Provide JUnit XML output") {
     junitEnabled = true
 }
 var result = ValueArgument(.path, "r", "resultBundlePath", required: true, allowsMultiple: true, helpMessage: "Path to a result bundle (allows multiple)")
 
-command.arguments = [help, verbose, junit, result]
+command.arguments = [help, verbose, junit, runDestinationInfo, result]
 
 if !command.isValid {
     print(command.usage)
@@ -51,7 +55,7 @@ catch let e {
 
 if junitEnabled {
     Logger.step("Building JUnit..")
-    let junitXml = summary.junit.xmlString
+    let junitXml = summary.junit(includeRunDestinationInfo: includeRunDestinationInfo).xmlString
     do {
         let path = "\(result.values.first!)/report.junit"
         Logger.substep("Writing JUnit report to \(path)")


### PR DESCRIPTION
The `--junit` option in the "deprecated" `xcpretty` used to generate a JUnit report file that didn't contain the name of the platform being used to run the test.

The name of the run destination is not necessarily a useful info to have everywhere in the test report and I feel like we should be able opt out of it.

This adds a new command line option (`-e`) to exclude those info from the report.