### PR TITLE
Lazy load screenshots

### DIFF
--- a/Sources/XCTestHTMLReportCore/HTML/screenshot.html
+++ b/Sources/XCTestHTMLReportCore/HTML/screenshot.html
@@ -2,5 +2,5 @@
     <span class="icon left screenshot-icon" style="margin-left: [[PADDING]]px"></span>
     [[NAME]]
     <span class="icon preview-icon" data="[[FILENAME]]" onclick="showScreenshot('[[FILENAME]]')"></span>
-    <img class="screenshot" src="[[SOURCE]]" id="screenshot-[[FILENAME]]" alt="[[FILENAME]]"/>
+    <img class="screenshot" src="[[SOURCE]]" loading="lazy" id="screenshot-[[FILENAME]]" alt="[[FILENAME]]"/>
   </p>


### PR DESCRIPTION
All screenshots are loaded immediately when opening the report even if they aren't in view. When opening a large report hosted remotely containing thousands of screenshots it can take several minutes to load. A quick fix is to [enable native image lazy loading](https://web.dev/articles/browser-level-image-lazy-loading) which is [supported in most popular browsers](https://caniuse.com/loading-lazy-attr) today.