### PR TITLE
Remove target information from the testcase name in the junit report, and instead add it as properties

### DIFF
--- a/Sources/XCTestHTMLReportCore/Classes/Models/RunDestination.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Models/RunDestination.swift
@@ -38,10 +38,20 @@ private extension Status {
     }
 }
 
-struct RunDestination: HTML {
+struct RunDestination: HTML, Equatable {
     let name: String
     let targetDevice: TargetDevice
     let status: Status
+
+    init(
+        name: String,
+        targetDevice: TargetDevice,
+        status: Status
+    ) {
+        self.name = name
+        self.targetDevice = targetDevice
+        self.status = status
+    }
 
     init(record: ActionRunDestinationRecord) {
         Logger.substep("Parsing ActionRunDestinationRecord")

--- a/Sources/XCTestHTMLReportCore/Classes/Models/TargetDevice.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Models/TargetDevice.swift
@@ -9,12 +9,18 @@
 import Foundation
 import XCResultKit
 
-struct TargetDevice
-{
+struct TargetDevice: Equatable {
     let identifier: String
     let uniqueIdentifier: String
     let osVersion: String
     let model: String
+
+    init(identifier: String, uniqueIdentifier: String, osVersion: String, model: String) {
+        self.identifier = identifier
+        self.uniqueIdentifier = uniqueIdentifier
+        self.osVersion = osVersion
+        self.model = model
+    }
 
     init(record: ActionDeviceRecord) {
         Logger.substep("Parsing ActionDeviceRecord")

--- a/Tests/XCTestHTMLReportTests/SanityTests.swift
+++ b/Tests/XCTestHTMLReportTests/SanityTests.swift
@@ -47,6 +47,10 @@ final class SanityTests: XCTestCase {
         let suite = try XCTUnwrap(junit.suites.first)
         XCTAssertEqual(suite.cases.count, 3)
 
+        XCTAssertEqual(suite.runDestination.name, "iPhone 8")
+        XCTAssertEqual(suite.runDestination.targetDevice.osVersion, "15.2")
+        XCTAssertEqual(suite.runDestination.targetDevice.model, "iPhone 8")
+
         let testRetryOnFailure = try XCTUnwrap(suite.cases.first { $0.name == "testRetryOnFailure()" })
         XCTAssertEqual(testRetryOnFailure.state, .mixed)
         assertJunitResults(testRetryOnFailure.results, count: 10, failed: 0, systemErr: 1, systemOut: 2, unknown: 7, skipped: 0)


### PR DESCRIPTION
Hi 👋 

This PR is an implementation of the discussions in https://github.com/XCTestHTMLReport/XCTestHTMLReport/pull/115

This is how a junit report would look:

```xml
<?xml version='1.0' encoding='UTF-8'?>
<testsuites name='JUnitReportName' tests='1' failures='1'>
  <testsuite name='JUnitReportTestSuiteName' tests='1' failures='1'>
  <properties>
    <property name='DestinationName' value='MySimulator'/>
    <property name='DestinationModel' value='iPhone 8'/>
    <property name='DestinationOS' value='iOS15.2'/>
    <property name='DestinationId' value='id'/>
  </properties>
  <testcase classname='MyClassName' name='MyName' time='0.00'>
    <system-out>TitleHere</system-out>
    <system-err>SystemErrorHere</system-err>
    <failure message='Assertion Failure: unknown: Application com.example.test is not running'>
    </failure>
  </testcase>
  </testsuite>
</testsuites>
```