### PR TITLE
Report mixed tests as success in junit if the last iteration passed

### DIFF
--- a/Tests/XCTestHTMLReportTests/CoreTests.swift
+++ b/Tests/XCTestHTMLReportTests/CoreTests.swift
@@ -41,10 +41,10 @@ final class CoreTests: XCTestCase {
             )
             let texts = try elements.eachText()
             XCTAssertEqual(texts.count, 5)
-            XCTAssertEqual(texts[0].intGroupMatch("All \\((\\d+)\\)"), 2)
+            XCTAssertEqual(texts[0].intGroupMatch("All \\((\\d+)\\)"), 3)
             XCTAssertEqual(texts[1].intGroupMatch("Passed \\((\\d+)\\)"), 1)
             XCTAssertEqual(texts[2].intGroupMatch("Skipped \\((\\d+)\\)"), 0)
-            XCTAssertEqual(texts[3].intGroupMatch("Failed \\((\\d+)\\)"), 0)
+            XCTAssertEqual(texts[3].intGroupMatch("Failed \\((\\d+)\\)"), 1)
             XCTAssertEqual(texts[4].intGroupMatch("Mixed \\((\\d+)\\)"), 1)
         })
     }

--- a/Tests/XCTestHTMLReportTests/JUnitReportTests.swift
+++ b/Tests/XCTestHTMLReportTests/JUnitReportTests.swift
@@ -23,6 +23,7 @@ final class JUnitReportTests: XCTestCase {
                 state: .failed,
                 results: [
                     JUnitReport.TestResult(title: "TitleHere<'&\\>", state: .systemOut),
+                    JUnitReport.TestResult(title: "SystemErrorHere<'&\\>", state: .systemErr),
                     JUnitReport.TestResult(
                         title: "Assertion Failure: <unknown>:0: Application com.example.test is not running",
                         state: .failed
@@ -59,6 +60,10 @@ final class JUnitReportTests: XCTestCase {
         let systemOutElem = try XCTUnwrap(testCaseElem.getElementsByTag("system-out").first)
         let systemOutText = try systemOutElem.text()
         XCTAssertEqual(Entities.escape(systemOutText), "TitleHere&lt;\'&amp;\\&gt;")
+
+        let systemErrElem = try XCTUnwrap(testCaseElem.getElementsByTag("system-err").first)
+        let systemErrText = try systemErrElem.text()
+        XCTAssertEqual(Entities.escape(systemErrText), "SystemErrorHere&lt;\'&amp;\\&gt;")
 
         let failureElem = try XCTUnwrap(testCaseElem.getElementsByTag("failure").first)
         let failureMessage = try failureElem.attr("message")

--- a/Tests/XCTestHTMLReportTests/SanityTests.swift
+++ b/Tests/XCTestHTMLReportTests/SanityTests.swift
@@ -32,4 +32,51 @@ final class SanityTests: XCTestCase {
             XCTAssertEqual(texts[4].intGroupMatch("Mixed \\((\\d+)\\)"), 0)
         }
     }
+
+    func testRetryFunctionalityJunit() throws {
+        guard let testResultsUrl = Bundle.testBundle.url(forResource: "RetryResults", withExtension: "xcresult") else {
+            throw XCTSkip("RetryResults.xcresult not found, this likely means Xcode < 13.0")
+        }
+
+        let summary = Summary(resultPaths: [testResultsUrl.path], renderingMode: .linking, downsizeImagesEnabled: false)
+        let junit = summary.junit
+
+        XCTAssertEqual(junit.failures, 1)
+        XCTAssertEqual(junit.suites.count, 1)
+
+        let suite = try XCTUnwrap(junit.suites.first)
+        XCTAssertEqual(suite.cases.count, 3)
+
+        let testRetryOnFailure = try XCTUnwrap(suite.cases.first { $0.name == "testRetryOnFailure()" })
+        XCTAssertEqual(testRetryOnFailure.state, .mixed)
+        assertJunitResults(testRetryOnFailure.results, count: 10, failed: 0, systemErr: 1, systemOut: 2, unknown: 7, skipped: 0)
+
+        let testJustFail = try XCTUnwrap(suite.cases.first { $0.name == "testJustFail()" })
+        XCTAssertEqual(testJustFail.state, .failed)
+        assertJunitResults(testJustFail.results, count: 8, failed: 1, systemErr: 1, systemOut: 0, unknown: 6, skipped: 0)
+
+        let testJustPass = try XCTUnwrap(suite.cases.first { $0.name == "testJustPass()" })
+        XCTAssertEqual(testJustPass.state, .passed)
+        assertJunitResults(testJustPass.results, count: 4, failed: 0, systemErr: 0, systemOut: 0, unknown: 4, skipped: 0)
+    }
+}
+
+private extension SanityTests {
+    func assertJunitResults(
+        _ results: [JUnitReport.TestResult],
+        count: Int,
+        failed: Int,
+        systemErr: Int,
+        systemOut: Int,
+        unknown: Int,
+        skipped: Int
+    ) {
+        XCTAssertEqual(results.count, count)
+        XCTAssertEqual(results.filter({ $0.state == .failed }).count, failed)
+        XCTAssertEqual(results.filter({ $0.state == .systemErr }).count, systemErr)
+        XCTAssertEqual(results.filter({ $0.state == .systemOut }).count, systemOut)
+        XCTAssertEqual(results.filter({ $0.state == .unknown }).count, unknown)
+        XCTAssertEqual(results.filter({ $0.state == .skipped }).count, skipped)
+        XCTAssertEqual(count, failed + systemErr + systemOut + unknown + skipped)
+    }
 }

--- a/XCTestHTMLReportSampleApp/SampleAppUITests/RetryTests.swift
+++ b/XCTestHTMLReportSampleApp/SampleAppUITests/RetryTests.swift
@@ -28,6 +28,10 @@ class RetryTests: XCTestCase {
         XCTAssertTrue(true)
     }
 
+    func testJustFail() {
+        XCTAssertTrue(false)
+    }
+
     // First iteration will always fail, retry will succeed
     func testRetryOnFailure() throws {
         try XCTContext.runActivity(named: "Retryable Activity") { _ in


### PR DESCRIPTION
👋 

This PR introduces the `system-err` XML tag for the junit report. You can see how this is used by the teamcity junit parser [here](https://github.com/JetBrains/teamcity-xml-tests-reporting/blob/b86b9336679a04653792b2915af8de4941304c75/agent/src/jetbrains/buildServer/xmlReportPlugin/parsers/antJUnit/AntJUnitXmlReportParser.java#L145).

This way, now when there are multiple iterations of a test, the final result of the test is the status of its last iteration. For example, having two iterations:
* If the first succeeds, test is shown as passed
* If the first fails and the second succeeds, test is shown as passed
* If both fail, test is shown as failed

Failed iterations that are not the last one are reported using the `system-err` tag.

I would say this makes more sense than previous implementation, as usually when you have multiple iterations of a test is to fight against flakiness.

See for example how this looks after teamcity parses the junit XML:
In the test history:
<img width="779" alt="Screenshot 2022-08-26 at 11 15 21" src="https://user-images.githubusercontent.com/7938671/186871901-98538581-5576-409b-9b24-2c78dc87ed29.png">

In the test log:
<img width="1069" alt="Screenshot 2022-08-26 at 11 15 37" src="https://user-images.githubusercontent.com/7938671/186871903-69d9ee6c-c05e-447e-99e6-2147b8210a0e.png">

I believe that the main issue here is that junit reports do not support reporting multiple iterations of a test 😢 

