### PR TITLE
Support mixed children test types in test suites

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ RetryResults*
 SanityResults*
 .DS_Store
 /.build
+/XCTestHTMLReportSampleApp/Build
 /Packages
 
 /*.xcodeproj

--- a/Sources/XCTestHTMLReportCore/Classes/HTMLTemplates.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/HTMLTemplates.swift
@@ -1027,12 +1027,13 @@ struct HTMLTemplates
       for (var i = 0; i < testSummaryGroups.length; i++) {
           var testSummaryGroup = testSummaryGroups[i];
           var children = Array.prototype.slice.call(testSummaryGroup.children);
-          var testSummaries = children.filter(function(a) { return a.classList.contains('test-summary'); });
-          if (testSummaries.length == 0) {
+          var testSummaryChildren = children.filter(function(a) { return a.classList.contains('test-summary'); });
+          var testSummaryGroupChildren = children.filter(function(a) { return a.classList.contains('test-summary-group'); });
+          if (testSummaryChildren == 0 || testSummaryGroupChildren.length > 0) {
             continue;
           }
 
-          if (testSummaries.filter(function(a) { return a.style.display == 'block' }).length == 0) {
+          if (testSummaryChildren.filter(function(a) { return a.style.display == 'block' }).length == 0) {
             testSummaryGroup.style.display = 'none';
           } else {
             testSummaryGroup.style.display = 'block';

--- a/Sources/XCTestHTMLReportCore/Classes/Models/Test.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Models/Test.swift
@@ -98,6 +98,8 @@ public struct TestGroup: Test {
         identifier = group.identifier ?? "---group-identifier-not-found---"
         duration = group.duration
 
+        Logger.substep("Initializing TestGroup \(identifier)")
+
         if !group.subtests.isEmpty {
           subTests += Array(group.subtests.reduce(into: Set<TestCase>()) { subTestSet, metadata in
             let newTest = TestCase(
@@ -204,6 +206,8 @@ struct TestCase: Test {
     ) {
         title = metadata.name ?? ""
         identifier = metadata.identifier ?? ""
+
+        Logger.substep("Initializing TestCase \(identifier)")
 
         iterations = [Iteration(
             metadata: metadata,

--- a/Sources/XCTestHTMLReportCore/Classes/Models/Test.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Models/Test.swift
@@ -74,7 +74,7 @@ public struct TestGroup: Test {
         return .unknown
     }
 
-    let subTests: [Test]
+    var subTests: [Test] = []
 
     var descendantSubTests: [Test] {
         subTests.flatMap { subTest -> [Test] in
@@ -98,31 +98,33 @@ public struct TestGroup: Test {
         identifier = group.identifier ?? "---group-identifier-not-found---"
         duration = group.duration
 
-        if group.subtests.isEmpty {
-            subTests = group.subtestGroups.map { TestGroup(
-                group: $0,
-                resultFile: resultFile,
-                renderingMode: renderingMode,
-                downsizeImagesEnabled: downsizeImagesEnabled,
-                downsizeScaleFactor: downsizeScaleFactor
-            ) }
-        } else {
-            subTests = Array(group.subtests.reduce(into: Set<TestCase>()) { subTestSet, metadata in
-                let newTest = TestCase(
-                    metadata: metadata,
-                    resultFile: resultFile,
-                    renderingMode: renderingMode,
-                    downsizeImagesEnabled: downsizeImagesEnabled,
-                    downsizeScaleFactor: downsizeScaleFactor
-                )
-                if let index = subTestSet.firstIndex(of: newTest) {
-                    var existingTest = subTestSet[index]
-                    existingTest.iterations.append(contentsOf: newTest.iterations)
-                    subTestSet.update(with: existingTest)
-                } else {
-                    subTestSet.insert(newTest)
-                }
-            })
+        if !group.subtests.isEmpty {
+          subTests += Array(group.subtests.reduce(into: Set<TestCase>()) { subTestSet, metadata in
+            let newTest = TestCase(
+              metadata: metadata,
+              resultFile: resultFile,
+              renderingMode: renderingMode,
+              downsizeImagesEnabled: downsizeImagesEnabled,
+              downsizeScaleFactor: downsizeScaleFactor
+            )
+            if let index = subTestSet.firstIndex(of: newTest) {
+              var existingTest = subTestSet[index]
+              existingTest.iterations.append(contentsOf: newTest.iterations)
+              subTestSet.update(with: existingTest)
+            } else {
+              subTestSet.insert(newTest)
+            }
+          })
+        }
+
+        if !group.subtestGroups.isEmpty {
+          subTests += group.subtestGroups.map { TestGroup(
+            group: $0,
+            resultFile: resultFile,
+            renderingMode: renderingMode,
+            downsizeImagesEnabled: downsizeImagesEnabled,
+            downsizeScaleFactor: downsizeScaleFactor
+          ) }
         }
     }
 }


### PR DESCRIPTION
In the latest Xcode build tools [15.1](https://developer.apple.com/documentation/xcode-release-notes/xcode-15_1-release-notes) and iOS 17.0.1 versions we've been randomly getting some "dangling" test data, meaning they are in a test group a level higher than they should be. This causes the HTML report tool to end early resulting in many missing tests because it assumes since there is a child test there can't be a child test group.

This changes handles the bad data better by checking all children regardless of their type. We'll reach out to Apple support to see if they are already aware of the issue but for now this unblocks us.

I ran the unit tests and manually ran reports on known good and bad data. There is no difference to users not experiencing the issue.