### PR TITLE
Update XCResultKit, add --json report flag

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -33,7 +33,7 @@
         "repositoryURL": "https://github.com/tylervick/XCResultKit.git",
         "state": {
           "branch": null,
-          "revision": "6a16ad01ed9c694becd3d361e1ca992674368b83",
+          "revision": "29f5badcbf7cfcbea8278de34cc7b8774f4b22e8",
           "version": null
         }
       }

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/onevcat/Rainbow.git", .upToNextMajor(from: "3.0.0")),
-        .package(url: "https://github.com/tylervick/XCResultKit.git", revision: "6a16ad01ed9c694becd3d361e1ca992674368b83"),
+        .package(url: "https://github.com/tylervick/XCResultKit.git", revision: "29f5badcbf7cfcbea8278de34cc7b8774f4b22e8"),
         .package(url: "https://github.com/scinfu/SwiftSoup.git", from: "2.4.3"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0"),
     ],

--- a/Sources/XCTestHTMLReport/XCTestHtmlReport.swift
+++ b/Sources/XCTestHTMLReport/XCTestHtmlReport.swift
@@ -12,6 +12,13 @@ struct JUnitOptions: ParsableArguments {
     var excludeRunDestinationInfo = false
 }
 
+struct JsonOptions: ParsableArguments {
+
+    @Flag(name: .customLong("json"), help: ArgumentHelp("Output result.json"))
+    var jsonEnabled = false
+
+}
+
 struct HtmlOptions: ParsableArguments {
     init() {}
 
@@ -83,6 +90,9 @@ struct XCTestHtmlReport: AsyncParsableCommand {
     
     @OptionGroup
     var summaryOptions: SummaryOptions
+    
+    @OptionGroup
+    var jsonOptions: JsonOptions
 }
 
 extension XCTestHtmlReport {
@@ -133,6 +143,22 @@ extension XCTestHtmlReport {
                 Logger.error("An error has occured while creating the JUnit report.")
                 throw error
             }
+        }
+        
+        if jsonOptions.jsonEnabled {
+
+            let json = summary.generatedJsonReport()
+            let jsonPath = path.addPathComponent("report.json")
+            Logger.substep("Writing JSON report to \(jsonPath)")
+            
+            do {
+                try json.write(toFile: jsonPath, atomically: false, encoding: .utf8)
+                Logger.success("\nJSON report successfully created at \(jsonPath)")
+            } catch {
+                Logger.error("An error has occurred while creating the JSON report.")
+                throw error
+            }
+
         }
     }
 

--- a/Sources/XCTestHTMLReportCore/Classes/Models/Activity.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Models/Activity.swift
@@ -98,7 +98,7 @@ struct Activity: HTML {
         let issueType = failureSummary.issueType ?? "Assertion Failure"
         let message = failureSummary.message ?? "[message not provided]"
         title =
-            "\(issueType) at \(failureSummary.fileName.lastPathComponent()):\(failureSummary.lineNumber):\(message)"
+            "\(issueType) at \(failureSummary.fileName?.lastPathComponent() ?? ""):\(failureSummary.lineNumber):\(message)"
         type = .assertionFailure
         subActivities = []
         attachments = failureSummary.attachments.map {

--- a/Sources/XCTestHTMLReportCore/Classes/Models/Iteration.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Models/Iteration.swift
@@ -28,8 +28,8 @@ struct Iteration: Test {
         renderingMode: Summary.RenderingMode,
         downsizeImagesEnabled: Bool
     ) {
-        title = metadata.name
-        identifier = metadata.identifier
+        title = metadata.name ?? ""
+        identifier = metadata.identifier ?? ""
         status = Status(rawValue: metadata.testStatus) ?? .unknown
         duration = metadata.duration ?? 0
 

--- a/Sources/XCTestHTMLReportCore/Classes/Models/ResultFile.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Models/ResultFile.swift
@@ -95,6 +95,10 @@ class ResultFile {
         }
         return logSection.formatEmittedOutput().data(using: .utf8)
     }
+    
+    func exportJson() -> Data? {
+        file.exportRecursiveJson()
+    }
 }
 
 extension ResultFile {

--- a/Sources/XCTestHTMLReportCore/Classes/Models/Test.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Models/Test.swift
@@ -174,8 +174,8 @@ struct TestCase: Test {
     var iterations: [Iteration]
 
     init(metadata: ActionTestMetadata, resultFile: ResultFile, renderingMode: Summary.RenderingMode, downsizeImagesEnabled: Bool) {
-        title = metadata.name
-        identifier = metadata.identifier
+        title = metadata.name ?? ""
+        identifier = metadata.identifier ?? ""
 
         iterations = [Iteration(metadata: metadata, resultFile: resultFile, renderingMode: renderingMode, downsizeImagesEnabled: downsizeImagesEnabled)]
     }

--- a/Sources/XCTestHTMLReportCore/Classes/Protocols/EmittableOutput.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Protocols/EmittableOutput.swift
@@ -19,7 +19,7 @@ extension ActivityLogUnitTestSection: EmittableOutput {
     func formatEmittedOutput() -> String {
         "-------- \(title) --------\n" +
         (emittedOutput ?? "") +
-        unitTestSubsections
+        subsections
             .compactMap {
                 "\t" + $0.formatEmittedOutput()
                     .split(separator: "\n")
@@ -33,7 +33,7 @@ extension ActivityLogUnitTestSection: EmittableOutput {
 extension ActivityLogSection: EmittableOutput {
 
     func formatEmittedOutput() -> String {
-        "\(title)\n\n" + unitTestSubsections
+        "\(title)\n\n" + subsections
             .compactMap { $0.formatEmittedOutput() }
             .joined(separator: "\n")
     }


### PR DESCRIPTION
Background

Updating the forked XCResultKit dependency to a rebased commit. This includes the Xcode 14 schema updates from the upstream repo as well as the encodable capability to output a nested json object from the invocation record.

Changes
- Update XCResultKit sha
- Minor refactors to reflect updated schema
- Add `--json` flag to output a `report.json` file containing the nested xcresult json data
