### PR TITLE
Release HTML string replacement memory

### DIFF
--- a/Sources/XCTestHTMLReportCore/Classes/Protocols/HTML.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Protocols/HTML.swift
@@ -18,7 +18,9 @@ extension HTML
 {
     var html: String {
         return htmlPlaceholderValues.reduce(htmlTemplate, { (accumulator: String, rel: (String, String)) -> String in
-            return accumulator.replacingOccurrences(of: "[[\(rel.0)]]", with: rel.1)
+            return autoreleasepool {
+                accumulator.replacingOccurrences(of: "[[\(rel.0)]]", with: rel.1)
+            }
         })
     }
 }


### PR DESCRIPTION
**Background:**
The current implementation of HTML templating relies on NSString's `stringByReplacingOccurrencesOfString`. The recursive approach here results in a massive number of strings hanging around waiting to be autoreleased. This is particularly evident when using `--renderingMode inline` where all attachments will be contained in this pool.

**Change:**
Quick fix by using `autoreleasepool` to dealloc strings as the html is being accumulated.


A 180 MB result file before:
<img width="1396" alt="Screen Shot 2021-10-12 at 6 49 17 PM" src="https://user-images.githubusercontent.com/1395852/137050238-d8eedf31-8379-4123-8329-b15cf876ea0f.png">
and after:
<img width="1396" alt="Screen Shot 2021-10-12 at 6 49 22 PM" src="https://user-images.githubusercontent.com/1395852/137050427-1eab70df-262f-46fc-9cbd-6b9c7f47b0b1.png">

This is more drastic with the bundle size, but a similar magnitude can be observed on bundles (tested as small as 7.5 MB).