### PR TITLE
Add Dependabot for GitHub Actions and SwiftPM

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,40 @@
+version: 2
+
+updates:
+  # Third-party actions in this repo went years without a bump — at the 3.0
+  # release, five of them were between two and six major versions behind, and
+  # two workflows were broken by drift nobody was watching for.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    labels:
+      - dependencies
+      - github_actions
+    # Minor and patch bumps arrive as one PR so a quiet week is one review, not
+    # nine. Majors stay separate: they are the ones that break workflows.
+    groups:
+      actions-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: swift
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    labels:
+      - dependencies
+    groups:
+      swift-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+    open-pull-requests-limit: 5


### PR DESCRIPTION
First of the maintenance-automation batch. Closes part of #384.

## Why

Third-party actions in this repo went years without a bump. At the 3.0 release, five were between **two and six major versions behind**:

| Action | Was | Current |
| --- | --- | --- |
| `Apple-Actions/import-codesign-certs` | v1 | **v7** |
| `softprops/action-gh-release` | v1 | **v3** |
| `peter-evans/create-pull-request` | v3 | **v8** |
| `dawidd6/action-homebrew-bump-formula` | v3.10.1 | **v8** |
| `reecetech/version-increment` | 2022.5.1 | **2024.10.1** |

And two workflows were already broken by drift nobody was watching for — `ci.yml` and `release.yml` both pinned Xcode versions that no longer exist on `macos-latest`, the second of which would have failed *during* a release.

Dependabot is the cheapest fix for this class of rot, and unlike a drift detector it arrives with the fix already written.

## Grouping

Minor and patch updates are grouped into one PR per ecosystem, so a quiet week costs one review instead of nine. Majors stay ungrouped — those are the ones that break workflows and deserve individual attention.

Weekly, Mondays. Labels reuse the repo's existing `dependencies` and `github_actions`.

## On `Package.resolved`

This repo's `Package.resolved` is **schema version 1** — the Swift 5.5-era format, where pins live under `object.pins` with `repositoryURL`/`package` keys rather than the modern top-level `pins` with `location`/`identity`.

Rather than assume Dependabot could read it, I checked `dependabot-core`:

```ruby
SUPPORTED_VERSIONS = [1, 2, 3].freeze

PIN_KEYS = {
  1 => { url: "repositoryURL", identity: "package", state: "state" },
  ...
```

v1 is supported and maps to exactly the keys this file uses, so no regeneration is needed. Regenerating would have churned pinned versions for no benefit.

## Not in this PR

SHA-pinning the actions (the other half of #384) comes after the lint workflow lands — it rewrites every `uses:` line and would conflict with anything adding CI steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated weekly maintenance checks to help keep the project’s supporting components up to date.
  * Updates are grouped and labeled consistently, with safeguards to limit the number of simultaneous maintenance changes.
  * This streamlines routine upkeep and makes maintenance activity easier to track.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->