### PR TITLE
Support Swift Testing Global Tests

### DIFF
--- a/Sources/XCTestHTMLReportCore/Classes/Models/TestSummary.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Models/TestSummary.swift
@@ -51,7 +51,7 @@ struct TestSummary: HTML {
         uuid = UUID().uuidString
         testName = summary.targetName ?? ""
         // TODO: Reduce this with iterations & accum with hashmap
-        tests = summary.tests.map {
+        let testGroups = summary.tests.map {
             TestGroup(
                 group: $0,
                 resultFile: file,
@@ -60,6 +60,15 @@ struct TestSummary: HTML {
                 downsizeScaleFactor: downsizeScaleFactor
             )
         }
+        let globalTestGroup = TestGroup(
+            globalMetadata: summary.globalTests,
+            resultFile: file,
+            renderingMode: renderingMode,
+            downsizeImagesEnabled: downsizeImagesEnabled,
+            downsizeScaleFactor: downsizeScaleFactor
+        )
+
+        tests = testGroups + [globalTestGroup]
     }
 
     // PRAGMA MARK: - HTML


### PR DESCRIPTION
The new [Swift Testing](https://github.com/swiftlang/swift-testing) framework supports writing free function tests at the global scope.

```Swift
func myTest() {
  #expect(testToPass)
}
```

However, XCTestHTMLReport does not output results for these top-level tests, even though the data for these tests exists in the XCResult bundle.

According this [comment](https://github.com/davidahouse/XCResultKit/blob/4d13c245f374d9af67fb9260cd14a4d58f6c6c82/Sources/XCResultKit/Schema/ActionTestableSummary.swift#L43) in the XCResultKit repository, these top level functions are included in the test data in an unusual way, and are exposed by XCResultKit via a `globalTests` property.

This PR incorporates these global tests into the existing `TestGroup`.