### PR TITLE
Repair the release pipeline for 3.0

### DIFF
--- a/.github/workflows/homebrew-bump.yml
+++ b/.github/workflows/homebrew-bump.yml
@@ -1,31 +1,38 @@
 name: Brew Bump
 
 on:
+  # Fires only for non-prerelease publications, so `rc` tags never reach
+  # homebrew-core. Manual dispatch remains available for re-runs.
+  release:
+    types: [released]
   workflow_dispatch:
     inputs:
       version:
         type: string
         required: true
-        description: "Release tag to use. e.g. refs/tags/2.2.4"
+        description: "Release tag to bump to, e.g. 3.0.0"
 
 jobs:
   update_brew_formula:
     runs-on: ubuntu-latest
 
     steps:
-#    - name: Update Homebrew tap
-#      uses: dawidd6/action-homebrew-bump-formula@v3
-#      with:
-#        token: ${{ secrets.HOMEBREW_BUMP_ACCESS_TOKEN }}
-#        org: XCTestHTMLReport
-#        tap: XCTestHTMLReport/homebrew-xchtmlreport
-#        formula: xchtmlreport
-#        tag: ${{ github.event.inputs.version }}        
+    - name: Resolve tag
+      id: tag
+      run: |
+        if [[ -n "${{ github.event.inputs.version }}" ]]; then
+          TAG="${{ github.event.inputs.version }}"
+        else
+          TAG="${{ github.event.release.tag_name }}"
+        fi
+        # Tolerate a full ref being pasted into the manual input.
+        TAG="${TAG#refs/tags/}"
+        echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+        echo "bumping to ${TAG}"
 
     - name: Update Official Homebrew formula
-      uses: dawidd6/action-homebrew-bump-formula@v3.10.1
+      uses: dawidd6/action-homebrew-bump-formula@v8
       with:
         token: ${{ secrets.HOMEBREW_BUMP_ACCESS_TOKEN }}
-        # org: XCTestHTMLReport
         formula: xctesthtmlreport
-        tag: ${{ github.event.inputs.version }}
+        tag: ${{ steps.tag.outputs.tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,32 +5,61 @@ on:
    tags:
    - '[0-9]+.[0-9]+.[0-9]+'
    - '[0-9]+.[0-9]+.[0-9]+rc[0-9]+'
+  # Lets the whole build/sign/package path be exercised without publishing
+  # anything. Before this existed the only way to test a release was to cut one.
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        type: boolean
+        default: true
+        description: "Build, sign and package, but do not notarize or publish"
 
 jobs:
   build:
     runs-on: macos-latest
+    outputs:
+      prerelease: ${{ steps.metadata.outputs.prerelease }}
 
     steps:
     - uses: actions/checkout@v4
 
     - name: Configure Signing
-      uses: Apple-Actions/import-codesign-certs@v1
+      uses: Apple-Actions/import-codesign-certs@v7
       with:
         p12-file-base64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
         p12-password: ${{ secrets.P12_PASSWORD }}
 
     - name: Setup Xcode version
-      uses: maxim-lobanov/setup-xcode@v1.6.0        
+      uses: maxim-lobanov/setup-xcode@v1.6.0
       with:
-        xcode-version: ^16
+        xcode-version: latest-stable
 
     - name: Generate Metadata
       id: metadata
       run: |
-        [[ "$GITHUB_REF" =~ refs/tags ]] && VERSION=${GITHUB_REF/refs\/tags\//} || exit
-        echo ::set-output name=version::${VERSION}
-        echo ::set-output name=bin_path::.build/universal/release/xchtmlreport
-        echo ::set-output name=archive_name::xchtmlreport-${VERSION}.zip
+        if [[ "$GITHUB_REF" =~ ^refs/tags/ ]]; then
+          VERSION="${GITHUB_REF#refs/tags/}"
+        else
+          VERSION="0.0.0-dryrun"
+        fi
+        # `rc` tags carry no hyphen, so a `contains(github.ref, '-')` test
+        # never fired for them and release candidates shipped as full releases.
+        if [[ "$VERSION" == *rc* ]]; then PRERELEASE=true; else PRERELEASE=false; fi
+        {
+          echo "version=${VERSION}"
+          echo "prerelease=${PRERELEASE}"
+          echo "bin_path=.build/universal/release/xchtmlreport"
+          echo "archive_name=xchtmlreport-${VERSION}.zip"
+        } >> "$GITHUB_OUTPUT"
+
+    - name: Stamp version into the binary
+      # Version.swift was only ever written by the post-release bump job, so the
+      # released binary reported whatever happened to be on main rather than the
+      # tag it was built from. Stamping here makes `--version` match the tag.
+      run: |
+        echo "let version = \"${{ steps.metadata.outputs.version }}\"" \
+          > Sources/XCTestHTMLReport/Version.swift
+        cat Sources/XCTestHTMLReport/Version.swift
 
     - name: Build (arm64)
       run: swift build -v -c release --triple arm64-apple-macosx
@@ -44,16 +73,28 @@ jobs:
         lipo -create -output ${{ steps.metadata.outputs.bin_path }} \
         .build/arm64-apple-macosx/release/xchtmlreport \
         .build/x86_64-apple-macosx/release/xchtmlreport
+        lipo -info ${{ steps.metadata.outputs.bin_path }}
+
+    - name: Verify the built binary reports the tagged version
+      run: |
+        REPORTED=$(${{ steps.metadata.outputs.bin_path }} --version)
+        echo "reported: ${REPORTED}"
+        if [[ "${REPORTED}" != "${{ steps.metadata.outputs.version }}" ]]; then
+          echo "::error::binary reports '${REPORTED}' but this is release '${{ steps.metadata.outputs.version }}'"
+          exit 1
+        fi
 
     - name: Sign
       run: |
         codesign --verbose --verify --options=runtime -f \
         -s "Developer ID Application: Tyler Vick (${{ secrets.AC_TEAM_ID }})" \
         ${{ steps.metadata.outputs.bin_path }}
-    
+
     - name: Verify
+      # --deep is deprecated by Apple and is not the right check for a lone
+      # executable; --strict on the binary itself is.
       run: |
-        codesign -vvv --deep --strict ${{ steps.metadata.outputs.bin_path }}
+        codesign -vvv --strict ${{ steps.metadata.outputs.bin_path }}
 
     - name: Package
       run: |
@@ -62,6 +103,7 @@ jobs:
         ${{ steps.metadata.outputs.archive_name }}
 
     - name: Notarize
+      if: github.event_name == 'push'
       run: |
         xcrun notarytool submit ${{ steps.metadata.outputs.archive_name }} \
         --apple-id ${{ secrets.AC_USERNAME }} \
@@ -75,19 +117,26 @@ jobs:
         name: application
         path: ${{ steps.metadata.outputs.archive_name }}
 
+    - name: Dry run summary
+      if: github.event_name == 'workflow_dispatch'
+      run: |
+        echo "### Dry run complete" >> "$GITHUB_STEP_SUMMARY"
+        echo "Built, signed and packaged \`${{ steps.metadata.outputs.archive_name }}\`." >> "$GITHUB_STEP_SUMMARY"
+        echo "Notarization and publishing were skipped." >> "$GITHUB_STEP_SUMMARY"
+
   release:
     runs-on: ubuntu-latest
-    
     needs: build
-    
+    if: github.event_name == 'push'
+
     steps:
     - name: Download
-      uses: actions/download-artifact@v4.1.7
-    
+      uses: actions/download-artifact@v4
+
     - name: Release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v3
       with:
-        prerelease: ${{ contains(github.ref, '-') }}
+        prerelease: ${{ needs.build.outputs.prerelease == 'true' }}
         generate_release_notes: true
         files: |
           application/xchtmlreport-*
@@ -97,11 +146,14 @@ jobs:
   bump_version:
     runs-on: ubuntu-latest
     needs: release
+    if: github.event_name == 'push'
     steps:
       - uses: actions/checkout@v4
 
+      # Bumps the patch component only. Major and minor bumps are deliberate
+      # decisions and are made by hand before tagging.
       - name: Get next version
-        uses: reecetech/version-increment@2022.5.1
+        uses: reecetech/version-increment@2024.10.1
         id: version
         with:
           scheme: semver
@@ -111,7 +163,7 @@ jobs:
         run: echo 'let version = "${{ steps.version.outputs.version }}"' > Sources/XCTestHTMLReport/Version.swift
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v8
         with:
           title: "${{ steps.version.outputs.version }} Version Bump"
           body: "Bumping version from ${{ steps.version.outputs.current-version }} to ${{ steps.version.outputs.version }}"

--- a/Sources/XCTestHTMLReport/Version.swift
+++ b/Sources/XCTestHTMLReport/Version.swift
@@ -1,1 +1,1 @@
-let version = "2.5.2-pre.bc4e30e"
+let version = "3.0.0-pre"


### PR DESCRIPTION
The release workflow could not have succeeded as written. Found while preparing to tag 3.0.

## Fatal today

**`xcode-version: ^16` fails outright.** `macos-latest` is now `macos-26`, which ships only Xcode 26.x — the identical break that just hit `ci.yml`. The release build cannot get past step 3.

**The binary's version never had to match the tag.** `Version.swift` was written only by the post-release `bump_version` job, so the released binary reported whatever happened to be on `main`. Confirmed locally:

```
$ swift build -c release && .build/.../xchtmlreport --version
2.5.2-pre.bc4e30e
```

So tagging `3.0.0` today would have published a binary announcing itself as `2.5.2-pre.bc4e30e`. The tag is now stamped into `Version.swift` before the build, and a new step **fails the release** if the built binary disagrees with the tag.

**`rc` tags would have shipped as full releases.** `prerelease` was computed as `contains(github.ref, '-')`, but the accepted tag patterns are `X.Y.Z` and `X.Y.ZrcN` — neither contains a hyphen. Now keyed on `rc`.

## Also fixed

- `::set-output` → `$GITHUB_OUTPUT` (deprecated; still worked as of the 2.5.1 release, but on borrowed time)
- `codesign --deep` dropped — deprecated by Apple, and the wrong check for a single executable; `--strict` on the binary is right
- `homebrew-bump.yml` was half commented out and five majors stale. It now triggers on `release: types: [released]`, which fires only for non-prereleases, so `rc` tags never reach homebrew-core. Manual dispatch still available.

Action versions, all badly behind: `import-codesign-certs` v1→**v7**, `action-gh-release` v1→**v3**, `create-pull-request` v3→**v8**, `version-increment` 2022.5.1→**2024.10.1**, `homebrew-bump-formula` v3.10.1→**v8**.

## New: a dry run

`workflow_dispatch` with `dry_run` builds, signs and packages **without** notarizing or publishing. Previously the only way to test a release was to cut one.

This matters more than it sounds: `BUILD_CERTIFICATE_BASE64` was added in October 2021, and Developer ID certificates are valid for five years. If it has expired or is about to, the dry run surfaces that before a tag is pushed rather than halfway through a release.

## Version

`Version.swift` → `3.0.0-pre`, so anyone on `brew install xctesthtmlreport --HEAD` or `mint install …@main` sees they are on pre-3.0 code carrying the exit-code break, instead of a string claiming 2.5.x.

## Not changed

`bump_version` still increments the patch component. Major and minor bumps stay deliberate manual decisions made before tagging — automating a major bump is not something a release pipeline should do on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Process**
  * Added support for manually previewing releases without publishing or notarizing them.
  * Improved release metadata and version verification, including prerelease detection.
  * Updated build signing and validation for more reliable release artifacts.
  * Homebrew updates now run automatically after stable releases while retaining manual triggering.

* **Maintenance**
  * Updated the application version to 3.0.0-pre.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->