### PR TITLE
Handle successful test with failed assertions during Junit report generation

### DIFF
--- a/Tests/XCTestHTMLReportTests/CoreTests.swift
+++ b/Tests/XCTestHTMLReportTests/CoreTests.swift
@@ -35,7 +35,7 @@ final class CoreTests: XCTestCase {
             )
             let texts = try elements.eachText()
             XCTAssertEqual(texts.count, 5)
-            XCTAssertEqual(texts[0].intGroupMatch("All \\((\\d+)\\)"), 3)
+            XCTAssertEqual(texts[0].intGroupMatch("All \\((\\d+)\\)"), 4)
             XCTAssertEqual(texts[1].intGroupMatch("Passed \\((\\d+)\\)"), 1)
             XCTAssertEqual(texts[2].intGroupMatch("Skipped \\((\\d+)\\)"), 0)
             XCTAssertEqual(texts[3].intGroupMatch("Failed \\((\\d+)\\)"), 1)
@@ -84,7 +84,7 @@ final class CoreTests: XCTestCase {
         XCTAssertEqual(junit.suites.count, 1)
 
         let suite = try XCTUnwrap(junit.suites.first)
-        XCTAssertEqual(suite.cases.count, 3)
+        XCTAssertEqual(suite.cases.count, 4)
 
         let testRetryOnFailure = try XCTUnwrap(
             suite.cases
@@ -117,6 +117,18 @@ final class CoreTests: XCTestCase {
         XCTAssertEqual(testJustPass.state, .passed)
         assertJunitResults(
             testJustPass.results,
+            count: 4,
+            failed: 0,
+            systemErr: 0,
+            systemOut: 0,
+            unknown: 4,
+            skipped: 0
+        )
+
+        let testInUnknownState = try XCTUnwrap(suite.cases.first { $0.name == "testInUnknownState()" })
+        XCTAssertEqual(testInUnknownState.state, .unknown)
+        assertJunitResults(
+            testInUnknownState.results,
             count: 4,
             failed: 0,
             systemErr: 0,

--- a/Tests/XCTestHTMLReportTests/JUnitReportTests.swift
+++ b/Tests/XCTestHTMLReportTests/JUnitReportTests.swift
@@ -76,8 +76,8 @@ final class JUnitReportTests: XCTestCase {
         let string = jUnitReport.xmlString
         let expectedString = #"""
         <?xml version='1.0' encoding='UTF-8'?>
-        <testsuites name='JUnitReportName&lt;&apos;&amp;\&gt;' tests='1' failures='1'>
-          <testsuite name='JUnitReportTestSuiteName&lt;&apos;&amp;\&gt;' tests='1' failures='1'>
+        <testsuites name='JUnitReportName&lt;&apos;&amp;\&gt;' tests='1' failures='1' skipped='0'>
+          <testsuite name='JUnitReportTestSuiteName&lt;&apos;&amp;\&gt;' tests='1' failures='1' skipped='0'>
           <testcase classname='MyClassName&lt;&apos;&amp;\&gt;' name='MyName&lt;&apos;&amp;\&gt;' time='0.00'>
             <system-out>TitleHere&lt;&apos;&amp;\&gt;</system-out>
             <system-err>SystemErrorHere&lt;&apos;&amp;\&gt;</system-err>

--- a/XCTestHTMLReportSampleApp/SampleAppUITests/RetryTests.swift
+++ b/XCTestHTMLReportSampleApp/SampleAppUITests/RetryTests.swift
@@ -31,6 +31,12 @@ class RetryTests: XCTestCase {
         XCTAssertTrue(false)
     }
 
+    func testInUnknownState() {
+        XCTExpectFailure("Expecting a failure here") {
+            XCTAssertTrue(false)
+        }
+    }
+
     // First iteration will always fail, retry will succeed
     func testRetryOnFailure() throws {
         try XCTContext.runActivity(named: "Retryable Activity") { _ in


### PR DESCRIPTION
👋 

Handle successful test with failed assertions during Junit report generation. See code for details.

Context: I experienced the edge case of a test with a failed assertion, but success status:

![Screenshot 2024-10-31 at 03 55 36](https://github.com/user-attachments/assets/93a87613-bd87-4dea-8346-99a4cb30f474)

