### PR TITLE
Use fputs for stderr writes in Logger

### DIFF
--- a/Sources/XCTestHTMLReportCore/Classes/Helpers/Logger.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Helpers/Logger.swift
@@ -41,6 +41,12 @@ public enum Logger {
     }
 
     private static func printToStandardError(_ message: String) {
-        FileHandle.standardError.write(Data((message + "\n").utf8))
+        // `FileHandle.write` is unbuffered while `print`'s stdout is block-buffered
+        // when piped, so under `2>&1` these lines would jump ahead of stdout output
+        // instead of interleaving where they occurred. It also raises an uncatchable
+        // Objective-C exception when the descriptor is closed (e.g. `2>&-`). `fputs`
+        // avoids both problems. Flushing stdout first keeps interleaving accurate.
+        fflush(stdout)
+        fputs(message + "\n", stderr)
     }
 }


### PR DESCRIPTION
## What was wrong

3.0 moved `Logger.error` and `Logger.warning` to stderr via `FileHandle.standardError.write`. That introduced two problems:

1. **Output ordering.** `print` writes to a block-buffered stdout when output is piped; `FileHandle.write` is unbuffered. Under `2>&1` (i.e. any CI log), warnings/errors jumped ahead of the "Report successfully created" line instead of interleaving where they actually occurred.
2. **Crash on a closed descriptor.** `FileHandle.write` raises an uncatchable Objective-C exception, so `xchtmlreport … 2>&-` crashed where it previously failed silently.

Fixes #390.

## What changed

Only `Sources/XCTestHTMLReportCore/Classes/Helpers/Logger.swift`: `printToStandardError` now flushes stdout and uses `fputs(message + "\n", stderr)` instead of `FileHandle.standardError.write`. `error` and `warning` still go to stderr; `success`, `step`, and `substep` are untouched and remain on stdout (verified by the CLI test suite, which parses `Logger.success` output from stdout).

```diff
     private static func printToStandardError(_ message: String) {
-        FileHandle.standardError.write(Data((message + "\n").utf8))
+        // `FileHandle.write` is unbuffered while `print`'s stdout is block-buffered
+        // when piped, so under `2>&1` these lines would jump ahead of stdout output
+        // instead of interleaving where they occurred. It also raises an uncatchable
+        // Objective-C exception when the descriptor is closed (e.g. `2>&-`). `fputs`
+        // avoids both problems. Flushing stdout first keeps interleaving accurate.
+        fflush(stdout)
+        fputs(message + "\n", stderr)
     }
```

## Verification

All commands run from a clean checkout of this branch, fixtures generated via `./prepareTestResults.sh`.

**1. `swift build` — clean**

```
Build complete! (1.23s)
```

**2. `swift test` — 22 tests, 1 skipped, 0 failures**

```
Test Suite 'XCTestHTMLReportPackageTests.xctest' passed at 2026-08-07 18:01:18.640.
	 Executed 22 tests, with 1 test skipped and 0 failures (0 unexpected) in 12.363 (12.367) seconds
Test Suite 'All tests' passed at 2026-08-07 18:01:18.640.
	 Executed 22 tests, with 1 test skipped and 0 failures (0 unexpected) in 12.363 (12.368) seconds
```

(`CoreTests.testRetryFunctionalityJunit` is skipped pending #378, as expected.)

**3. Ordering fix**, using a degraded bundle (`mkdir -p /tmp/Broken.xcresult`) piped with `> out.log 2>&1`:

Before this fix (stashed the change, rebuilt), the success line was pushed to the very end, after all the warnings that were chronologically emitted later:
```
1	Error: Failed to create a new result bundle reader, underlying error: Info.plist at /tmp/Broken.xcresult/Info.plist does not exist, the result bundle might be corrupted or the provided path is not a result bundle
2	Warning: Can't find invocation record for : /tmp/Broken.xcresult
3	Warning: Report is degraded: 1 fault(s)
4	Warning:   missingInvocationRecord: /tmp/Broken.xcresult
5	Error: Exiting non-zero. Pass --lenient to ignore faults.
6	
7	Report successfully created at /tmp/broken-out/index.html
```

After this fix, "Report successfully created" appears in its correct chronological position — before the later degradation warnings that are emitted after the report is written:
```
1	Error: Failed to create a new result bundle reader, underlying error: Info.plist at /tmp/Broken.xcresult/Info.plist does not exist, the result bundle might be corrupted or the provided path is not a result bundle
2	Warning: Can't find invocation record for : /tmp/Broken.xcresult
3	
4	Report successfully created at /tmp/broken-out/index.html
5	Warning: Report is degraded: 1 fault(s)
6	Warning:   missingInvocationRecord: /tmp/Broken.xcresult
7	Error: Exiting non-zero. Pass --lenient to ignore faults.
```

**4. Crash fix**, running with stderr closed (`xchtmlreport -o /tmp/broken-out /tmp/Broken.xcresult 2>&-`):

Before this fix:
```
line 3: 76010 Abort trap: 6           "$BIN" -o /tmp/broken-out /tmp/Broken.xcresult 2>&-
EXIT CODE: 134
```

After this fix:
```
Report successfully created at /tmp/broken-out/index.html
EXIT CODE: 3
```

No crash; exits cleanly with code 3 (faults were collected, as expected for a broken bundle).

**5. `Logger.success` still on stdout** (`xchtmlreport -o /tmp/broken-out /tmp/Broken.xcresult 2>/dev/null`):

```
Report successfully created at /tmp/broken-out/index.html
```

## Concerns

None. The change is scoped to the single private helper method in `Logger.swift`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
