### PR TITLE
Stop asserting simulator reliability in testResultStatusCount

### DIFF
--- a/Tests/XCTestHTMLReportTests/CoreTests.swift
+++ b/Tests/XCTestHTMLReportTests/CoreTests.swift
@@ -61,11 +61,27 @@ final class CoreTests: XCTestCase {
             )
             let texts = try elements.eachText()
             XCTAssertEqual(texts.count, 5)
-            XCTAssertEqual(texts[0].intGroupMatch("All \\((\\d+)\\)"), 13)
-            XCTAssertEqual(texts[1].intGroupMatch("Passed \\((\\d+)\\)"), 7)
-            XCTAssertEqual(texts[2].intGroupMatch("Skipped \\((\\d+)\\)"), 1)
-            XCTAssertEqual(texts[3].intGroupMatch("Failed \\((\\d+)\\)"), 5)
-            XCTAssertEqual(texts[4].intGroupMatch("Mixed \\((\\d+)\\)"), 0)
+
+            let all = try XCTUnwrap(texts[0].intGroupMatch("All \\((\\d+)\\)"))
+            let passed = try XCTUnwrap(texts[1].intGroupMatch("Passed \\((\\d+)\\)"))
+            let skipped = try XCTUnwrap(texts[2].intGroupMatch("Skipped \\((\\d+)\\)"))
+            let failed = try XCTUnwrap(texts[3].intGroupMatch("Failed \\((\\d+)\\)"))
+            let mixed = try XCTUnwrap(texts[4].intGroupMatch("Mixed \\((\\d+)\\)"))
+
+            // Fixtures are regenerated on every run, so the pass/fail split is
+            // not fixed: the sample UI tests launch the app in setUp with
+            // continueAfterFailure = false, and a slow simulator turns a
+            // would-be pass into a failure. Asserting an exact split therefore
+            // measures simulator reliability rather than this project's
+            // behaviour. Assert only what the source actually determines.
+            XCTAssertEqual(all, 13, "One row per test method; fixed by the sample sources")
+            XCTAssertEqual(skipped, 1, "SampleAppUnitTests.testSkipped is an unconditional XCTSkipIf")
+            XCTAssertEqual(mixed, 0, "TestResults excludes RetryTests, so nothing can be mixed")
+            XCTAssertEqual(passed + failed, all - skipped, "Every remaining test lands in exactly one bucket")
+            XCTAssertGreaterThanOrEqual(
+                failed, 5,
+                "Five sample tests fail deliberately; a lower count means failures are being lost"
+            )
         }
     }
 


### PR DESCRIPTION
The `Codecov` run on `main` is failing. `Test` on the **same commit** passes.

```
53adfaf  Test    -> success
53adfaf  Codecov -> failure
```

Both run `./prepareTestResults.sh && swift test`. Same code, same commit, different outcome — so this is nondeterminism, not a code defect.

## What happens

```
CoreTests.swift:65: XCTAssertEqual failed: ("Optional(6)") is not equal to ("Optional(7)")
CoreTests.swift:67: XCTAssertEqual failed: ("Optional(6)") is not equal to ("Optional(5)")
```

`Passed` went 7→6 and `Failed` went 5→6; the total stayed 13. One test moved buckets. The fixture-generation log shows `FirstSuite.testOne` as **both** passed and failed:

```
1 Test Case '-[SampleAppUITests.FirstSuite testOne]' passed
1 Test Case '-[SampleAppUITests.FirstSuite testOne]' failed
```

Its body is `XCTAssert(true)` plus an attachment — it cannot fail on its own assertion. The failure comes from `setUp`, which calls `XCUIApplication().launch()` with `continueAfterFailure = false`. Under CI load the simulator is sometimes slow to launch the app, and the test fails before its body runs.

## Why it started now

This is a consequence of #379. Fixtures used to be fixed artifacts downloaded from a private bucket — byte-identical every run, so exact per-bucket assertions were safe. They are now regenerated on every run, which is a better trade overall (they can't go stale, and fork PRs can run them), but it means UI-test flakiness feeds straight into assertions that were written for stable input.

## The fix

Assert only what the sample sources actually determine:

| Assertion | Why it's stable |
| --- | --- |
| `all == 13` | one row per test method, fixed by source |
| `skipped == 1` | `SampleAppUnitTests.testSkipped` is an unconditional `XCTSkipIf` |
| `mixed == 0` | `TestResults` excludes `RetryTests` |
| `passed + failed == all - skipped` | every test lands in exactly one bucket |
| `failed >= 5` | five sample tests fail deliberately |

The exact pass/fail split is dropped, because it measures whether the simulator launched an app in time — not anything this project does.

**This still catches real regressions.** Losing a test breaks `all == 13`. Silently dropping failures breaks `failed >= 5`. Miscounting breaks the sum invariant. Under the flaked run (`passed=6, failed=6`) the new assertions correctly pass.

`testMixedStatus` is left alone: it reads `RetryResults`, and `RetryTests` has no `setUp` and never launches the app, so it isn't exposed to this.

## Follow-up

The underlying flakiness is worth its own issue — the sample UI tests launch the app purely so the run produces screen recordings (the only `.mp4` fixture coverage), and none of them actually interact with the UI. There may be a way to keep the recordings without the launch being a failure point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)