### PR TITLE
Issue #217 Fix to eliminate re-counting of retried test cases, and append "retry iteration #" on names of retried tests

### DIFF
--- a/Sources/XCTestHTMLReportCore/Classes/Models/JUnitReport.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Models/JUnitReport.swift
@@ -194,7 +194,6 @@ extension JUnitReport.TestSuite
         name = (run.testSummaries.first?.testName ?? "") + " - " + run.runDestination.deviceInfo
         tests = run.numberOfTests        
         cases = run.allTests.map { JUnitReport.TestCase(run: run, test: $0) }
-        cases = appendNameForRetriedTestCases(testcases: cases)
     }
     
     func removeDuplicateTestCases(testcases: [JUnitReport.TestCase]) -> [JUnitReport.TestCase] {
@@ -214,18 +213,6 @@ extension JUnitReport.TestSuite
             }
         }
         return uniqueTests
-    }
-    
-    func appendNameForRetriedTestCases(testcases: [JUnitReport.TestCase]) -> [JUnitReport.TestCase] {
-        var allTests = [JUnitReport.TestCase]()
-        for var testcase in testcases {
-            let duplicateTestCount = allTests.filter({ $0.classname == testcase.classname && $0.name == testcase.name }).count
-            if duplicateTestCount > 0 {
-                testcase.name = testcase.name + " - retry iteration \(duplicateTestCount + 1)"
-            }
-            allTests.append(testcase)
-        }
-        return allTests
     }
 }
 

--- a/Sources/XCTestHTMLReportCore/Classes/Models/JUnitReport.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Models/JUnitReport.swift
@@ -24,7 +24,6 @@ struct JUnitReport
         var tests: Int
         var failures: Int {
             return uniqueCases.filter { $0.state == .failed }.count
-            //return cases.filter { $0.state == .failed }.count
         }
         var cases: [TestCase]
         var uniqueCases: [TestCase] {

--- a/Sources/XCTestHTMLReportCore/Classes/Models/JUnitReport.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Models/JUnitReport.swift
@@ -194,6 +194,7 @@ extension JUnitReport.TestSuite
         name = (run.testSummaries.first?.testName ?? "") + " - " + run.runDestination.deviceInfo
         tests = run.numberOfTests        
         cases = run.allTests.map { JUnitReport.TestCase(run: run, test: $0) }
+        cases = appendNameForRetriedTestCases(testcases: cases)
     }
     
     func removeDuplicateTestCases(testcases: [JUnitReport.TestCase]) -> [JUnitReport.TestCase] {
@@ -213,6 +214,18 @@ extension JUnitReport.TestSuite
             }
         }
         return uniqueTests
+    }
+    
+    func appendNameForRetriedTestCases(testcases: [JUnitReport.TestCase]) -> [JUnitReport.TestCase] {
+        var allTests = [JUnitReport.TestCase]()
+        for var testcase in testcases {
+            let duplicateTestCount = allTests.filter({ $0.classname == testcase.classname && $0.name == testcase.name }).count
+            if duplicateTestCount > 0 {
+                testcase.name = testcase.name + " - retry iteration \(duplicateTestCount + 1)"
+            }
+            allTests.append(testcase)
+        }
+        return allTests
     }
 }
 

--- a/Sources/XCTestHTMLReportCore/Classes/Models/Run.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Models/Run.swift
@@ -32,18 +32,26 @@ struct Run: HTML
                 : test.allSubTests
         }
     }
+    var allUniqueTests: [Test] {
+        let tests = testSummaries.flatMap { $0.tests }
+        return tests.flatMap { test -> [Test] in
+            return test.allUniqueSubTests.isEmpty
+                ? [test]
+                : test.allUniqueSubTests
+        }
+    }
     var numberOfTests : Int {
-        let a = allTests
+        let a = allUniqueTests
         return a.count
     }
     var numberOfPassedTests : Int {
-        return allTests.filter { $0.status == .success }.count
+        return allUniqueTests.filter { $0.status == .success }.count
     }
     var numberOfSkippedTests : Int {
-        return allTests.filter { $0.status == .skipped }.count
+        return allUniqueTests.filter { $0.status == .skipped }.count
     }
     var numberOfFailedTests : Int {
-        return allTests.filter { $0.status == .failure }.count
+        return allUniqueTests.filter { $0.status == .failure }.count
     }
 
     init?(action: ActionRecord, file: ResultFile, renderingMode: Summary.RenderingMode) {

--- a/Sources/XCTestHTMLReportCore/Classes/Models/Test.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Models/Test.swift
@@ -55,7 +55,7 @@ struct Test: HTML
     let identifier: String
     let duration: Double
     let name: String
-    let subTests: [Test]
+    var subTests: [Test]
     let activities: [Activity]
     let status: Status
     let objectClass: ObjectClass
@@ -83,6 +83,7 @@ struct Test: HTML
             self.subTests = group.subtestGroups.map { Test(group: $0, file: file, renderingMode: renderingMode) }
         } else {
             self.subTests = group.subtests.map { Test(metadata: $0, file: file, renderingMode: renderingMode) }
+            
         }
         self.objectClass = .testSummaryGroup
         self.activities = []
@@ -107,6 +108,7 @@ struct Test: HTML
             self.activities = []
         }
         testScreenshotFlow = TestScreenshotFlow(activities: activities)
+        subTests = removeDuplicateElements(testcases: self.subTests)        
     }
 
     // PRAGMA MARK: - HTML
@@ -116,7 +118,8 @@ struct Test: HTML
     var htmlPlaceholderValues: [String: String] {
         return [
             "UUID": uuid,
-            "NAME": name + (amountSubTests > 0 ? " - \(amountSubTests) tests" : ""),
+            ///"NAME": name + (amountSubTests > 0 ? " - \(amountSubTests) tests" : ""),
+            "NAME": name + (" - \(subTests.count) tests"),
             "TIME": duration.timeString,
             "SUB_TESTS": subTests.reduce("") { (accumulator: String, test: Test) -> String in
                 return accumulator + test.html
@@ -129,5 +132,25 @@ struct Test: HTML
             "SCREENSHOT_FLOW": testScreenshotFlow?.screenshots.accumulateHTMLAsString ?? "",
             "SCREENSHOT_TAIL": testScreenshotFlow?.screenshotsTail.accumulateHTMLAsString ?? ""
         ]
+    }
+    
+    func removeDuplicateElements(testcases: [Test]) -> [Test] {
+        print("running removeDuplicateElements")
+        var uniqueTests = [Test]()
+        for testcase in testcases {
+            print("testcase.identifier is \(testcase.identifier)")
+            print("testcase.name is \(testcase.name)")
+            print("testcase.activities is \(testcase.activities)")
+            print("testcase.uuid is \(testcase.uuid)")
+            print("testcase.subTests is \(testcase.subTests)")
+            print("testcase.subTests count is \(testcase.subTests.count)")
+            print("testcase.objectClass is \(testcase.objectClass)")
+            print("testcase.status is \(testcase.status)")
+            print("testcase.testScreenshotFlow is \(testcase.testScreenshotFlow)")
+            if !uniqueTests.contains(where: {$0.identifier == testcase.identifier && $0.objectClass == .testSummary }) {
+                uniqueTests.append(testcase)
+            }
+        }
+        return uniqueTests
     }
 }

--- a/Sources/XCTestHTMLReportCore/Classes/Models/Test.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Models/Test.swift
@@ -61,8 +61,12 @@ struct Test: HTML
     let objectClass: ObjectClass
     let testScreenshotFlow: TestScreenshotFlow?
 
+    var subTestsUnique: [Test] {
+        return removeDuplicateElements(testcases: subTests)
+    }
+    
     var allSubTests: [Test] {
-        return subTests.flatMap { test -> [Test] in
+        return subTestsUnique.flatMap { test -> [Test] in
             return test.allSubTests.isEmpty
                 ? [test]
                 : test.allSubTests
@@ -70,8 +74,8 @@ struct Test: HTML
     }
 
     var amountSubTests: Int {
-        let a = subTests.reduce(0) { $0 + $1.amountSubTests }
-        return a == 0 ? subTests.count : a
+        let a = subTestsUnique.reduce(0) { $0 + $1.amountSubTests }
+        return a == 0 ? subTestsUnique.count : a
     }
 
     init(group: ActionTestSummaryGroup, file: ResultFile, renderingMode: Summary.RenderingMode) {
@@ -88,7 +92,7 @@ struct Test: HTML
         self.activities = []
         self.status = .unknown // ???: Usefull?
         testScreenshotFlow = TestScreenshotFlow(activities: activities)
-        subTests = removeDuplicateElements(testcases: self.subTests)
+        self.subTests = appendNameForRetriedTests(testcases: self.subTests)
     }
 
     init(metadata: ActionTestMetadata, file: ResultFile, renderingMode: Summary.RenderingMode) {
@@ -96,7 +100,7 @@ struct Test: HTML
         self.identifier = metadata.identifier
         self.duration = metadata.duration ?? 0
         self.name = metadata.name
-        self.subTests = []
+        self.subTests = []        
         self.status = Status(rawValue: metadata.testStatus) ?? .failure
         self.objectClass = .testSummary
         if let id = metadata.summaryRef?.id,

--- a/Sources/XCTestHTMLReportCore/Classes/Models/Test.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Models/Test.swift
@@ -121,8 +121,7 @@ struct Test: HTML
     var htmlPlaceholderValues: [String: String] {
         return [
             "UUID": uuid,
-            ///"NAME": name + (amountSubTests > 0 ? " - \(amountSubTests) tests" : ""),
-            "NAME": name + (" - \(subTests.count) tests"),
+            "NAME": name + (amountSubTests > 0 ? " - \(amountSubTests) tests" : ""),
             "TIME": duration.timeString,
             "SUB_TESTS": subTests.reduce("") { (accumulator: String, test: Test) -> String in
                 return accumulator + test.html

--- a/Sources/XCTestHTMLReportCore/Classes/Models/Test.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Models/Test.swift
@@ -83,12 +83,12 @@ struct Test: HTML
             self.subTests = group.subtestGroups.map { Test(group: $0, file: file, renderingMode: renderingMode) }
         } else {
             self.subTests = group.subtests.map { Test(metadata: $0, file: file, renderingMode: renderingMode) }
-            
         }
         self.objectClass = .testSummaryGroup
         self.activities = []
         self.status = .unknown // ???: Usefull?
         testScreenshotFlow = TestScreenshotFlow(activities: activities)
+        subTests = removeDuplicateElements(testcases: self.subTests)
     }
 
     init(metadata: ActionTestMetadata, file: ResultFile, renderingMode: Summary.RenderingMode) {
@@ -107,8 +107,7 @@ struct Test: HTML
         } else {
             self.activities = []
         }
-        testScreenshotFlow = TestScreenshotFlow(activities: activities)
-        subTests = removeDuplicateElements(testcases: self.subTests)
+        testScreenshotFlow = TestScreenshotFlow(activities: activities)        
     }
 
     // PRAGMA MARK: - HTML

--- a/Sources/XCTestHTMLReportCore/Classes/Models/Test.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Models/Test.swift
@@ -108,7 +108,7 @@ struct Test: HTML
             self.activities = []
         }
         testScreenshotFlow = TestScreenshotFlow(activities: activities)
-        subTests = removeDuplicateElements(testcases: self.subTests)        
+        subTests = removeDuplicateElements(testcases: self.subTests)
     }
 
     // PRAGMA MARK: - HTML

--- a/Sources/XCTestHTMLReportCore/Classes/Models/Test.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Models/Test.swift
@@ -54,7 +54,7 @@ struct Test: HTML
     let uuid: String
     let identifier: String
     let duration: Double
-    let name: String
+    var name: String
     var subTests: [Test]
     let activities: [Activity]
     let status: Status
@@ -134,22 +134,26 @@ struct Test: HTML
     }
     
     func removeDuplicateElements(testcases: [Test]) -> [Test] {
-        print("running removeDuplicateElements")
         var uniqueTests = [Test]()
         for testcase in testcases {
-            print("testcase.identifier is \(testcase.identifier)")
-            print("testcase.name is \(testcase.name)")
-            print("testcase.activities is \(testcase.activities)")
-            print("testcase.uuid is \(testcase.uuid)")
-            print("testcase.subTests is \(testcase.subTests)")
-            print("testcase.subTests count is \(testcase.subTests.count)")
-            print("testcase.objectClass is \(testcase.objectClass)")
-            print("testcase.status is \(testcase.status)")
-            print("testcase.testScreenshotFlow is \(testcase.testScreenshotFlow)")
             if !uniqueTests.contains(where: {$0.identifier == testcase.identifier && $0.objectClass == .testSummary }) {
                 uniqueTests.append(testcase)
             }
         }
         return uniqueTests
     }
+    
+    func appendNameForRetriedTests(testcases: [Test]) -> [Test] {
+        var allTests = [Test]()
+        for var testcase in testcases {
+            let duplicateTest = allTests.filter({ $0.identifier == testcase.identifier && $0.objectClass == .testSummary })
+            let count = duplicateTest.count
+            if count > 0 {
+                testcase.name = testcase.name + " - retry iteration \(count + 1)"
+            }
+            allTests.append(testcase)
+        }
+        return allTests
+    }
+
 }

--- a/Sources/XCTestHTMLReportCore/Classes/Models/Test.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Models/Test.swift
@@ -54,7 +54,8 @@ struct Test: HTML
     let uuid: String
     let identifier: String
     let duration: Double
-    var name: String
+    let name: String
+    var reportName: String
     var subTests: [Test]
     let activities: [Activity]
     let status: Status
@@ -82,7 +83,9 @@ struct Test: HTML
         self.uuid = NSUUID().uuidString
         self.identifier = group.identifier ?? "---identifier-not-found---"
         self.duration = group.duration
-        self.name = group.name ?? "---group-name-not-found---"
+        let name = group.name ?? "---group-name-not-found---"
+        self.name = name
+        self.reportName = name
         if group.subtests.isEmpty {
             self.subTests = group.subtestGroups.map { Test(group: $0, file: file, renderingMode: renderingMode) }
         } else {
@@ -99,7 +102,9 @@ struct Test: HTML
         self.uuid = NSUUID().uuidString
         self.identifier = metadata.identifier
         self.duration = metadata.duration ?? 0
-        self.name = metadata.name
+        let name = metadata.name
+        self.name = name
+        self.reportName = name
         self.subTests = []
         self.status = Status(rawValue: metadata.testStatus) ?? .failure
         self.objectClass = .testSummary
@@ -121,7 +126,7 @@ struct Test: HTML
     var htmlPlaceholderValues: [String: String] {
         return [
             "UUID": uuid,
-            "NAME": name + (amountSubTests > 0 ? " - \(amountSubTests) tests" : ""),
+            "NAME": reportName + (amountSubTests > 0 ? " - \(amountSubTests) tests" : ""),
             "TIME": duration.timeString,
             "SUB_TESTS": subTests.reduce("") { (accumulator: String, test: Test) -> String in
                 return accumulator + test.html
@@ -160,11 +165,10 @@ struct Test: HTML
         for var testcase in testcases {
             let duplicateTestCount = allTests.filter({ $0.identifier == testcase.identifier && $0.objectClass == .testSummary }).count
             if duplicateTestCount > 0 {
-                testcase.name = testcase.name + " - retry iteration \(duplicateTestCount + 1)"
+                testcase.reportName = testcase.reportName + " - retry iteration \(duplicateTestCount + 1)"
             }
             allTests.append(testcase)
         }
         return allTests
     }
-
 }

--- a/Sources/XCTestHTMLReportCore/Classes/Models/Test.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Models/Test.swift
@@ -54,8 +54,7 @@ struct Test: HTML
     let uuid: String
     let identifier: String
     let duration: Double
-    let name: String
-    var reportName: String
+    var name: String
     var subTests: [Test]
     let activities: [Activity]
     let status: Status
@@ -66,8 +65,16 @@ struct Test: HTML
         return removeDuplicateElements(testcases: subTests)
     }
     
-    var allSubTests: [Test] {
+    var allUniqueSubTests: [Test] {
         return subTestsUnique.flatMap { test -> [Test] in
+            return test.allUniqueSubTests.isEmpty
+                ? [test]
+                : test.allUniqueSubTests
+        }
+    }
+    
+    var allSubTests: [Test] {
+        return subTests.flatMap { test -> [Test] in
             return test.allSubTests.isEmpty
                 ? [test]
                 : test.allSubTests
@@ -83,9 +90,7 @@ struct Test: HTML
         self.uuid = NSUUID().uuidString
         self.identifier = group.identifier ?? "---identifier-not-found---"
         self.duration = group.duration
-        let name = group.name ?? "---group-name-not-found---"
-        self.name = name
-        self.reportName = name
+        self.name = group.name ?? "---group-name-not-found---"
         if group.subtests.isEmpty {
             self.subTests = group.subtestGroups.map { Test(group: $0, file: file, renderingMode: renderingMode) }
         } else {
@@ -102,9 +107,7 @@ struct Test: HTML
         self.uuid = NSUUID().uuidString
         self.identifier = metadata.identifier
         self.duration = metadata.duration ?? 0
-        let name = metadata.name
-        self.name = name
-        self.reportName = name
+        self.name = metadata.name
         self.subTests = []
         self.status = Status(rawValue: metadata.testStatus) ?? .failure
         self.objectClass = .testSummary
@@ -126,7 +129,7 @@ struct Test: HTML
     var htmlPlaceholderValues: [String: String] {
         return [
             "UUID": uuid,
-            "NAME": reportName + (amountSubTests > 0 ? " - \(amountSubTests) tests" : ""),
+            "NAME": name + (amountSubTests > 0 ? " - \(amountSubTests) tests" : ""),
             "TIME": duration.timeString,
             "SUB_TESTS": subTests.reduce("") { (accumulator: String, test: Test) -> String in
                 return accumulator + test.html
@@ -165,7 +168,7 @@ struct Test: HTML
         for var testcase in testcases {
             let duplicateTestCount = allTests.filter({ $0.identifier == testcase.identifier && $0.objectClass == .testSummary }).count
             if duplicateTestCount > 0 {
-                testcase.reportName = testcase.reportName + " - retry iteration \(duplicateTestCount + 1)"
+                testcase.name = testcase.name + " - retry iteration \(duplicateTestCount + 1)"
             }
             allTests.append(testcase)
         }

--- a/XCTestHTMLReportSampleApp/SampleAppUITests/FirstSuite.swift
+++ b/XCTestHTMLReportSampleApp/SampleAppUITests/FirstSuite.swift
@@ -79,4 +79,12 @@ class FirstSuite: XCTestCase {
             XCTAssert(false, "Test with \(specialChars) failed on purpose")
         }
     }
+    
+    /// This test is a good candidate to test retry test counts for a partial failed case
+    func testThree() {
+        let array = [1, 2, 3, 5, 7, 8, 9]
+        let randomItem = array.randomElement() ?? 3
+        print("random item selected from the array is \(randomItem)")
+        XCTAssert(randomItem % 2 == 0, "random item is not an even number")
+    }
 }

--- a/prepareTestResults.sh
+++ b/prepareTestResults.sh
@@ -11,6 +11,13 @@ xcodebuild test \
     -scheme MainScheme \
     -destination 'platform=iOS Simulator,name=iPhone 8,OS=latest' \
     -resultBundlePath "$FILENAME" || true
+#xcodebuild test \
+#    -project SampleApp.xcodeproj \
+#    -scheme MainScheme \
+#    -destination 'platform=iOS Simulator,name=iPhone 8,OS=latest' \
+#    -test-iterations 5 \
+#    -retry-tests-on-failure \
+#    -resultBundlePath "$FILENAME" || true
 echo "Even if some test failed this is OK."
 echo "${FILENAME} should contain succeed, failed and skipped tests for xchtmlreport functional testing"
 rm -rf "../Tests/XCTestHTMLReportTests/${FILENAME}"

--- a/prepareTestResults.sh
+++ b/prepareTestResults.sh
@@ -10,14 +10,9 @@ xcodebuild test \
     -project SampleApp.xcodeproj \
     -scheme MainScheme \
     -destination 'platform=iOS Simulator,name=iPhone 8,OS=latest' \
+    -test-iterations 5 \
+    -retry-tests-on-failure \
     -resultBundlePath "$FILENAME" || true
-#xcodebuild test \
-#    -project SampleApp.xcodeproj \
-#    -scheme MainScheme \
-#    -destination 'platform=iOS Simulator,name=iPhone 8,OS=latest' \
-#    -test-iterations 5 \
-#    -retry-tests-on-failure \
-#    -resultBundlePath "$FILENAME" || true
 echo "Even if some test failed this is OK."
 echo "${FILENAME} should contain succeed, failed and skipped tests for xchtmlreport functional testing"
 rm -rf "../Tests/XCTestHTMLReportTests/${FILENAME}"


### PR DESCRIPTION
Fix for https://github.com/XCTestHTMLReport/XCTestHTMLReport/issues/217
#217 

Fix will include:
1) Eliminating duplicate counts of retried tests in HTML as well JUNIT report
![image](https://user-images.githubusercontent.com/15973152/142512733-b4f35b62-52ae-494a-bec2-050bcba484f2.png)
All = Total Unique Tests (Same as XCode)
Passed = Passed + Mixed (These tests may have failed but passed on retry, they are categorized as Mixed in XCode)
Failed = Total Unique Failed Tests (It won't count retried tests)

As now you can see we match closely with XCode pattern.

2) Appending "retry iteration #" to different retried tests on HTML report
![image](https://user-images.githubusercontent.com/15973152/142488328-b63db1de-9a1b-4152-9446-fe70c86710b6.png)
