### PR TITLE
Update source for XCResultKit to support Xcode16 schema changes

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -39,11 +39,11 @@
       },
       {
         "package": "XCResultKit",
-        "repositoryURL": "https://github.com/tylervick/XCResultKit.git",
+        "repositoryURL": "https://github.com/davidahouse/XCResultKit.git",
         "state": {
           "branch": null,
-          "revision": "3555389dd5cff613945da9bf77dde0bf9754737d",
-          "version": null
+          "revision": "63a93e454e30084b8948cba0ee42112fca1f6010",
+          "version": "1.2.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -14,10 +14,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/onevcat/Rainbow.git", .upToNextMajor(from: "3.0.0")),
-        .package(
-            url: "https://github.com/tylervick/XCResultKit.git",
-            revision: "3555389dd5cff613945da9bf77dde0bf9754737d"
-        ),
+        .package(url: "https://github.com/davidahouse/XCResultKit.git", from: "1.2.0"),
         .package(url: "https://github.com/scinfu/SwiftSoup.git", from: "2.4.3"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0"),
         .package(url: "https://github.com/nicklockwood/SwiftFormat", from: "0.50.4"),


### PR DESCRIPTION
This is to address [#358] issue. 
The [davidahouse/XCResultKit.git](https://github.com/davidahouse/XCResultKit) already has the patch to resolve Xcode16 schema changes. I am just replacing the existing XCResultKit source with this one. 

Here's a sample report file generated from TestResults.xcresult
[report.json](https://github.com/user-attachments/files/16477024/report.json)
