### PR TITLE
Remove AsyncParsableCommand

### DIFF
--- a/Sources/XCTestHTMLReport/XCTestHtmlReport.swift
+++ b/Sources/XCTestHTMLReport/XCTestHtmlReport.swift
@@ -80,7 +80,7 @@ struct SummaryOptions: ParsableArguments {
 }
 
 @main
-struct XCTestHtmlReport: AsyncParsableCommand {
+struct XCTestHtmlReport: ParsableCommand {
     static var configuration = CommandConfiguration(
         commandName: "xchtmlreport",
         version: version,
@@ -102,7 +102,7 @@ struct XCTestHtmlReport: AsyncParsableCommand {
     @OptionGroup
     var jsonOptions: JsonOptions
 
-    func run() async throws {
+    func run() throws {
         Logger.verbose = verbose
 
         guard let path = htmlOptions.output ?? summaryOptions.finalResults.first?


### PR DESCRIPTION
AsyncParsableCommand doesn't work with `@main` on Swift 5.5 and below. Since we're not currently using async functionality in the main method this can be removed.