### PR TITLE
Build the sample app once instead of three times

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ xcuserdata/
 Tests/XCTestHTMLReportTests/Resources/index.html
 Tests/XCTestHTMLReportTests/Resources/report.junit
 Tests/XCTestHTMLReportTests/Resources/report.json
+
+# Built once by prepareTestResults.sh so each test pass reuses it.
+.derived-data/

--- a/prepareTestResults.sh
+++ b/prepareTestResults.sh
@@ -53,13 +53,27 @@ fi
 echo "Using simulator: $DEVICE_NAME (iOS $OS_VERSION)"
 SIM_DESTINATION="platform=iOS Simulator,name=${DEVICE_NAME},OS=${OS_VERSION}"
 
-# Create TestResults.xcresult for functional tests
-FILENAME='TestResults.xcresult'
-rm -rf "$FILENAME"
-xcodebuild test \
+# Build the sample app once, then run each pass against that build.
+#
+# Each pass used to be `xcodebuild test`, which builds before it runs — so the
+# same target was compiled three times to produce three sets of results. Fixture
+# generation is ~85% of the CI test job (#412), and most of that was rebuilds.
+DERIVED_DATA="$(pwd)/.derived-data"
+rm -rf "$DERIVED_DATA"
+xcodebuild build-for-testing \
     -project SampleApp.xcodeproj \
     -scheme MainScheme \
     -destination "$SIM_DESTINATION" \
+    -derivedDataPath "$DERIVED_DATA"
+
+# Create TestResults.xcresult for functional tests
+FILENAME='TestResults.xcresult'
+rm -rf "$FILENAME"
+xcodebuild test-without-building \
+    -project SampleApp.xcodeproj \
+    -scheme MainScheme \
+    -destination "$SIM_DESTINATION" \
+    -derivedDataPath "$DERIVED_DATA" \
     -skip-testing:SampleAppUITests/RetryTests \
     -resultBundlePath "$FILENAME" || true
 
@@ -72,10 +86,11 @@ mv "$FILENAME" "../Tests/XCTestHTMLReportTests/Resources/"
 
 SANITY_FILENAME='SanityResults.xcresult'
 rm -rf "$SANITY_FILENAME"
-xcodebuild test \
+xcodebuild test-without-building \
     -project SampleApp.xcodeproj \
     -scheme MainScheme \
     -destination "$SIM_DESTINATION" \
+    -derivedDataPath "$DERIVED_DATA" \
     -only-testing:SampleAppUITests/FirstSuite/testOne \
     -resultBundlePath "$SANITY_FILENAME" || true
 
@@ -87,10 +102,11 @@ if [[ $XCODE_VERSION != 12.* && $XCODE_VERSION != 11.* ]]; then
     # "Mixed" test results must be run separately to use -retry-tests-on-failure
     RETRY_FILENAME='RetryResults.xcresult'
     rm -rf "$RETRY_FILENAME"
-    xcodebuild test \
+    xcodebuild test-without-building \
         -project SampleApp.xcodeproj \
         -scheme MainScheme \
         -destination "$SIM_DESTINATION" \
+    -derivedDataPath "$DERIVED_DATA" \
         -test-iterations 2 \
         -retry-tests-on-failure \
         -only-testing:SampleAppUITests/RetryTests \


### PR DESCRIPTION
Toward #412. The `test` job now takes **15m33s**, of which **790s (85%) is fixture generation**.

## The cost is per-invocation build overhead, not test execution

`prepareTestResults.sh` ran `xcodebuild test` three times, and that action builds before it runs — so the same target was compiled three times to produce three sets of results. CI timestamps from run `31372309618`:

| Invocation | What it runs | Duration |
| --- | --- | --- |
| TestResults | full suite minus `RetryTests` | 364s |
| Sanity | **one single test** | **196s** |
| Retry | 4 tests, 2 iterations | ~200s |

The middle one is the tell: `-only-testing:SampleAppUITests/FirstSuite/testOne` runs *one test* and still costs over three minutes. That is build-and-install overhead.

This builds once with `build-for-testing` into a shared `-derivedDataPath`, then runs each pass with `test-without-building`.

## Local timing is not offered as evidence

This machine's DerivedData is warm, so the old script pays almost no rebuild cost here — **85s for all three passes locally, versus 790s on CI**. Measured both ways; the new version is 92s locally, i.e. indistinguishable. The saving exists only on a cold runner, so CI has to be the judge. That is the point of this PR being measurable rather than argued.

## Verified locally for correctness, not speed

- all three fixtures produced
- `swift test` → 23 tests, 1 skipped, 0 failures
- `SanityResults.xcresult` still contains exactly **1 test, 1 passed**, so `-only-testing` is still honoured under `test-without-building` and `SanityTests`' assertions hold

## An unrelated finding, worth recording on #398

While checking whether this change altered fixture content, `SanityResults.xcresult` came out at **152K on one run and 51M on another** — a 340× swing. I re-ran the **old, unmodified** script and it also produced 51M, so this change is not the cause.

The difference is a ~30MB screen recording being attached or not. So the sample-suite flakiness (#398) does not merely move a test between pass and fail buckets — it changes whether large attachments exist in the fixture at all. Any future assertion about attachment presence would be flaky for the same reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved test execution by building the app once and reusing the build artifacts across functional, sanity, and retry test passes.
* **Test Infrastructure**
  * Preserved existing test filters and result bundles for each test pass.
  * Added support for reusing generated test data between runs.
* **Chores**
  * Excluded generated test data from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->