### PR TITLE
Publish releases with the runner's gh CLI instead of a third-party action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,6 +164,14 @@ jobs:
       #
       # An unmatched glob fails the step, where the action would have published
       # a release with no binary attached to it.
+      #
+      # Re-running this over a tag that already has a published release fails,
+      # rather than replacing its assets the way the action did. That is the
+      # behaviour we want: these binaries are signed and notarized, and quietly
+      # swapping the ones people have already downloaded is not something a
+      # re-run button should be able to do. Failed runs need no cleanup — with
+      # assets, gh creates the release as a draft, uploads, then publishes, and
+      # deletes the draft if any of that fails.
       run: |
         args=(--generate-notes --verify-tag)
         if [[ "$PRERELEASE" == "true" ]]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,14 +146,30 @@ jobs:
       uses: actions/download-artifact@v8
 
     - name: Release
-      uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
-      with:
-        prerelease: ${{ needs.build.outputs.prerelease == 'true' }}
-        generate_release_notes: true
-        files: |
-          application/xchtmlreport-*
+      # The GitHub CLI is preinstalled on the runner and does everything the
+      # third-party release action was doing here, so the one job that handles
+      # signed, notarized binaries and repository secrets no longer depends on
+      # a third party. Reported as superfluous by zizmor.
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # This job deliberately has no checkout, so gh cannot work out which
+        # repository it is talking to from a git remote.
+        GH_REPO: ${{ github.repository }}
+        # Through the environment rather than interpolated into the script.
+        TAG: ${{ github.ref_name }}
+        PRERELEASE: ${{ needs.build.outputs.prerelease }}
+      # --verify-tag because `gh release create` otherwise invents a tag from
+      # the default branch when the one it is given does not exist. The tag is
+      # what triggered this run, so that can only ever mean something is wrong.
+      #
+      # An unmatched glob fails the step, where the action would have published
+      # a release with no binary attached to it.
+      run: |
+        args=(--generate-notes --verify-tag)
+        if [[ "$PRERELEASE" == "true" ]]; then
+          args+=(--prerelease)
+        fi
+        gh release create "$TAG" "${args[@]}" application/xchtmlreport-*
 
   bump_version:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #414.

Removes `softprops/action-gh-release` from the release job and publishes with the runner's preinstalled `gh` CLI instead. That job holds the Developer ID signing identity, the notarization credentials and a `contents: write` token — it is the last place in the repository that should be reaching for a third-party action to do something the runner already does. `zizmor` reports it as `superfluous-actions`; CodeRabbit raised the same thing on #413.

## Matching what the action actually did

I checked each input against the action's source at the pinned SHA and against the two releases this pipeline has produced, rather than against the sketch in the issue.

| | before | after |
|---|---|---|
| tag | `tag_name` defaults to `github.ref` | `github.ref_name`, via `$TAG` |
| assets | `files: application/xchtmlreport-*` | same glob, expanded by the shell |
| notes | `generate_release_notes: true` | `--generate-notes` |
| title | not set; action fell back to the tag | not set; `--generate-notes` makes GitHub generate it, and the API returns the tag |
| prerelease | `needs.build.outputs.prerelease == 'true'` | `--prerelease` appended when `$PRERELEASE` is `true` |
| draft | default `false` | not passed |
| `make_latest` | not sent | not sent |

On the title: `gh` without `--notes-start-tag` sends `generate_release_notes: true` and no `name`, so GitHub generates both. I called the generate-notes API against this repo to confirm what it returns for a name — `3.0.0rc2` for a tag of that name, i.e. the tag itself, which is exactly what 3.0.0rc1 and 3.0.0 ended up with.

On the assets: the `application/` prefix is real, not incidental — `download-artifact` with no `name` creates a directory per artifact. The 3.0.0 run log shows `Starting download of artifact to: /home/runner/work/XCTestHTMLReport/XCTestHTMLReport/application`, and the glob resolves from the workspace.

## Two deliberate differences

Both make the step stricter than what it replaces:

- **`--verify-tag`.** Without it, `gh release create` will invent the tag off the default branch when the one it is handed does not exist. A tag push is what triggers this job, so a missing tag could only mean something has gone badly wrong; better to stop.
- **An unmatched glob now fails the step.** The action's `fail_on_unmatched_files` defaults to `false`, so a build that produced no archive would have published a release with no binary attached to it and reported success.

Also: `GH_REPO` is set because this job deliberately has no checkout, so `gh` has no git remote to infer the repository from. Everything reaches the script through the environment rather than being interpolated into it.

## What has and has not been exercised

**Not exercised: the release job has not run.** It is guarded on `github.event_name == 'push'`, so the `workflow_dispatch` dry run skips it entirely — a green run on this PR says nothing at all about this change. That is precisely why #413 deferred it. Do not read CI on this PR as verification.

What I did check, all of it short of running the job:

- `actionlint` on the workflow — clean apart from a pre-existing SC2129 on the dry-run summary step, which is untouched and present on `main` too.
- `shellcheck` on the `run` block in isolation — clean.
- `zizmor --persona=pedantic`, before and after: `superfluous-actions` drops from 2 findings to 1 (the remaining one is `create-pull-request` in `bump_version`, out of scope here). Every other finding count is unchanged — in particular no new `template-injection`, because nothing is interpolated into the script.
- The action's source at the pinned SHA, for the defaults in the table above.
- The 3.0.0 run log, for the artifact layout.

**The real verification is a `3.0.1rc1` tag**, cut immediately after this merges. `rc` tags are correctly treated as prereleases since #396, do not reach Homebrew, and skip `bump_version`, so this is the safe rehearsal — and it exercises the whole path for real: build, sign, notarize, publish. I will report the outcome here.

Until that tag has been cut and the release job has actually gone green, this is unverified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the release process for greater reliability.
  * Added validation to ensure releases are created for the correct tag.
  * Automatically generates release notes and identifies prereleases.
  * Uploads packaged binaries as release assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->