### PR TITLE
GH Action for CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CD
+
+on:
+  push:
+    branches: [ develop ]
+  pull_request:
+    branches: [ develop ]
+
+jobs:
+  build:
+    strategy:
+      fail-fast: true
+      matrix:
+        xcode_version: [12.5, 13.0]
+    runs-on: macos-11
+    
+    steps:
+    - uses: actions/checkout@v2
+    
+    - name: Xcode Select
+      uses: devbotsxyz/xcode-select@v1.1.0
+      with:
+        version: ${{ matrix.xcode_version }}
+
+    - name: Build
+      run: swift build -v -c release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,3 +24,6 @@ jobs:
 
     - name: Build
       run: swift build -v -c release
+      
+    - name: Test
+      run: swift test -v


### PR DESCRIPTION
Create a basic GitHub action to build/test the primary executable against N & N-1 Xcode versions on PR/push to trunk