### PR TITLE
Pin third-party actions to SHAs and scope workflow tokens

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [ main ]
 
+# Only reads the tree. The repository default is write, so scope the token
+# down explicitly rather than inheriting more than is needed.
+permissions:
+  contents: read
+
 jobs:
   build:
     strategy:
@@ -23,9 +28,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
 
     - name: Setup Xcode version
-      uses: maxim-lobanov/setup-xcode@v1.6.0        
+      uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0        
       with:
         xcode-version: ${{ matrix.xcode_version }}
 

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -5,15 +5,22 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+# Only reads the tree. The repository default is write, so scope the token
+# down explicitly rather than inheriting more than is needed.
+permissions:
+  contents: read
+
 jobs:
   coverage:
     runs-on: macos-latest
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
 
     - name: Setup Xcode version
-      uses: maxim-lobanov/setup-xcode@v1.6.0
+      uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
       with:
         xcode-version: latest-stable
 
@@ -29,7 +36,7 @@ jobs:
         .build/debug/XCTestHTMLReportPackageTests.xctest/Contents/MacOS/XCTestHTMLReportPackageTests \
         -instr-profile .build/debug/codecov/default.profdata > info.lcov
 
-    - uses: codecov/codecov-action@v4
+    - uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
       with:
         files: info.lcov
         verbose: true

--- a/.github/workflows/homebrew-bump.yml
+++ b/.github/workflows/homebrew-bump.yml
@@ -18,6 +18,11 @@ on:
         required: true
         description: "Release tag to bump to, e.g. 3.0.0"
 
+# Only reads the tree. The repository default is write, so scope the token
+# down explicitly rather than inheriting more than is needed.
+permissions:
+  contents: read
+
 jobs:
   update_brew_formula:
     runs-on: ubuntu-latest
@@ -41,7 +46,7 @@ jobs:
         echo "bumping to ${TAG}"
 
     - name: Update Official Homebrew formula
-      uses: dawidd6/action-homebrew-bump-formula@v8
+      uses: dawidd6/action-homebrew-bump-formula@a0e064e08103c01870c6d1b05168d1b726aab119 # v8
       with:
         token: ${{ secrets.HOMEBREW_BUMP_ACCESS_TOKEN }}
         formula: xctesthtmlreport

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -3,14 +3,14 @@ name: Publish GitHub Pages
 on:
   workflow_dispatch:
 
-# Only reads the tree. The repository default is write, so scope the token
-# down explicitly rather than inheriting more than is needed.
-permissions:
-  contents: read
-
+# Declared per job rather than at workflow level. The repository default is
+# write, so every job states its own minimum; deploy needs no contents access
+# at all.
 jobs:
   build:
     runs-on: macos-latest
+    permissions:
+      contents: read
     steps:    
     - uses: actions/checkout@v2
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -3,6 +3,11 @@ name: Publish GitHub Pages
 on:
   workflow_dispatch:
 
+# Only reads the tree. The repository default is write, so scope the token
+# down explicitly rather than inheriting more than is needed.
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: macos-latest
@@ -15,7 +20,7 @@ jobs:
         version: 14.2
 
     - name: Download XCResult
-      uses: dawidd6/action-download-artifact@v6
+      uses: dawidd6/action-download-artifact@bf251b5aa9c2f7eeb574a96ee720e24f801b7c11 # v6
       with:
         workflow: test-artifacts.yml
         workflow_conclusion: success

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,14 +14,14 @@ on:
         default: true
         description: "Build, sign and package, but do not notarize or publish"
 
-# Declared per job: the build only reads, publishing needs to write releases,
-# and the version bump needs to open a pull request.
-permissions:
-  contents: read
-
+# Declared per job rather than at workflow level, so no job silently inherits
+# a grant it does not need: the build only reads, publishing writes releases,
+# and the version bump also opens a pull request.
 jobs:
   build:
     runs-on: macos-latest
+    permissions:
+      contents: read
     outputs:
       prerelease: ${{ steps.metadata.outputs.prerelease }}
       version: ${{ steps.metadata.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,11 @@ on:
         default: true
         description: "Build, sign and package, but do not notarize or publish"
 
+# Declared per job: the build only reads, publishing needs to write releases,
+# and the version bump needs to open a pull request.
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: macos-latest
@@ -23,15 +28,19 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        # Nothing in this job pushes. bump_version's checkout keeps its
+        # credentials, because create-pull-request pushes a branch from it.
+        persist-credentials: false
 
     - name: Configure Signing
-      uses: Apple-Actions/import-codesign-certs@v7
+      uses: Apple-Actions/import-codesign-certs@5142e029c445c10ffc7149d172e540235a065466 # v7
       with:
         p12-file-base64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
         p12-password: ${{ secrets.P12_PASSWORD }}
 
     - name: Setup Xcode version
-      uses: maxim-lobanov/setup-xcode@v1.6.0
+      uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
       with:
         xcode-version: latest-stable
 
@@ -129,13 +138,15 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     if: github.event_name == 'push'
+    permissions:
+      contents: write
 
     steps:
     - name: Download
       uses: actions/download-artifact@v4
 
     - name: Release
-      uses: softprops/action-gh-release@v3
+      uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
       with:
         prerelease: ${{ needs.build.outputs.prerelease == 'true' }}
         generate_release_notes: true
@@ -147,6 +158,9 @@ jobs:
   bump_version:
     runs-on: ubuntu-latest
     needs: [build, release]
+    permissions:
+      contents: write
+      pull-requests: write
     # Never bump after a release candidate. Beyond making no sense on its own
     # terms, rc tags use the form X.Y.ZrcN, which is not valid semver (that
     # would be X.Y.Z-rcN). version-increment cannot parse it, silently falls
@@ -159,7 +173,7 @@ jobs:
       # Bumps the patch component only. Major and minor bumps are deliberate
       # decisions and are made by hand before tagging.
       - name: Get next version
-        uses: reecetech/version-increment@2024.10.1
+        uses: reecetech/version-increment@a29aa752dc3b8118a2dc2ed93faf0e95a73a9c7e # 2024.10.1
         id: version
         with:
           scheme: semver
@@ -169,7 +183,7 @@ jobs:
         run: echo 'let version = "${{ steps.version.outputs.version }}"' > Sources/XCTestHTMLReport/Version.swift
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:
           title: "${{ steps.version.outputs.version }} Version Bump"
           body: "Bumping version from ${{ steps.version.outputs.current-version }} to ${{ steps.version.outputs.version }}"

--- a/.github/workflows/test-artifacts.yml
+++ b/.github/workflows/test-artifacts.yml
@@ -3,6 +3,11 @@ name: Generate Test Artifacts
 on:
   workflow_dispatch:
 
+# Only reads the tree. The repository default is write, so scope the token
+# down explicitly rather than inheriting more than is needed.
+permissions:
+  contents: read
+
 jobs:
   create_test_data:
     strategy:
@@ -21,9 +26,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-  
+        with:
+          persist-credentials: false
+
       - name: Setup Xcode version
-        uses: maxim-lobanov/setup-xcode@v1.6.0
+        uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
         with:
           xcode-version: ${{ matrix.xcode_version }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,14 +6,21 @@ on:
   pull_request:
   workflow_dispatch:
 
+# Only reads the tree. The repository default is write, so scope the token
+# down explicitly rather than inheriting more than is needed.
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
 
     - name: Setup Xcode version
-      uses: maxim-lobanov/setup-xcode@v1.6.0
+      uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
       with:
         xcode-version: latest-stable
 


### PR DESCRIPTION
Closes the rest of #384. Third of the maintenance-automation batch.

## SHA pinning

Every third-party action was referenced by mutable tag — the finding SonarCloud has been raising on every PR in this batch (`githubactions:S7637`). A tag can be repointed by the action owner, or by anyone who compromises the action's repository, and these workflows would silently execute different code.

Eight actions pinned to full commit SHAs with the tag preserved in a trailing comment, which is the form Dependabot reads and bumps:

| Action | SHA |
| --- | --- |
| `Apple-Actions/import-codesign-certs` | `5142e029…` (v7) |
| `codecov/codecov-action` | `b9fd7d16…` (v4) |
| `dawidd6/action-download-artifact` | `bf251b5a…` (v6) |
| `dawidd6/action-homebrew-bump-formula` | `a0e064e0…` (v8) |
| `maxim-lobanov/setup-xcode` | `60606e26…` (v1.6.0) |
| `peter-evans/create-pull-request` | `5f6978fa…` (v8) |
| `reecetech/version-increment` | `a29aa752…` (2024.10.1) |
| `softprops/action-gh-release` | `3d0d9888…` (v3) |

`actions/*` are left on tags — first-party, and not what the rule targets.

## One action could not be pinned, because it no longer exists

```
$ gh api repos/devbotsxyz/xcode-select
{"message":"Not Found","status":"404"}
```

`devbotsxyz/xcode-select@v1.1.0` is used at `pages.yml:13`. **The repository has been deleted from GitHub**, so that workflow cannot run at all — a third independent breakage on top of the two already recorded in #385 (`--` swallowing `-j`, and downloading an artifact name that is no longer produced).

Left in place rather than guessing at a replacement, since #385 asks whether Pages publishing is still wanted at all. If it is, that action needs replacing with `maxim-lobanov/setup-xcode` as part of fixing it.

## Token scoping

The repository default workflow permission is **write**, so every workflow has been inheriting a write-scoped `GITHUB_TOKEN` regardless of what it does. Each now declares its minimum.

`release.yml` differs per job rather than taking a blanket value:

| Job | Permissions | Why |
| --- | --- | --- |
| `build` | `contents: read` | builds, signs, uploads an artifact |
| `release` | `contents: write` | publishes the GitHub release |
| `bump_version` | `contents: write`, `pull-requests: write` | opens the version-bump PR |

## `persist-credentials`

`actions/checkout` leaves the token in `.git/config` by default. Set to `false` on every checkout that does not push, so it is not sitting on disk while builds and third-party tooling (`brew install`, `xcodebuild`) run.

Two checkouts deliberately keep credentials:

- **`bump_version`** — `peter-evans/create-pull-request` pushes a branch from that working copy.
- **`pages.yml`** — untouched pending #385.

## Verification

All nine workflow files parse, and each checkout's setting was confirmed by walking the parsed YAML per step rather than by reading the diff — `test-artifacts.yml` uses 6-space step indentation where the others use 4, and the first attempt put `with:` at the wrong level. YAML validation caught it.

A release dry run follows, to confirm the `release.yml` permission and checkout changes do not disturb a pipeline that was verified end to end earlier today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security & Reliability**
  * Strengthened automation security with least-privilege repository permissions.
  * Disabled persistent checkout credentials.
  * Pinned third-party workflow actions to immutable versions for more predictable and secure builds, tests, releases, and deployments.
  * Preserved required write access only for release and version-management tasks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->