### PR TITLE
Update format timer for more meaningful of the quick function

### DIFF
--- a/Sources/XCTestHTMLReportCore/Classes/Extensions/TimeInterval+Time.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Extensions/TimeInterval+Time.swift
@@ -10,6 +10,6 @@ import Foundation
 
 extension TimeInterval {
     var formattedSeconds: String {
-        String(format: "%.2fs", self)
+        String(format: "%.4fs", self)
     }
 }


### PR DESCRIPTION
<img width="279" height="198" alt="Screenshot 2025-10-03 at 14 26 12" src="https://github.com/user-attachments/assets/5fab0432-64e0-4f8a-9b3b-6e489625509d" />
The %0.2f format is not enough for quick test function