### PR TITLE
Don't bump Homebrew from the release; the formula is autobumped

### DIFF
--- a/.github/workflows/homebrew-bump.yml
+++ b/.github/workflows/homebrew-bump.yml
@@ -1,15 +1,16 @@
 name: Brew Bump
 
+# Manual escape hatch only.
+#
+# xctesthtmlreport is on Homebrew's autobump list: BrewTestBot opens a
+# version-bump PR against homebrew-core on its own roughly every 3 hours after
+# a release, and `brew bump-formula-pr` refuses a manual bump for autobumped
+# formulae. Every formula PR since 2.5.1 has been opened by BrewTestBot.
+#
+# This is kept only for the case where the formula leaves the autobump list
+# (gains a `no_autobump!` or a skipped livecheck). It is deliberately not wired
+# into the release workflow, because it would fail every release.
 on:
-  # Called by the Release workflow. A `release:` event trigger cannot work
-  # here: the release is published by softprops/action-gh-release using
-  # GITHUB_TOKEN, and GitHub deliberately does not start new workflow runs
-  # from events created by GITHUB_TOKEN.
-  workflow_call:
-    inputs:
-      version:
-        type: string
-        required: true
   workflow_dispatch:
     inputs:
       version:
@@ -27,9 +28,7 @@ jobs:
       # The input reaches the shell through the environment, never through
       # ${{ }} interpolation into the script body — a dispatch input is
       # attacker-controllable by anyone with write access, and this job holds
-      # the Homebrew token. Validated against the tag shapes the release
-      # workflow accepts, so a malformed value fails here rather than being
-      # passed to Homebrew.
+      # the Homebrew token.
       env:
         RAW_VERSION: ${{ inputs.version }}
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,18 +179,3 @@ jobs:
           reviewers: tylervick
           base: main
 
-  homebrew:
-    # Called directly rather than triggered by a `release:` event, because the
-    # release is published with GITHUB_TOKEN and GitHub does not start new
-    # workflow runs from events that token creates.
-    needs: [build, release]
-    if: github.event_name == 'push' && needs.build.outputs.prerelease != 'true'
-    uses: ./.github/workflows/homebrew-bump.yml
-    with:
-      version: ${{ needs.build.outputs.version }}
-    # inherit rather than passing a named secret: the called workflow also runs
-    # standalone via workflow_dispatch, which cannot be passed secrets at all,
-    # so it must read HOMEBREW_BUMP_ACCESS_TOKEN from the repository either way.
-    # Inheriting keeps one code path instead of a fallback whose branches
-    # resolve differently depending on how the workflow was triggered.
-    secrets: inherit


### PR DESCRIPTION
The `homebrew` job added in #400 would have failed on **every** release. Removing it.

## What happened

With `HOMEBREW_BUMP_ACCESS_TOKEN` regenerated, the bump got past authentication and reached `brew bump-formula-pr`, which refused it:

```
Whoops, the xctesthtmlreport formula has its version update
pull requests automatically opened by BrewTestBot every ~3 hours!
```

`xctesthtmlreport` is on Homebrew's autobump list. `brew bump-formula-pr` deliberately rejects manual bumps for autobumped formulae.

## This was already true

| PR | Title | Author |
| --- | --- | --- |
| Homebrew/homebrew-core#211135 | xctesthtmlreport 2.5.1 | **BrewTestBot** |
| Homebrew/homebrew-core#238348 | xctesthtmlreport: update 2.5.1 bottle | BrewTestBot |

The 2.5.1 formula PR was opened by BrewTestBot ~2.5 hours after the 2.5.1 release, and the `Brew Bump` workflow has **zero runs** in its entire history. The formula has been updating on its own the whole time; the workflow never did anything.

3.0.0 will reach Homebrew the same way, without intervention.

## Change

- Remove the `homebrew` job from `release.yml`, and the `workflow_call` plumbing that existed only to serve it.
- Keep `homebrew-bump.yml` as a **manual `workflow_dispatch` escape hatch**, for the case where the formula later leaves the autobump list (gains `no_autobump!` or a skipped livecheck). It is deliberately not wired into the release, since it would fail there.
- The script-injection hardening from #400 is retained.

## Why it wasn't caught sooner

The expired token masked it: brew failed at authentication before it ever evaluated whether the formula was autobumped. Checking who authors the formula PRs in homebrew-core would have revealed it immediately, and should have been the first thing checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Homebrew publishing workflows to support manual execution only.
  * Removed automatic Homebrew updates from the release process.
  * Added documentation clarifying Homebrew autobump behavior and manual workflow usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->