### PR TITLE
Drop the unused SwiftFormat package dependency

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -20,15 +20,6 @@
         }
       },
       {
-        "package": "SwiftFormat",
-        "repositoryURL": "https://github.com/nicklockwood/SwiftFormat",
-        "state": {
-          "branch": null,
-          "revision": "2226e9d89bf05a604cc985bab3dccb44ff7c8ee3",
-          "version": "0.62.1"
-        }
-      },
-      {
         "package": "SwiftSoup",
         "repositoryURL": "https://github.com/scinfu/SwiftSoup.git",
         "state": {

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,6 @@ let package = Package(
         .package(url: "https://github.com/davidahouse/XCResultKit.git", from: "1.2.1"),
         .package(url: "https://github.com/scinfu/SwiftSoup.git", from: "2.4.3"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0"),
-        .package(url: "https://github.com/nicklockwood/SwiftFormat", from: "0.50.4"),
     ],
     targets: [
         .executableTarget(


### PR DESCRIPTION
Closes #381.

#381 asked for SwiftFormat to be enforced in CI. That half landed with #410 — the `swift` job runs `swiftformat --lint --reporter github-actions-log .` and is a required check. What was left behind is the reason the issue stayed open: `Package.swift` still declared SwiftFormat as a package dependency, and **no target ever consumed it**.

Every place the repo actually uses SwiftFormat invokes the Homebrew binary, not the SPM product:

- `.github/workflows/lint.yml:37,40`
- `.githooks/pre-commit:27-36`
- `CONTRIBUTING.md:59,72`

So the declaration bought nothing and cost a full resolve of SwiftFormat's dependency tree on every cold checkout. Measured with isolated `--cache-path`/`--scratch-path` so the local SPM cache didn't skew it:

| | cold resolve | cache |
| --- | --- | --- |
| with the unused dep | 171.3s | 506 MB |
| without | **10.1s** | **14 MB** |

## What I am not claiming

That CI gets 161s faster. GitHub's macOS runners have far better network than my laptop, and the branch run will show the real number — the `Run tests` step was 96s total on the last run, so the CI saving is bounded well below the local figure. #422 was closed for exactly this kind of extrapolation, so the number to trust is the one CI reports on this PR, not the one above.

The local measurement is still the right justification: the dependency is unused, and unused dependencies are removed regardless of how much they cost.

## Compatibility

`Package.resolved` loses only the SwiftFormat pin. Schema version stays `1`, so nothing changes for older toolchains. The `xchtmlreportcore` library product never exposed a SwiftFormat product, so no consumer can be relying on it transitively.

## Verified

- `swift build` — clean
- `swift test` — 23 tests, 1 skipped, 0 failures
- `swiftformat --lint .` — 0/44 files require formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the SwiftFormat package dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->