### PR TITLE
Add Swift Testing (@Test) fixture and structural assertions

### DIFF
--- a/Tests/XCTestHTMLReportTests/CoreTests.swift
+++ b/Tests/XCTestHTMLReportTests/CoreTests.swift
@@ -74,7 +74,10 @@ final class CoreTests: XCTestCase {
             // would-be pass into a failure. Asserting an exact split therefore
             // measures simulator reliability rather than this project's
             // behaviour. Assert only what the source actually determines.
-            XCTAssertEqual(all, 13, "One row per test method; fixed by the sample sources")
+            //
+            // 16 = 13 XCTest methods + 3 Swift Testing `@Test` functions in
+            // SwiftTestingSuite (SampleAppUnitTests target).
+            XCTAssertEqual(all, 16, "One row per test method; fixed by the sample sources")
             XCTAssertEqual(
                 skipped,
                 1,
@@ -87,9 +90,59 @@ final class CoreTests: XCTestCase {
                 "Every remaining test lands in exactly one bucket"
             )
             XCTAssertGreaterThanOrEqual(
-                failed, 5,
-                "Five sample tests fail deliberately; a lower count means failures are being lost"
+                failed, 6,
+                "Six sample tests fail deliberately (including SwiftTestingSuite.intentionalFailure); " +
+                    "a lower count means failures are being lost"
             )
+        }
+    }
+
+    /// Swift Testing (`import Testing`, `@Test`) results are recorded
+    /// differently inside an `.xcresult` than plain XCTest results. This
+    /// asserts they still make it through the HTML pipeline: rendered at
+    /// all, with the right pass/fail status, and with the failure message
+    /// attached. See #393.
+    func testSwiftTestingResultsRendered() throws {
+        let testResultsUrl = try XCTUnwrap(testResultsUrl)
+        let summary = Summary(
+            resultPaths: [testResultsUrl.path],
+            renderingMode: .linking,
+            downsizeImagesEnabled: false,
+            downsizeScaleFactor: 0.5
+        )
+
+        let document = try SwiftSoup.parse(summary.html)
+
+        try XCTContext.runActivity(named: "Swift Testing results render like XCTest results") { _ in
+            let testCases = try document.select("div.test-summary")
+
+            func testCase(named name: String) throws -> Element {
+                try XCTUnwrap(
+                    testCases.first {
+                        let label = try? $0.select("p.list-item").first()?.text()
+                        return label?.hasPrefix(name) == true
+                    },
+                    "No rendered test case found for Swift Testing test '\(name)'"
+                )
+            }
+
+            let passing = try testCase(named: "additionWorks()")
+            XCTAssertTrue(
+                passing.hasClass("succeeded"),
+                "additionWorks() is an unconditional #expect(true)"
+            )
+
+            let tagged = try testCase(named: "taggedMultiplication()")
+            XCTAssertTrue(
+                tagged.hasClass("succeeded"),
+                "taggedMultiplication() carries a .tags() trait but still passes"
+            )
+
+            let failing = try testCase(named: "intentionalFailure()")
+            XCTAssertTrue(failing.hasClass("failed"), "intentionalFailure() calls #expect(false)")
+
+            let failureText = try failing.select("div.activity-assertion-failure").text()
+            try XCTAssertContains(failureText, "This Swift Testing test intentionally fails")
         }
     }
 

--- a/XCTestHTMLReportSampleApp/SampleApp.xcodeproj/project.pbxproj
+++ b/XCTestHTMLReportSampleApp/SampleApp.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		F3AB01411F2459FA00334580 /* FirstSuite.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3AB01401F2459FA00334580 /* FirstSuite.swift */; };
 		F3BBACC41F2853570069962A /* iPhone.png in Resources */ = {isa = PBXBuildFile; fileRef = F3223CEF1F26341D00BEDA4A /* iPhone.png */; };
 		F3C1FC591FECE3C30028EC72 /* SampleAppUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3C1FC581FECE3C30028EC72 /* SampleAppUnitTests.swift */; };
+		5B67974379BD4801BE959C18 /* SwiftTestingSuite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38E9439014F9402F8D99C320 /* SwiftTestingSuite.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -56,6 +57,7 @@
 		F3C1FC561FECE3C30028EC72 /* SampleAppUnitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SampleAppUnitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		F3C1FC581FECE3C30028EC72 /* SampleAppUnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SampleAppUnitTests.swift; sourceTree = "<group>"; };
 		F3C1FC5A1FECE3C30028EC72 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		38E9439014F9402F8D99C320 /* SwiftTestingSuite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftTestingSuite.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -134,6 +136,7 @@
 			isa = PBXGroup;
 			children = (
 				F3C1FC581FECE3C30028EC72 /* SampleAppUnitTests.swift */,
+				38E9439014F9402F8D99C320 /* SwiftTestingSuite.swift */,
 				F3C1FC5A1FECE3C30028EC72 /* Info.plist */,
 			);
 			path = SampleAppUnitTests;
@@ -296,6 +299,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				F3C1FC591FECE3C30028EC72 /* SampleAppUnitTests.swift in Sources */,
+				5B67974379BD4801BE959C18 /* SwiftTestingSuite.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -512,7 +516,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = XK98WVAH5W;
 				INFOPLIST_FILE = SampleAppUnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.tito.XCTestHTMLReportSampleAppUnitTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -529,7 +533,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = XK98WVAH5W;
 				INFOPLIST_FILE = SampleAppUnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.tito.XCTestHTMLReportSampleAppUnitTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/XCTestHTMLReportSampleApp/SampleAppUnitTests/SwiftTestingSuite.swift
+++ b/XCTestHTMLReportSampleApp/SampleAppUnitTests/SwiftTestingSuite.swift
@@ -1,0 +1,28 @@
+//
+//  SwiftTestingSuite.swift
+//  SampleAppUnitTests
+//
+//  Added to investigate XCTestHTMLReport's support for Swift Testing
+//  results (`import Testing`) as part of #393.
+//
+
+import Testing
+
+struct SwiftTestingSuite {
+    @Test func additionWorks() {
+        #expect(1 + 1 == 2)
+    }
+
+    @Test func intentionalFailure() {
+        #expect(false, "This Swift Testing test intentionally fails")
+    }
+
+    @Test("Tagged multiplication check", .tags(.sampleTag))
+    func taggedMultiplication() {
+        #expect(2 * 3 == 6)
+    }
+}
+
+extension Tag {
+    @Tag static var sampleTag: Tag
+}


### PR DESCRIPTION
## Summary

- Adds `SwiftTestingSuite.swift` to the sample app's `SampleAppUnitTests` target using `import Testing`: a passing `@Test`, a failing one (`#expect(false)`), and one carrying a `.tags()` trait plus a custom display name — so a real Swift Testing suite is exercised in the `.xcresult` fixtures `prepareTestResults.sh` generates for the whole test suite.
- Wiring the file into `SampleApp.xcodeproj` required bumping `SampleAppUnitTests`' `IPHONEOS_DEPLOYMENT_TARGET` from `12.0` to `13.0` — Swift Testing's macro expansion needs `Actor`/`#isolation`, both iOS 13+. The app and UI test targets are untouched.
- Extends `CoreTests.swift` with `testSwiftTestingResultsRendered`, a SwiftSoup structural test (following the existing patterns in that file) asserting the suite renders with correct pass/fail status and failure message.
- Updates `testResultStatusCount`'s fixed counts (13 → 16 total, failed ≥5 → ≥6) to account for the 3 new sample tests.

## Why

Per #393, roughly half the README's advertised features have no fixture exercising them — Swift Testing support was flagged as the highest-priority gap since `import Testing` appeared nowhere in the repo and the tool had never been run against a Swift Testing bundle.

Investigation (posted as a comment on #393) found Swift Testing support **works today** for the tool's core job: pass/fail status, per-suite/per-test counts, and failure messages all render correctly and consistently in HTML, JUnit, and JSON, and the tool exits 0 (not degraded). The one confirmed gap — `@Test` display names and `.tags()` traits never surface, because this tool reads bundles through `xcresulttool`'s legacy schema, which predates Swift Testing — is out of scope for this PR; fixing it is a larger design change that needs maintainer input.

## Test plan

- [x] `swift test` — 23 tests, 1 skipped, 0 failures (was 22/1/0; the new `testSwiftTestingResultsRendered` is the addition)
- [x] `swiftformat --lint` / `swiftlint lint` clean on changed files (two pre-existing warnings elsewhere in `CoreTests.swift` are unrelated to this change, confirmed via `git stash`)
- [x] `xcodebuild build-for-testing` / `xcodebuild test` against `MainScheme` on iPhone 17 Pro (iOS 26.2) to confirm the sample app target still builds and runs
- [x] Manually ran `./.build/debug/xchtmlreport` against a bundle containing `SwiftTestingSuite` and confirmed HTML/JUnit/JSON all show correct status, counts, and failure text (see #393 comment for full output)

Not merging — per the task, this is left open for maintainer review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)