### PR TITLE
Don't bump the version after a release candidate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,8 +145,13 @@ jobs:
 
   bump_version:
     runs-on: ubuntu-latest
-    needs: release
-    if: github.event_name == 'push'
+    needs: [build, release]
+    # Never bump after a release candidate. Beyond making no sense on its own
+    # terms, rc tags use the form X.Y.ZrcN, which is not valid semver (that
+    # would be X.Y.Z-rcN). version-increment cannot parse it, silently falls
+    # back to the last parseable tag, and proposes a version that goes
+    # backwards — after 3.0.0rc1 it proposed 2.5.2.
+    if: github.event_name == 'push' && needs.build.outputs.prerelease != 'true'
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Found by cutting `3.0.0rc1`. The release itself worked end to end — notarized, published, correctly marked as a prerelease, and Homebrew correctly left alone — but `bump_version` then opened [#395](https://github.com/XCTestHTMLReport/XCTestHTMLReport/pull/395) proposing to set `Version.swift` to `2.5.2-pre.53adfaf`.

That is **backwards**: `main` is at `3.0.0-pre`, and merging it would have regressed the version to a 2.5.x string.

## Cause

The rc tag format is `X.Y.ZrcN`. That is not valid semver — semver requires `X.Y.Z-rcN`, with a hyphen. `reecetech/version-increment` could not parse `3.0.0rc1`, silently fell back to the last tag it *could* parse (`2.5.1`), and incremented that to `2.5.2`.

Worth noting this is the **same root cause** as the `prerelease` bug fixed in #394: the old check was `contains(github.ref, '-')`, which assumed the semver hyphen that this tag format doesn't have. The non-standard tag format has now caused two separate defects.

## Fix

Skip `bump_version` for prereleases entirely. Bumping the version after a release candidate is wrong on its own terms — the rc is not the release — so this is the correct behaviour regardless of the parsing problem, and it doesn't paper over the tag format.

The condition reuses the `build` job's existing `prerelease` output rather than re-deriving it, so there is one source of truth for what counts as a prerelease.

## Not fixed here

The tag format itself. Migrating `X.Y.ZrcN` → `X.Y.Z-rcN` would make it real semver and remove this whole class of bug, but it changes an established convention and affects the tag-matching patterns. Worth doing deliberately, separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updates now run only after successful builds and releases.
  * Release candidate tags no longer trigger automatic version updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->