### PR TITLE
Reduce the memory footprint when -z option is used

### DIFF
--- a/Sources/XCTestHTMLReportCore/Classes/Models/Activity.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Models/Activity.swift
@@ -138,15 +138,17 @@ struct Activity: HTML {
             )
         }
         type = ActivityType(rawValue: summary.activityType)
-        attachments = summary.attachments.map {
-            Attachment(
-                attachment: $0,
-                file: file,
-                padding: padding + 16,
-                renderingMode: renderingMode,
-                downsizeImagesEnabled: downsizeImagesEnabled,
-                downsizeScaleFactor: downsizeScaleFactor
-            )
+        attachments = summary.attachments.map { attachment in
+            autoreleasepool {
+                Attachment(
+                    attachment: attachment,
+                    file: file,
+                    padding: padding + 16,
+                    renderingMode: renderingMode,
+                    downsizeImagesEnabled: downsizeImagesEnabled,
+                    downsizeScaleFactor: downsizeScaleFactor
+                )
+            }
         }
         self.padding = padding
     }


### PR DESCRIPTION
Initialization of an attachment is now inside an autoreleasepool because the memory footprint is huge when using the -z option. The memory usage jumps to 10 gigabytes under 10 seconds. Releasing the NSImage related objects at each iteration via autorelease pool reduces it to a few hundred megabytes.