### PR TITLE
Add support for skipped test message in JUnit report

### DIFF
--- a/Sources/XCTestHTMLReportCore/Classes/Models/Iteration.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Models/Iteration.swift
@@ -17,6 +17,7 @@ struct Iteration: Test {
     let status: Status
     let activities: [Activity]
     let repetitionPolicy: ActionTestRepetitionPolicySummary?
+    let skipNoticeMessage: String
 
     var testScreenshotFlow: TestScreenshotFlow? {
         TestScreenshotFlow(activities: activities)
@@ -83,9 +84,11 @@ struct Iteration: Test {
             }
 
             repetitionPolicy = actionTestSummary.repetitionPolicySummary
+            skipNoticeMessage = actionTestSummary.skipNoticeSummary?.message ?? ""
         } else {
             activities = []
             repetitionPolicy = nil
+            skipNoticeMessage = ""
         }
     }
 }

--- a/Sources/XCTestHTMLReportCore/Classes/Models/JUnitReport.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Models/JUnitReport.swift
@@ -51,6 +51,7 @@ struct JUnitReport {
         var name: String
         var time: TimeInterval
         var state: State
+        var skippedMessage: String
         var results: [TestResult]
     }
 
@@ -115,7 +116,11 @@ extension JUnitReport.TestCase: XMLRepresentable {
         /// Skipped tests can have no TestResults (logs) so we need to check the status to add the skipped tag to the xml file
         if self.state == .skipped {
             xml += ">\n"
-            xml += "    <skipped/>"
+            if !skippedMessage.isEmpty {
+                xml += "    <skipped message='\(skippedMessage.stringByEscapingXMLChars)'>\n    </skipped>"
+            } else {
+                xml += "    <skipped/>"
+            }
             xml += "\n  </testcase>\n"
         } else if results.isEmpty {
             xml += "/>\n"
@@ -165,6 +170,7 @@ private extension JUnitReport.TestCase {
         let components = test.identifier.components(separatedBy: "/")
         time = test.duration
         name = components.last ?? ""
+        skippedMessage = ""
 
         var classname = components.first ?? ""
         if includeRunDestinationInfo {
@@ -219,6 +225,12 @@ private extension JUnitReport.TestCase {
                 if isFailureFatal, !results.contains(where: { $0.state == .failed }) {
                     results += [.init(title: "Test status: \(iteration.status)", state: .failed)]
                 }
+            }
+
+            if testCase.status == .skipped {
+                skippedMessage = testCase.iterations
+                    .map(\.skipNoticeMessage)
+                    .first(where: { !$0.isEmpty }) ?? ""
             }
         }
     }

--- a/Tests/XCTestHTMLReportTests/JUnitReportTests.swift
+++ b/Tests/XCTestHTMLReportTests/JUnitReportTests.swift
@@ -13,24 +13,39 @@ import XCTest
 final class JUnitReportTests: XCTestCase {
     let jUnitReport = JUnitReport(
         name: "JUnitReportName<'&\\>",
-        suites: [JUnitReport.TestSuite(
-            name: "JUnitReportTestSuiteName<'&\\>",
-            tests: 1,
-            cases: [JUnitReport.TestCase(
-                classname: "MyClassName<'&\\>",
-                name: "MyName<'&\\>",
-                time: 0.002,
-                state: .failed,
-                results: [
-                    JUnitReport.TestResult(title: "TitleHere<'&\\>", state: .systemOut),
-                    JUnitReport.TestResult(title: "SystemErrorHere<'&\\>", state: .systemErr),
-                    JUnitReport.TestResult(
-                        title: "Assertion Failure: <unknown>:0: Application com.example.test is not running",
-                        state: .failed
+        suites: [
+            JUnitReport.TestSuite(
+                name: "JUnitReportTestSuiteName<'&\\>",
+                tests: 1,
+                cases: [
+                    JUnitReport.TestCase(
+                        classname: "MyClassName<'&\\>",
+                        name: "MyName<'&\\>",
+                        time: 0.002,
+                        state: .failed,
+                        skippedMessage: "There is a known issue with this test.",
+                        results: [
+                            JUnitReport.TestResult(title: "TitleHere<'&\\>", state: .systemOut),
+                            JUnitReport.TestResult(title: "SystemErrorHere<'&\\>", state: .systemErr),
+                            JUnitReport.TestResult(
+                                title: "Assertion Failure: <unknown>:0: Application com.example.test is not running",
+                                state: .failed
+                            ),
+                        ]
                     ),
+                    JUnitReport.TestCase(
+                        classname: "MyClassName<'&\\>",
+                        name: "MyName<'&\\>",
+                        time: 0.002,
+                        state: .skipped,
+                        skippedMessage: "There is a known issue with this test.",
+                        results: [
+                            JUnitReport.TestResult(title: "TitleHere<'&\\>", state: .skipped),
+                        ]
+                    )
                 ]
-            )]
-        )]
+            )
+        ]
     )
 
     func testXmlTreeLayoutAndAttributes() throws {
@@ -76,13 +91,17 @@ final class JUnitReportTests: XCTestCase {
         let string = jUnitReport.xmlString
         let expectedString = #"""
         <?xml version='1.0' encoding='UTF-8'?>
-        <testsuites name='JUnitReportName&lt;&apos;&amp;\&gt;' tests='1' failures='1' skipped='0'>
-          <testsuite name='JUnitReportTestSuiteName&lt;&apos;&amp;\&gt;' tests='1' failures='1' skipped='0'>
+        <testsuites name='JUnitReportName&lt;&apos;&amp;\&gt;' tests='1' failures='1' skipped='1'>
+          <testsuite name='JUnitReportTestSuiteName&lt;&apos;&amp;\&gt;' tests='1' failures='1' skipped='1'>
           <testcase classname='MyClassName&lt;&apos;&amp;\&gt;' name='MyName&lt;&apos;&amp;\&gt;' time='0.00'>
             <system-out>TitleHere&lt;&apos;&amp;\&gt;</system-out>
             <system-err>SystemErrorHere&lt;&apos;&amp;\&gt;</system-err>
             <failure message='Assertion Failure: &lt;unknown&gt;:0: Application com.example.test is not running'>
             </failure>
+          </testcase>
+          <testcase classname='MyClassName&lt;&apos;&amp;\&gt;' name='MyName&lt;&apos;&amp;\&gt;' time='0.00'>
+            <skipped message='There is a known issue with this test.'>
+            </skipped>
           </testcase>
           </testsuite>
         </testsuites>


### PR DESCRIPTION
If there is a message for a skipped test it will show up in the JSON report but not in the JUnit report. This fixes that so the skipped message can be supported within the JUnit report. This message can contain important information about why the test was skipped.