### PR TITLE
bump xcresultkit to use xcresulttool version 3.44

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -42,7 +42,7 @@
         "repositoryURL": "https://github.com/tylervick/XCResultKit.git",
         "state": {
           "branch": null,
-          "revision": "d5462510fc09055594b3cf472e443bee0d130043",
+          "revision": "3555389dd5cff613945da9bf77dde0bf9754737d",
           "version": null
         }
       }

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         .package(url: "https://github.com/onevcat/Rainbow.git", .upToNextMajor(from: "3.0.0")),
         .package(
             url: "https://github.com/tylervick/XCResultKit.git",
-            revision: "d5462510fc09055594b3cf472e443bee0d130043"
+            revision: "3555389dd5cff613945da9bf77dde0bf9754737d"
         ),
         .package(url: "https://github.com/scinfu/SwiftSoup.git", from: "2.4.3"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0"),


### PR DESCRIPTION
Bumping XCResultKit dependency after Xcode 15/xcresulttool 3.44 schema updates: https://github.com/davidahouse/XCResultKit/pull/50

We're still using the forked version to support JSON output, but once https://github.com/davidahouse/XCResultKit/pull/46 is merged we can switch back to the original repo.