### PR TITLE
Update actions, remove xc 12.5

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,6 +10,8 @@ jobs:
   build:
     strategy:
       fail-fast: true
+      matrix:
+        arch: [ "arm64-apple-macosx", "x86_64-apple-macosx" ]
     runs-on: macos-11
     
     steps:
@@ -34,22 +36,22 @@ jobs:
         echo ::set-output name=archive_name::xchtmlreport-${VERSION}.zip
 
     - name: Build
-      run: swift build -v -c release
+      run: swift build -v -c release --triple ${{ matrix.arch }}
       
     - name: Sign
       run: |
         codesign --verbose --verify --options=runtime -f \
         -s "Developer ID Application: Tyler Vick (${{ secrets.AC_TEAM_ID }})" \
-        .build/x86_64-apple-macosx/release/xchtmlreport
+        .build/${{ matrix.arch }}/release/xchtmlreport
     
     - name: Verify
       run: |
-        codesign -vvv --deep --strict .build/x86_64-apple-macosx/release/xchtmlreport
+        codesign -vvv --deep --strict .build/${{ matrix.arch }}/release/xchtmlreport
 
     - name: Package
       run: |
         ditto -c -k \
-        --keepParent ".build/x86_64-apple-macosx/release/xchtmlreport" \
+        --keepParent ".build/${{ matrix.arch }}/release/xchtmlreport" \
         ${{ steps.metadata.outputs.archive_name }}
 
     - name: Notarize

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -33,7 +33,7 @@ jobs:
       run: |
         [[ "$GITHUB_REF" =~ refs/tags ]] && VERSION=${GITHUB_REF/refs\/tags\//} || exit
         echo ::set-output name=version::${VERSION}
-        echo ::set-output name=archive_name::xchtmlreport-${VERSION}.zip
+        echo ::set-output name=archive_name::xchtmlreport-${VERSION}-${{ matrix.arch }}.zip
 
     - name: Build
       run: swift build -v -c release --triple ${{ matrix.arch }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CD
+name: CI
 
 on:
   push:
@@ -11,9 +11,9 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        xcode_version: [12.5, 13.0]
+        xcode_version: [ 13.0 ]
     runs-on: macos-11
-    
+
     steps:
     - uses: actions/checkout@v2
     
@@ -23,9 +23,15 @@ jobs:
         version: ${{ matrix.xcode_version }}
 
     - name: Build
-      run: swift build -v -c release
+      run: swift build -v -c release --arch arm64 --arch x86_64
+
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.7
+        bundler-cache: true
+    - run: gem install xcpretty
       
     - name: Test
       run: |
         ./prepareTestResults.sh
-        swift test -v
+        swift test -c release 2>&1 | xcpretty

--- a/.github/workflows/sync-next.yml
+++ b/.github/workflows/sync-next.yml
@@ -1,0 +1,27 @@
+name: Sync "next" branch
+
+on:
+  push:
+    branches: [ main ]
+
+  workflow_dispatch:
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    permissions: 
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Sync branches
+        uses: TreTuna/sync-branches@1.4.0
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FROM_BRANCH: main
+          TO_BRANCH: next
+          # What you would like as the title of the pull request. Default: 'sync: {FROM_BRANCH} to {TO_BRANCH}'
+#           PULL_REQUEST_TITLE: # optional
+          # What you would like in the body of the pull request. Default: 'New code has just landed in {fromBranch} so let's bring {toBranch} up to speed!'
+#           PULL_REQUEST_BODY: # optional
+          REVIEWERS: '["tylervick"]'


### PR DESCRIPTION
Xcode 13 has been the standard for several months now - we will begin building/testing only in Xcode 13 and later update the Swift version to 5.5.

Other minor QOL changes including arm64 (Apple Silicon) release artifacts and xcpretty.