### PR TITLE
Add an opt-in pre-commit hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Runs the same checks CI runs, on staged files only.
+#
+# Not installed automatically — see CONTRIBUTING.md. A repository that silently
+# takes over your git config is worse than one that asks.
+#
+# Skip a single commit with:  git commit --no-verify
+set -uo pipefail
+
+staged() { git diff --cached --name-only --diff-filter=ACMR -z -- "$@"; }
+fail=0
+note() { printf '\n\033[1m%s\033[0m\n' "$1"; }
+
+# --- shell ---------------------------------------------------------------
+if [[ -n "$(staged '*.sh' | tr -d '\0')" ]]; then
+  if command -v shellcheck >/dev/null; then
+    note "shellcheck"
+    staged '*.sh' | xargs -0 shellcheck || fail=1
+  else
+    echo "shellcheck not installed; skipping (brew install shellcheck)"
+  fi
+fi
+
+# --- swift ---------------------------------------------------------------
+swift_staged="$(staged '*.swift' | tr -d '\0')"
+if [[ -n "$swift_staged" ]]; then
+  if command -v swiftformat >/dev/null; then
+    note "swiftformat"
+    # --lint rather than formatting in place: a hook that rewrites files under
+    # you produces commits whose contents you did not read.
+    staged '*.swift' | xargs -0 swiftformat --lint || {
+      echo "run 'swiftformat .' to fix, then re-stage"
+      fail=1
+    }
+  else
+    echo "swiftformat not installed; skipping (brew install swiftformat)"
+  fi
+
+  if command -v swiftlint >/dev/null; then
+    note "swiftlint"
+    # SwiftLint reads .swiftlint.yml for its own include/exclude rules, so pass
+    # paths explicitly to keep the hook scoped to what is being committed.
+    staged '*.swift' | xargs -0 swiftlint lint --quiet || fail=1
+  else
+    echo "swiftlint not installed; skipping (brew install swiftlint)"
+  fi
+fi
+
+if [[ $fail -ne 0 ]]; then
+  printf '\n\033[31mpre-commit checks failed.\033[0m Fix the above, or commit with --no-verify.\n'
+  exit 1
+fi
+exit 0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,5 +54,31 @@ green run locally means a green run on your pull request.
 Regenerate fixtures after upgrading Xcode; `.xcresult` contents change between
 Xcode versions.
 
+### Optional: run the checks before committing
+
+CI runs shellcheck, SwiftFormat, and SwiftLint. The same checks can run locally on
+staged files, so you find problems before pushing:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+That is opt-in on purpose — nothing installs it for you.
+
+The hook only checks files you are actually committing, and skips a tool entirely
+if it is not installed:
+
+```bash
+brew install shellcheck swiftformat swiftlint
+```
+
+It reports problems rather than rewriting your files, so a commit never contains
+changes you have not read. To skip it for one commit:
+
+```bash
+git commit --no-verify
+```
+
+
 
 *Some of the ideas and wording for the statements above were based on [AFNetworking](https://github.com/AFNetworking/AFNetworking).


### PR DESCRIPTION
Closes #383. Last of the maintenance-automation batch (#402, #410, #413 preceding).

Runs the same three checks CI runs — shellcheck, SwiftFormat, SwiftLint — against **staged files only**, so it stays fast rather than linting the whole tree on every commit.

## Three deliberate design choices

**Opt-in, not automatic.** Enabled with `git config core.hooksPath .githooks`, documented in CONTRIBUTING. Nothing installs it for you — a repository that silently takes over your git config is worse than one that asks.

**Lints rather than formatting in place.** A hook that rewrites files underneath you produces commits whose contents you never read. It tells you to run `swiftformat .` instead.

**Degrades rather than blocking.** Each tool is skipped with a note if it is not installed, so a contributor who has not run `brew install shellcheck swiftformat swiftlint` yet can still commit.

## Verified by running it, not by reading it

| Case | Result |
| --- | --- |
| Staged `.swift` with a formatting violation | **blocked** — `git log` confirmed no commit landed |
| Clean staged `.swift` | committed |
| `git commit --no-verify` | bypassed as expected |
| Docs-only commit | both linters skipped entirely |

The hook also passes `shellcheck` itself, which felt like the minimum for a script whose job is running shellcheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added optional pre-commit checks for staged shell and Swift files.
  * Reports issues from available linting and formatting tools before commits.
  * Provides clear guidance when checks fail, while allowing commits to bypass checks when needed.

* **Documentation**
  * Added setup and usage instructions for enabling and configuring the pre-commit checks.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->