### PR TITLE
Give the image rendering path its first test coverage

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -9,6 +9,13 @@ included:
 
 excluded:
   - .build
+  # Xcode's build products for the sample app. #425 moved DerivedData inside
+  # the repo (gitignored) to keep local fixture generation incremental, but
+  # SwiftLint does not read .gitignore -- it walked in and reported errors from
+  # Xcode-generated sources such as GeneratedAssetSymbols.swift. CI never saw
+  # this because the lint job does not run prepareTestResults.sh, so the
+  # directory only exists on machines that generate fixtures.
+  - XCTestHTMLReportSampleApp/.derivedData
   # Generated (carries a DO NOT EDIT header) and almost entirely multiline
   # string literals holding the emitted HTML. Also excluded from SwiftFormat.
   - Sources/XCTestHTMLReportCore/Classes/HTMLTemplates.swift

--- a/Tests/XCTestHTMLReportTests/CliTests.swift
+++ b/Tests/XCTestHTMLReportTests/CliTests.swift
@@ -59,19 +59,35 @@ final class CliTests: XCTestCase {
         let document = try parseReportDocument(xchtmlreportArgs: defaultArgs + extraArgs)
         let reportDir = testResultsUrl.deletingLastPathComponent()
 
-        // Remove this logic for now since Xcode 15 attaches videos by default.
-        // We'll want to create a separate test result specifically with screenshots enabled
-//        try XCTContext.runActivity(named: "Image attachments exist") { _ in
-//            let imgTags = try document.select("img.screenshot, img.screenshot-flow")
-//            XCTAssertFalse(imgTags.isEmpty())
-//
-//            try imgTags.forEach { img in
-//                let src = try img.attr("src")
-//                XCTAssertTrue(src.starts(with: "TestResults.xcresult/"))
-//                let attachmentUrl = try XCTUnwrap(URL(string: src, relativeTo: reportDir))
-//                XCTAssertNoThrow(try attachmentUrl.checkResourceIsReachable())
-//            }
-//        }
+        // Restored by #393. This was commented out when Xcode 15 began attaching
+        // videos by default, which left every image path in the tool -- the
+        // `screenshot` CSS class, screenshot.html, and the `-z` downsizing
+        // branch -- with no coverage at all. `FirstSuite.testAttachScreenshot`
+        // now attaches a real `public.png`, so these assertions have something
+        // to bite on. If this stops finding images, the fixture lost its
+        // screenshot; do not comment it out again.
+        try XCTContext.runActivity(named: "Image attachments exist") { _ in
+            let imgTags = try document
+                .select("img.screenshot, img.screenshot-flow, img.screenshot-tail")
+            XCTAssertFalse(
+                imgTags.isEmpty(),
+                "No image attachments rendered. Expected at least the screenshot "
+                    + "attached by FirstSuite.testAttachScreenshot."
+            )
+
+            try imgTags.forEach { img in
+                let src = try img.attr("src")
+                XCTAssertTrue(
+                    src.starts(with: "TestResults.xcresult/"),
+                    "Unexpected image src: \(src)"
+                )
+                let attachmentUrl = try XCTUnwrap(URL(string: src, relativeTo: reportDir))
+                XCTAssertNoThrow(
+                    try attachmentUrl.checkResourceIsReachable(),
+                    "Image referenced but not exported: \(src)"
+                )
+            }
+        }
 
         try XCTContext.runActivity(named: "Other attachments exist", block: { _ in
             let spanTags = try document.select("span.icon.preview-icon")

--- a/Tests/XCTestHTMLReportTests/CoreTests.swift
+++ b/Tests/XCTestHTMLReportTests/CoreTests.swift
@@ -68,16 +68,21 @@ final class CoreTests: XCTestCase {
             let failed = try XCTUnwrap(texts[3].intGroupMatch("Failed \\((\\d+)\\)"))
             let mixed = try XCTUnwrap(texts[4].intGroupMatch("Mixed \\((\\d+)\\)"))
 
-            // Fixtures are regenerated on every run, so the pass/fail split is
-            // not fixed: the sample UI tests launch the app in setUp with
-            // continueAfterFailure = false, and a slow simulator turns a
-            // would-be pass into a failure. Asserting an exact split therefore
-            // measures simulator reliability rather than this project's
-            // behaviour. Assert only what the source actually determines.
+            // Fixtures are regenerated on every run, so assert only what the
+            // sample sources actually determine, not the pass/fail split.
             //
-            // 16 = 13 XCTest methods + 3 Swift Testing `@Test` functions in
-            // SwiftTestingSuite (SampleAppUnitTests target).
-            XCTAssertEqual(all, 16, "One row per test method; fixed by the sample sources")
+            // The original reason for that caution -- the suites launched the
+            // app in setUp with continueAfterFailure = false, so a slow
+            // simulator turned a would-be pass into a failure -- no longer
+            // applies: #423 removed those launches. The caution stands anyway,
+            // because a run still depends on the simulator behaving, and an
+            // exact split would measure that rather than this project.
+            //
+            // 17 = 14 XCTest methods + 3 Swift Testing `@Test` functions in
+            // SwiftTestingSuite (SampleAppUnitTests target). The 14th is
+            // FirstSuite.testAttachScreenshot, added by #393 to give the image
+            // rendering path a fixture.
+            XCTAssertEqual(all, 17, "One row per test method; fixed by the sample sources")
             XCTAssertEqual(
                 skipped,
                 1,

--- a/XCTestHTMLReportSampleApp/SampleAppUITests/FirstSuite.swift
+++ b/XCTestHTMLReportSampleApp/SampleAppUITests/FirstSuite.swift
@@ -45,6 +45,26 @@ class FirstSuite: XCTestCase {
         add(html)
     }
 
+    /// Produces the report's only image attachment.
+    ///
+    /// Since Xcode 15 the suites capture screen recordings rather than
+    /// screenshots, so every image path in the tool -- the `screenshot` CSS
+    /// class, the `screenshot.html` template, the image-preview machinery, and
+    /// the `-z` downsizing branch -- had no fixture exercising it at all. See
+    /// #393.
+    ///
+    /// `XCUIScreen.main.screenshot()` captures the simulator screen and does
+    /// NOT require the app to be running. Do not add `XCUIApplication().launch()`
+    /// to make this "more realistic": #423 removed the launches from these
+    /// suites because they were pure flake risk with no fixture value, and a
+    /// screenshot of the idle screen exercises the same `public.png` path.
+    func testAttachScreenshot() {
+        let screenshot = XCTAttachment(screenshot: XCUIScreen.main.screenshot())
+        screenshot.name = "Screenshot"
+        screenshot.lifetime = .keepAlways
+        add(screenshot)
+    }
+
     func testOne() {
         XCTContext.runActivity(named: "Text Attachment") { activity in
             let logs = """


### PR DESCRIPTION
Closes #393. Unblocks #357.

## The hole

Generating a report from the project's own fixture on `main` (`822129f`):

| | count |
| --- | --- |
| `.mp4` references | 16 |
| `.png` / `.jpeg` references | 0 |
| rendered `img class="screenshot"` | 0 |

The `screenshot` CSS class, `HTML/screenshot.html`, the image-preview machinery and the `-z` downsizing branch were exercised by **no test**. That path could have been completely broken and `swift test` would still have passed. It also meant #357 — screenshots missing from reports, open since June 2024 — could not be investigated at all.

The cause is benign: since Xcode 15 the sample suites capture screen recordings rather than screenshots, so the image assertion in `CliTests.swift` was commented out with a note that a separate fixture was needed. That fixture never arrived.

## The fixture

`FirstSuite.testAttachScreenshot` attaches `XCUIScreen.main.screenshot()` with `.keepAlways`, producing a real `public.png` payload — which `Attachment.swift` maps to `isImage` → `cssClass "screenshot"`, the same path a user's screenshots take.

It deliberately **does not launch the app**. `XCUIScreen` captures the simulator screen without one, and #423 removed the launches from these suites as pure flake risk. The test carries a comment saying so, because "make it more realistic by launching the app" is exactly the plausible-looking change that would reintroduce the flake.

After: **1 `img class="screenshot"`, 8 `.png` references, `.mp4` still 16** — nothing regressed.

## The assertion, and proof it bites

The commented-out block is restored, widened to include `img.screenshot-tail` (the original selector missed it), with failure messages that say what is wrong.

I did not assume it works. Removing the screenshot test and regenerating makes it **fail on both variants**:

```
CliTests.swift:72: error: -[CliTests testDownsizedAttachmentsExist] :
  XCTAssertFalse failed - No image attachments rendered.
  Expected at least the screenshot attached by FirstSuite.testAttachScreenshot.
```

Restoring returns the suite to 23 tests / 1 skipped / 0 failures. This repository has produced enough tests that passed for the wrong reason that "it's green" is not evidence on its own.

**Bonus coverage:** `testDownsizedAttachmentsExist` runs with `-z`, and with no images in the fixture that flag previously had nothing to downsize. It now exercises the resize path for the first time — the same code implicated in #337.

## Two things found along the way

- **`CoreTests` expected 16 rows**, now 17 (14 XCTest + 3 Swift Testing). Its comment justified not asserting the pass/fail split because "the sample UI tests launch the app in setUp" — false since #423. Rewritten to state what is actually true, keeping the conservative assertion for the reason that still holds.
- **SwiftLint was erroring on `XCTestHTMLReportSampleApp/.derivedData`.** #425 (mine) moved DerivedData inside the repo for incremental local builds; SwiftLint does not read `.gitignore` and walked into Xcode-generated sources. CI never saw it because the lint job does not generate fixtures — it only bit people who run `prepareTestResults.sh` locally. Now excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)