### PR TITLE
Fix emitted logs for Xcode 13 output

### DIFF
--- a/Sources/XCTestHTMLReportCore/Classes/Models/ResultFile.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Models/ResultFile.swift
@@ -78,7 +78,7 @@ class ResultFile {
         let fileManager = FileManager.default
         do {
             try? fileManager.removeItem(at: url)
-            try logSection.emittedOutput?.write(to: url, atomically: true, encoding: .utf8)
+            try logSection.formatEmittedOutput().write(to: url, atomically: true, encoding: .utf8)
             return relativeUrl.appendingPathComponent(fileName)
         } catch {
             Logger.warning("Can't write output to \(url). \(error.localizedDescription)")
@@ -91,7 +91,7 @@ class ResultFile {
             Logger.warning("Can't get logss with id \(id)")
             return nil
         }
-        return logSection.emittedOutput?.data(using: .utf8)
+        return logSection.formatEmittedOutput().data(using: .utf8)
     }
 }
 

--- a/Sources/XCTestHTMLReportCore/Classes/Protocols/EmittableOutput.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Protocols/EmittableOutput.swift
@@ -9,30 +9,33 @@ import Foundation
 import XCResultKit
 
 protocol EmittableOutput {
-    var emittedOutput: String? { get }
+    func formatEmittedOutput() -> String
 }
 
-extension ActivityLogUnitTestSection: EmittableOutput {}
+extension ActivityLogUnitTestSection: EmittableOutput {
 
+    // Recursively collect emitted output from each subsection, adding an additional indent to each nested log
+    // This is how test steps are formatted in Xcode, including the repeated log lines
+    func formatEmittedOutput() -> String {
+        "-------- \(title) --------\n" +
+        (emittedOutput ?? "") +
+        unitTestSubsections
+            .compactMap {
+                "\t" + $0.formatEmittedOutput()
+                    .split(separator: "\n")
+                    .joined(separator: "\n\t")
+            }
+            .joined(separator: "\n")
+    }
+
+}
 
 extension ActivityLogSection: EmittableOutput {
 
-    var emittedOutput: String? {
-        return "\(title)\n\n"
-            + subsections
-                .compactMap { $0.emittedOutput }
-                .joined(separator: "\n")
+    func formatEmittedOutput() -> String {
+        "\(title)\n\n" + unitTestSubsections
+            .compactMap { $0.formatEmittedOutput() }
+            .joined(separator: "\n")
     }
+
 }
-
-extension ActivityLogMajorSection: EmittableOutput {
-
-    var emittedOutput: String? {
-        let t = [title, subtitle].compactMap { $0 }.joined(separator: " - ")
-        return "\(t)\n\n"
-            + unitTestSubsections
-                .compactMap { $0.emittedOutput }
-                .joined(separator: "\n")
-    }
-}
-


### PR DESCRIPTION
Xcode 13 began nesting emitted output under `ActivityLogUnitTestSection`

We need to print the title & emitted output, as well as any nested unit test subsections for each test.

Updated screenshot:
![XCTestHTMLReportTests_index html](https://user-images.githubusercontent.com/1395852/147166567-9ea1ef1a-e063-465b-9386-988ae30e3ebd.png)

