### PR TITLE
Sign & Release Pipeline

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -23,7 +23,7 @@ jobs:
         p12-file-base64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
         p12-password: ${{ secrets.P12_PASSWORD }}
 
-    - name: Install gon via HomeBrew for code signing and app notarization
+    - name: Install Gon
       run: |
         brew tap mitchellh/gon
         brew install mitchellh/gon/gon

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,83 @@
+name: Sign Release
+
+on:
+  push:
+   tags:
+     - '*'
+  workflow_dispatch:
+
+jobs:
+  build:
+    strategy:
+      fail-fast: true
+      matrix:
+        xcode_version: [12.5, 13.0]
+    runs-on: macos-11
+    
+    steps:
+    - uses: actions/checkout@v2
+    
+    - name: Configure Signing
+      uses: Apple-Actions/import-codesign-certs@v1
+      with:
+        p12-file-base64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
+        p12-password: ${{ secrets.P12_PASSWORD }}
+
+    - name: Install gon via HomeBrew for code signing and app notarization
+      run: |
+        brew tap mitchellh/gon
+        brew install mitchellh/gon/gon
+
+    - name: Xcode Select
+      uses: devbotsxyz/xcode-select@v1.1.0
+      with:
+        version: ${{ matrix.xcode_version }}
+
+    - name: Get version
+      id: get_version
+      run: echo ::set-output name=version::${GITHUB_REF/refs\/tags\//}
+
+    - name: Build
+      run: swift build -v -c release
+      
+    - name: Sign
+      run: |
+        codesign --verbose --verify --options=runtime -f -s "Developer ID Application: Tyler Vick (352UZEKYPP)" .build/x86_64-apple-macosx/release/xchtmlreport
+    
+    - name: Verify
+      run: codesign -vvv --deep --strict .build/x86_64-apple-macosx/release/xchtmlreport
+
+    - name: Package
+      run: |
+        ditto -c -k --keepParent ".build/x86_64-apple-macosx/release/xchtmlreport" xchtmlreport.zip
+
+    - name: Notarize
+      run: |
+        gon gon.json
+      env:
+        AC_PASSWORD: ${{ secrets.AC_PASSWORD }}
+        AC_USERNAME: ${{ secrets.AC_USERNAME }}
+
+    - name: Archive
+      uses: actions/upload-artifact@v2
+      with:
+        name: application
+        path: xchtmlreport.zip
+
+  release:
+    runs-on: macos-11
+    
+    needs: [build]
+    
+    steps:
+    - name: Download
+      uses: actions/download-artifact@v2
+    
+    - name: Release
+      uses: softprops/action-gh-release@v1
+      with:
+        prerelease: ${{ contains(github.ref, '-') }}
+        files: |
+          artifact-*/xchtmlreport-*
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/gon.json
+++ b/gon.json
@@ -1,0 +1,11 @@
+{
+  "notarize": [{
+    "path": "xchtmlreport.zip",
+    "bundle_id": "com.xctesthtmlreport.xctesthtmlreport",
+    "staple": false
+  }],
+  "apple_id": {
+    "username": "@env:AC_USERNAME",
+    "password": "@env:AC_PASSWORD"
+  }
+}


### PR DESCRIPTION
A github action `cd.yml` to build, sign, notarize, and release xchtmlreport binaries built against xcode 12.5 & 13.

Requires the following secrets:

- BUILD_CERTIFICATE_BASE64 - A b64 encoded string for the app identity cert
- P12_PASSWORD - The password for the above cert
- KEYCHAIN_PASSWORD - hardcoded pw for the builder keychain
- AC_USERNAME - apple dev account application username
- AC_PASSWORD - apple dev account application pw