### PR TITLE
Fix brew url

### DIFF
--- a/xchtmlreport.rb
+++ b/xchtmlreport.rb
@@ -1,8 +1,8 @@
 class Xchtmlreport < Formula
   desc "XCTestHTMLReport: Xcode-like HTML report for Unit and UI Tests"
   homepage "https://github.com/XCTestHTMLReport/XCTestHTMLReport"
-  url "https://github.com/XCTestHTMLReport/XCTestHTMLReport/releases/download/2.2.0/xchtmlreport-2.2.0.zip"
-  sha256 "eb9dc25cd49ff0f44bc28799cd567151df473d3d074bfb7b141111a451f08e36"
+  url "https://github.com/XCTestHTMLReport/XCTestHTMLReport/archive/refs/tags/2.2.0.tar.gz"
+  sha256 "bdab5934a92df2dfbeea40c3f0fefba816b48cb1c125785e87514ec0a534fada"
   license "MIT"
   head "https://github.com/XCTestHTMLReport/XCTestHTMLReport.git", :branch => "main"
 


### PR DESCRIPTION
Brew url was incorrectly set to the releasee artifact instead of the source archive.

fixing #228 