### PR TITLE
Fix: Use relative path for attachment reference in HTML report

### DIFF
--- a/Sources/XCTestHTMLReportCore/Classes/Models/ResultFile.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Models/ResultFile.swift
@@ -27,12 +27,14 @@ class ResultFile {
             Logger.warning("Can't export payload with id \(id)")
             return nil
         }
-        let url = url.appendingPathComponent(fileName ?? id)
+
         let fileManager = FileManager.default
         do {
+            let resolvedName = fileName ?? id
+            let url = url.appendingPathComponent(resolvedName)
             try? fileManager.removeItem(at: url)
             try fileManager.moveItem(at: savedURL, to: url)
-            return url
+            return relativeUrl.appendingPathComponent(resolvedName)
         } catch {
             Logger.warning("Can't move item from \(savedURL) to \(url). \(error.localizedDescription)")
             return nil

--- a/Tests/XCTestHTMLReportTests/FunctionalTests.swift
+++ b/Tests/XCTestHTMLReportTests/FunctionalTests.swift
@@ -36,6 +36,17 @@ final class FunctionalTests: XCTestCase {
             XCTAssertEqual(texts[3].intGroupMatch("Failed \\((\\d+)\\)"), 5)
         }
 
+        try XCTContext.runActivity(named: "Images should use the relative path") { _ in
+            let imgTags = parser.search(withQuery: "//img[@class='screenshot']")
+                + parser.search(withQuery: "//img[@class='screenshot-flow']")
+            XCTAssertFalse(imgTags.isEmpty)
+
+            try imgTags.forEach { img in
+                let src = try XCTUnwrap(img.attributes["src"])
+                let content = try XCTUnwrap(src["nodeContent"] as? String)
+                XCTAssertTrue(content.starts(with: "TestResults.xcresult"))
+            }
+        }
     }
 
     static var allTests = [


### PR DESCRIPTION
This PR is to fix the broken images issue https://github.com/XCTestHTMLReport/XCTestHTMLReport/issues/274.

## Changes
- Use `relativeUrl` to construct the return value in `ResultFile.exportPayload(id:, fileName:)`
- Add unit tests to avoid being broken in the future