### PR TITLE
Write attachment test reports to a temporary directory

### DIFF
--- a/Tests/XCTestHTMLReportTests/CliTests.swift
+++ b/Tests/XCTestHTMLReportTests/CliTests.swift
@@ -1,4 +1,6 @@
 import class Foundation.Bundle
+import class Foundation.FileManager
+import struct Foundation.UUID
 import SwiftSoup
 import XCTest
 
@@ -55,7 +57,15 @@ final class CliTests: XCTestCase {
 
     func assertAttachmentsExist(extraArgs: [String] = []) throws {
         let testResultsUrl = try XCTUnwrap(testResultsUrl)
-        let defaultArgs = ["-r", testResultsUrl.path]
+        let outputDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: outputDirectory,
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: outputDirectory) }
+
+        let defaultArgs = ["-r", testResultsUrl.path, "-o", outputDirectory.path]
         let document = try parseReportDocument(xchtmlreportArgs: defaultArgs + extraArgs)
         let reportDir = testResultsUrl.deletingLastPathComponent()
 

--- a/Tests/XCTestHTMLReportTests/CliTests.swift
+++ b/Tests/XCTestHTMLReportTests/CliTests.swift
@@ -1,5 +1,6 @@
 import class Foundation.Bundle
 import class Foundation.FileManager
+import struct Foundation.URL
 import struct Foundation.UUID
 import SwiftSoup
 import XCTest
@@ -25,9 +26,12 @@ final class CliTests: XCTestCase {
         guard let retryResultsUrl else {
             throw XCTSkip("RetryResults.xcresult not found, this likely means Xcode < 13.0")
         }
+        let outputDirectory = try makeTemporaryOutputDirectory()
 
         for attempt in 1 ... 5 {
-            let (status, _, maybeStdErr) = try xchtmlreportCmd(args: [retryResultsUrl.path])
+            let (status, _, maybeStdErr) = try xchtmlreportCmd(
+                args: [retryResultsUrl.path, "-o", outputDirectory.path]
+            )
             XCTAssertEqual(
                 status, 0,
                 "attempt \(attempt) exited \(status). stderr:\n\(maybeStdErr ?? "")"
@@ -57,13 +61,7 @@ final class CliTests: XCTestCase {
 
     func assertAttachmentsExist(extraArgs: [String] = []) throws {
         let testResultsUrl = try XCTUnwrap(testResultsUrl)
-        let outputDirectory = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString, isDirectory: true)
-        try FileManager.default.createDirectory(
-            at: outputDirectory,
-            withIntermediateDirectories: true
-        )
-        defer { try? FileManager.default.removeItem(at: outputDirectory) }
+        let outputDirectory = try makeTemporaryOutputDirectory()
 
         let defaultArgs = ["-r", testResultsUrl.path, "-o", outputDirectory.path]
         let document = try parseReportDocument(xchtmlreportArgs: defaultArgs + extraArgs)
@@ -103,8 +101,9 @@ final class CliTests: XCTestCase {
 
     func testLenientFlagIsAccepted() throws {
         let testResultsUrl = try XCTUnwrap(testResultsUrl)
+        let outputDirectory = try makeTemporaryOutputDirectory()
         let (status, maybeStdOut, _) = try xchtmlreportCmd(
-            args: ["--lenient", testResultsUrl.path]
+            args: ["--lenient", testResultsUrl.path, "-o", outputDirectory.path]
         )
 
         // --lenient never fails on faults, so a readable bundle always exits 0.
@@ -136,5 +135,18 @@ final class CliTests: XCTestCase {
         let (status, _, _) = try xchtmlreportCmd(args: ["--lenient", bogus])
 
         XCTAssertEqual(status, 0, "--lenient restores 2.x exit behaviour")
+    }
+
+    private func makeTemporaryOutputDirectory() throws -> URL {
+        let outputDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: outputDirectory,
+            withIntermediateDirectories: true
+        )
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: outputDirectory)
+        }
+        return outputDirectory
     }
 }


### PR DESCRIPTION
## Summary

- write attachment-test reports to a unique temporary directory
- remove the temporary output after each assertion completes
- keep generated `index.html` files out of the package test resources

## Root cause

The attachment tests passed `-r` without `-o`, so `xchtmlreport` used the `.xcresult` parent directory as its output directory. That left `Tests/XCTestHTMLReportTests/Resources/index.html` untracked after running `swift test`.

## Validation

- `swift test` — 23 tests passed, 1 existing Xcode 26 skip
- `swift test --filter CliTests` — 7 tests passed
- SwiftFormat lint — no formatting violations
- verified `swift test` leaves no `Resources/index.html`

Fixes #389


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved attachment-report test isolation by using unique temporary output directories.
  * Added automatic cleanup of temporary test files after execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->