### PR TITLE
Call the Homebrew bump from the release instead of an event trigger

### DIFF
--- a/.github/workflows/homebrew-bump.yml
+++ b/.github/workflows/homebrew-bump.yml
@@ -1,10 +1,18 @@
 name: Brew Bump
 
 on:
-  # Fires only for non-prerelease publications, so `rc` tags never reach
-  # homebrew-core. Manual dispatch remains available for re-runs.
-  release:
-    types: [released]
+  # Called by the Release workflow. A `release:` event trigger cannot work
+  # here: the release is published by softprops/action-gh-release using
+  # GITHUB_TOKEN, and GitHub deliberately does not start new workflow runs
+  # from events created by GITHUB_TOKEN.
+  workflow_call:
+    inputs:
+      version:
+        type: string
+        required: true
+    secrets:
+      token:
+        required: true
   workflow_dispatch:
     inputs:
       version:
@@ -20,11 +28,7 @@ jobs:
     - name: Resolve tag
       id: tag
       run: |
-        if [[ -n "${{ github.event.inputs.version }}" ]]; then
-          TAG="${{ github.event.inputs.version }}"
-        else
-          TAG="${{ github.event.release.tag_name }}"
-        fi
+        TAG="${{ inputs.version }}"
         # Tolerate a full ref being pasted into the manual input.
         TAG="${TAG#refs/tags/}"
         echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
@@ -33,6 +37,6 @@ jobs:
     - name: Update Official Homebrew formula
       uses: dawidd6/action-homebrew-bump-formula@v8
       with:
-        token: ${{ secrets.HOMEBREW_BUMP_ACCESS_TOKEN }}
+        token: ${{ secrets.token || secrets.HOMEBREW_BUMP_ACCESS_TOKEN }}
         formula: xctesthtmlreport
         tag: ${{ steps.tag.outputs.tag }}

--- a/.github/workflows/homebrew-bump.yml
+++ b/.github/workflows/homebrew-bump.yml
@@ -10,9 +10,6 @@ on:
       version:
         type: string
         required: true
-    secrets:
-      token:
-        required: true
   workflow_dispatch:
     inputs:
       version:
@@ -27,16 +24,26 @@ jobs:
     steps:
     - name: Resolve tag
       id: tag
+      # The input reaches the shell through the environment, never through
+      # ${{ }} interpolation into the script body — a dispatch input is
+      # attacker-controllable by anyone with write access, and this job holds
+      # the Homebrew token. Validated against the tag shapes the release
+      # workflow accepts, so a malformed value fails here rather than being
+      # passed to Homebrew.
+      env:
+        RAW_VERSION: ${{ inputs.version }}
       run: |
-        TAG="${{ inputs.version }}"
-        # Tolerate a full ref being pasted into the manual input.
-        TAG="${TAG#refs/tags/}"
+        TAG="${RAW_VERSION#refs/tags/}"
+        if [[ ! "$TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?$ ]]; then
+          echo "::error::'${TAG}' is not a release tag (expected X.Y.Z or X.Y.ZrcN)"
+          exit 1
+        fi
         echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
         echo "bumping to ${TAG}"
 
     - name: Update Official Homebrew formula
       uses: dawidd6/action-homebrew-bump-formula@v8
       with:
-        token: ${{ secrets.token || secrets.HOMEBREW_BUMP_ACCESS_TOKEN }}
+        token: ${{ secrets.HOMEBREW_BUMP_ACCESS_TOKEN }}
         formula: xctesthtmlreport
         tag: ${{ steps.tag.outputs.tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -188,5 +188,9 @@ jobs:
     uses: ./.github/workflows/homebrew-bump.yml
     with:
       version: ${{ needs.build.outputs.version }}
-    secrets:
-      token: ${{ secrets.HOMEBREW_BUMP_ACCESS_TOKEN }}
+    # inherit rather than passing a named secret: the called workflow also runs
+    # standalone via workflow_dispatch, which cannot be passed secrets at all,
+    # so it must read HOMEBREW_BUMP_ACCESS_TOKEN from the repository either way.
+    # Inheriting keeps one code path instead of a fallback whose branches
+    # resolve differently depending on how the workflow was triggered.
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
     runs-on: macos-latest
     outputs:
       prerelease: ${{ steps.metadata.outputs.prerelease }}
+      version: ${{ steps.metadata.outputs.version }}
 
     steps:
     - uses: actions/checkout@v4
@@ -177,3 +178,15 @@ jobs:
           add-paths: Sources/XCTestHTMLReport/Version.swift
           reviewers: tylervick
           base: main
+
+  homebrew:
+    # Called directly rather than triggered by a `release:` event, because the
+    # release is published with GITHUB_TOKEN and GitHub does not start new
+    # workflow runs from events that token creates.
+    needs: [build, release]
+    if: github.event_name == 'push' && needs.build.outputs.prerelease != 'true'
+    uses: ./.github/workflows/homebrew-bump.yml
+    with:
+      version: ${{ needs.build.outputs.version }}
+    secrets:
+      token: ${{ secrets.HOMEBREW_BUMP_ACCESS_TOKEN }}


### PR DESCRIPTION
The `release: types: [released]` trigger I added in #394 **can never fire**.

The release is published by `softprops/action-gh-release` using `secrets.GITHUB_TOKEN`, and GitHub deliberately does not start new workflow runs from events created by that token — a recursion guard. Confirmed on the real 3.0.0 release: the release published successfully, and the Brew Bump workflow recorded **zero runs**.

## Fix

`homebrew-bump.yml` becomes a reusable `workflow_call`, invoked directly as a job of `release.yml` once the release job succeeds. No event propagation involved, so nothing depends on which token published the release.

Guards preserved: `if: github.event_name == 'push' && needs.build.outputs.prerelease != 'true'`, so release candidates still never reach homebrew-core. Manual `workflow_dispatch` is kept for re-runs.

## This is not the only thing blocking the 3.0.0 formula bump

A manual dispatch also fails:

```
GitHub API Error: Bad credentials (GitHub::API::AuthenticationFailedError)
`$HOMEBREW_GITHUB_API_TOKEN` may be invalid or expired
```

**`HOMEBREW_BUMP_ACCESS_TOKEN` has expired or been revoked.** It was added 2023-11-13. No bump can succeed until it is regenerated, automatic or manual.

Homebrew currently serves **2.5.1** (31,640 installs in the last 90 days), and will keep doing so until that token is replaced and a bump runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Automated Homebrew updates now run as part of successful non-prerelease releases.
  * Release workflows securely pass the generated version and authorization to the Homebrew update process.
  * Manual Homebrew update runs remain supported.
  * Release tags are validated before Homebrew updates are submitted, helping prevent updates from invalid version formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->