### PR TITLE
Added gif attachment type support

### DIFF
--- a/Sources/XCTestHTMLReportCore/Classes/HTMLTemplates.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/HTMLTemplates.swift
@@ -430,6 +430,20 @@ struct HTMLTemplates
       display:none;
       z-index: 1000;
     }
+
+    .gif {
+      background-color: white;
+      padding: 4px;
+      height: 600px;
+      position: absolute;
+      top:0;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      margin: auto;
+      display:none;
+      z-index: 1000;
+    }
   
     .file-attachment-link {
       display:none;
@@ -553,6 +567,10 @@ struct HTMLTemplates
       display: none;
     }
 
+    .displayed-gif {
+      width: 100%;
+    }
+
     .attachments {
       display: none;
     }
@@ -615,6 +633,7 @@ struct HTMLTemplates
           <div class=\"resizer\"></div>
           <h2>No Selected Attachment</h2>
           <img src=\"\" class=\"displayed-screenshot\" id=\"screenshot\"/>
+          <img src=\"\" class=\"displayed-gif\" id=\"gif\"/>
           <iframe id=\"text-attachment\" src=\"\"></iframe>
           <h2 id=\"file-attachment\"><a target=\"_blank\"/></h2>
           <video class=\"displayed-video\" controls src=\"\" id=\"video\"/>
@@ -630,6 +649,7 @@ struct HTMLTemplates
     sidebar, startX, startWidth, originalWidth,
     screenshot = document.getElementById('screenshot'),
     video = document.getElementById('video'),
+    gif = document.getElementById('gif'),
     iframe = document.getElementById('text-attachment'),
     fileAttachment = document.getElementById('file-attachment');
 
@@ -672,6 +692,7 @@ struct HTMLTemplates
         hideScreenshot();
         hideLog();
         hideVideo();
+        hideGif();
         hideLinkAttachment();
         showAttachmentPlaceholder();
         return;
@@ -687,6 +708,8 @@ struct HTMLTemplates
         showVideo(path);
       } else if (photoExtensions.indexOf(extension) > 0 || extension.startsWith(\"data:image\")) {
         showScreenshot(path);
+      } else if (extension == \"gif\") {
+        showGif(path);
       } else {
         showLinkAttachment(path);
       }
@@ -865,6 +888,7 @@ struct HTMLTemplates
       hideAttachmentPlaceholder();
       hideScreenshot();
       hideVideo();
+      hideGif();
       hideLinkAttachment();
       iframe.style.display = \"block\";
       iframe.src = path;
@@ -878,10 +902,15 @@ struct HTMLTemplates
       video.style.display = \"none\";
     }
 
+    function hideGif() {
+      gif.style.display = \"none\";
+    }
+
     function showScreenshot(filename) {
       hideAttachmentPlaceholder();
       hideLog();
       hideVideo();
+      hideGif();
       hideLinkAttachment();
       var image = document.getElementById('screenshot-'+filename);
       screenshot.style.display = \"block\";
@@ -892,11 +921,24 @@ struct HTMLTemplates
       hideAttachmentPlaceholder();
       hideLog();
       hideScreenshot();
+      hideGif();
       hideLinkAttachment();
       var vid = document.getElementById('video-'+filename);
       video.style.display = \"block\";
       video.src = vid.src;
       video.play();
+    }
+
+    function showGif(filename) {
+    hideAttachmentPlaceholder();
+    hideLog();
+    hideVideo();
+    hideScreenshot();
+    hideLinkAttachment();
+    var gf = document.getElementById('gif-'+filename);
+    gif.style.display = \"block\";
+    gif.src = gf.src;
+    gif.play();
     }
     
     function hideLinkAttachment() {
@@ -908,6 +950,7 @@ struct HTMLTemplates
       hideLog();
       hideScreenshot();
       hideVideo();
+      hideGif();
       const fileAttachmentPath = document.getElementById(`file-attachment-${filename}`)
       const link = document.querySelector(\"#file-attachment > a\")
       link.textContent = `Download ${filename}`
@@ -1141,6 +1184,15 @@ struct HTMLTemplates
     [[NAME]]
     <span class=\"icon preview-icon\" data=\"[[FILENAME]]\" onclick=\"showScreenshot('[[FILENAME]]')\"></span>
     <img class=\"screenshot\" src=\"[[SOURCE]]\" id=\"screenshot-[[FILENAME]]\"/>
+  </p>
+  """
+
+  static let gif = """
+  <p class="attachment list-item">
+    <span class="icon left screenshot-icon" style="margin-left: [[PADDING]]px"></span>
+    [[NAME]]
+  <span class=\"icon preview-icon\" data=\"[[FILENAME]]\" onclick=\"showGif('[[FILENAME]]')\"></span>
+    <img class=\"gif\" src=\"[[SOURCE]]\" id=\"gif-[[FILENAME]]\"/>
   </p>
   """
 

--- a/Sources/XCTestHTMLReportCore/Classes/Models/Attachment.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Models/Attachment.swift
@@ -12,6 +12,7 @@ import XCResultKit
 
 enum AttachmentType: String {
     case unknown = ""
+    case gif = "com.compuserve.gif"
     case data = "public.data"
     case html = "public.html"
     case jpeg = "public.jpeg"
@@ -43,6 +44,8 @@ enum AttachmentType: String {
             return "video"
         case .text, .log:
             return "text"
+        case .gif:
+            return "gif"
         default:
             return ""
         }
@@ -60,6 +63,8 @@ enum AttachmentType: String {
         switch self {
         case .png:
             return "image/png"
+        case .gif:
+            return "image/gif"
         case .jpeg:
             return "image/jpeg"
         case .heic:
@@ -157,6 +162,8 @@ struct Attachment: HTML {
         switch type {
         case .png, .jpeg, .heic:
             return "Screenshot"
+        case .gif:
+            return "Gif"
         case .mp4:
             return "Video"
         case .text, .html, .data, .log, .zip:
@@ -205,6 +212,8 @@ struct Attachment: HTML {
             return HTMLTemplates.text
         case .zip, .unknown:
             return HTMLTemplates.link // If not known, link/download the resource
+        case .gif:
+            return HTMLTemplates.gif
         }
     }
 

--- a/Sources/XCTestHTMLReportCore/HTML/gif.html
+++ b/Sources/XCTestHTMLReportCore/HTML/gif.html
@@ -1,0 +1,6 @@
+  <p class="attachment list-item">
+    <span class="icon left screenshot-icon" style="margin-left: [[PADDING]]px"></span>
+    [[NAME]]
+    <span class="icon preview-icon" data="[[FILENAME]]" onclick="showGif('[[FILENAME]]')"></span>
+    <img class="gif" src="[[SOURCE]]" id="gif-[[FILENAME]]"/>
+  </p>


### PR DESCRIPTION
At Trendyol, we have implementation which takes a screenshot every 3 seconds in test cases and creates a gif from that screenshots. We add gif as an attachment so we want to overview the failed cases with using that gifs.

This pr adds gif support for animating the gif when attachment is clicked.

![xchtmlreport-gif-support](https://user-images.githubusercontent.com/53167930/215420883-2df0440f-52e5-41e9-aa41-6c3bdac2a7e4.gif)




