### PR TITLE
Stop launching the app in sample UI tests that never use it

### DIFF
--- a/XCTestHTMLReportSampleApp/SampleAppUITests/FirstSuite.swift
+++ b/XCTestHTMLReportSampleApp/SampleAppUITests/FirstSuite.swift
@@ -17,9 +17,6 @@ class FirstSuite: XCTestCase {
 
         // In UI tests it is usually best to stop immediately when a failure occurs.
         continueAfterFailure = false
-        // UI tests must launch the application that they test. Doing this in setup will make sure
-        // it happens for each test method.
-        XCUIApplication().launch()
 
         // In UI tests it’s important to set the initial state - such as interface orientation -
         // required for your tests before they run. The setUp method is a good place to do this.

--- a/XCTestHTMLReportSampleApp/SampleAppUITests/SecondSuite.swift
+++ b/XCTestHTMLReportSampleApp/SampleAppUITests/SecondSuite.swift
@@ -17,9 +17,6 @@ class SecondSuite: XCTestCase {
 
         // In UI tests it is usually best to stop immediately when a failure occurs.
         continueAfterFailure = false
-        // UI tests must launch the application that they test. Doing this in setup will make sure
-        // it happens for each test method.
-        XCUIApplication().launch()
 
         // In UI tests it’s important to set the initial state - such as interface orientation -
         // required for your tests before they run. The setUp method is a good place to do this.

--- a/XCTestHTMLReportSampleApp/SampleAppUITests/ThirdSuite.swift
+++ b/XCTestHTMLReportSampleApp/SampleAppUITests/ThirdSuite.swift
@@ -22,9 +22,6 @@ class ThirdSuite: XCTestCase {
 
         // In UI tests it is usually best to stop immediately when a failure occurs.
         continueAfterFailure = true
-        // UI tests must launch the application that they test. Doing this in setup will make sure
-        // it happens for each test method.
-        XCUIApplication().launch()
     }
 
     func testOne() {


### PR DESCRIPTION
Closes #398.

## The flake

`FirstSuite`, `SecondSuite` and `ThirdSuite` each called `XCUIApplication().launch()` in `setUp` with `continueAfterFailure = false`. When the simulator was slow the launch failed and took the test with it — `FirstSuite.testOne` is `XCTAssert(true)` plus an attachment and cannot fail on its own assertion, yet was observed failing (`53adfaf` passed under `Test` and failed under `Codecov`, same commit, same commands).

## No test uses the UI

There are no taps, no element queries, and no `XCUIApplication` use anywhere in the sample app beyond the launch itself. The launch existed to make these genuine UI tests, on the assumption that the **screen recording depended on it**.

## That assumption was wrong, and I tested it rather than reasoning about it

Removed the launch from `SecondSuite` **alone**, regenerated, and counted recordings in the fixture:

| | distinct screen recordings |
| --- | --- |
| before | 9 |
| after (SecondSuite only) | **9** |

Had `SecondSuite` lost its recordings the count would have dropped by two. Xcode captures the simulator screen for UI test targets regardless of whether the app runs.

So the launches were **pure flake risk with no fixture value**.

## Side effect: fixture generation is 41% faster locally

`85.7s → 50.4s`, because three suites no longer launch and terminate an app per test method.

Whether that carries to CI is for CI to measure — #412 records why local timing is not evidence for this repository, and the last attempt at that issue (#422) was closed after CI showed it *slower* despite a plausible local story. Same discipline applies here.

## One honest cost

`SanityResults.xcresult` shrinks from ~51M to ~140K, because a recording of an idle screen is much smaller than one of a launching app.

`TestResults.xcresult` still carries **9 recordings and 16 `.mp4` references**, so `.mp4` attachment coverage — the reason the launches were believed necessary — is intact. If a fixture is later needed that genuinely exercises a launching app, it should be one suite that does so deliberately, not every suite by default.

## Verified

- `swift test` → 23 tests, 1 skipped, 0 failures
- `TestResults` reports `All(16) Passed(9) Skipped(1) Failed(6)`, consistent with the suite after #417's Swift Testing fixture
- zero launch failures in the generation log
- SwiftFormat clean; the 4 `unneeded_override` SwiftLint warnings are pre-existing on `main` (empty `tearDown` overrides) and untouched here

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated UI test setup to prevent the application from launching automatically before every test.
  * Preserved failure-handling configuration during test initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->