### PR TITLE
Fix the run destination OS name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,10 @@
 TestResults*
 RetryResults*
 SanityResults*
+MacOSResults*
 .DS_Store
 /.build
+/XCTestHTMLReportSampleApp/MacOSResultFixture/.build
 /XCTestHTMLReportSampleApp/Build
 /XCTestHTMLReportSampleApp/.derivedData
 /Packages

--- a/Package.swift
+++ b/Package.swift
@@ -38,6 +38,7 @@ let package = Package(
                 .process("Resources/TestResults.xcresult"),
                 .process("Resources/RetryResults.xcresult"),
                 .process("Resources/SanityResults.xcresult"),
+                .process("Resources/MacOSResults.xcresult"),
             ]
         ),
     ]

--- a/Sources/XCTestHTMLReportCore/Classes/HTMLTemplates.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/HTMLTemplates.swift
@@ -1064,7 +1064,7 @@ struct HTMLTemplates
   static let device = """
     <ul class=\"device-info\" onclick=\"selectDevice('[[DEVICE_IDENTIFIER]]', this);\">
     <li>[[DEVICE_RESULT]]<h3 class=\"device-name\">[[DEVICE_NAME]]</h3></li>
-    <li class=\"device-os\">iOS [[DEVICE_OS]]</li>
+    <li class=\"device-os\">[[DEVICE_OS_NAME]] [[DEVICE_OS]]</li>
     <li class=\"device-model\">Model: [[DEVICE_MODEL]]</li>
     <li class=\"device-identifier\">Identifier: [[DEVICE_IDENTIFIER]]</li>
   </ul>

--- a/Sources/XCTestHTMLReportCore/Classes/Models/RunDestination.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Models/RunDestination.swift
@@ -38,14 +38,31 @@ private extension Status {
     }
 }
 
+private extension ActionSDKRecord {
+    var operatingSystemName: String {
+        let simulatorPrefix = "Simulator - "
+        let platformAndVersion = name.hasPrefix(simulatorPrefix)
+            ? String(name.dropFirst(simulatorPrefix.count))
+            : name
+        let versionSuffix = " \(operatingSystemVersion)"
+
+        guard platformAndVersion.hasSuffix(versionSuffix) else {
+            return platformAndVersion
+        }
+        return String(platformAndVersion.dropLast(versionSuffix.count))
+    }
+}
+
 struct RunDestination: HTML {
     let name: String
+    let operatingSystemName: String
     let targetDevice: TargetDevice
     let status: Status
 
     init(record: ActionRunDestinationRecord) {
         Logger.substep("Parsing ActionRunDestinationRecord")
         name = record.displayName
+        operatingSystemName = record.targetSDKRecord.operatingSystemName
         targetDevice = TargetDevice(record: record.targetDeviceRecord)
         status = .unknown // TODO: (Pierre Felgines) 04/10/2019 Find the correct value
     }
@@ -60,6 +77,7 @@ struct RunDestination: HTML {
             "DEVICE_NAME": name,
             "DEVICE_IDENTIFIER": targetDevice.uniqueIdentifier,
             "DEVICE_MODEL": targetDevice.model,
+            "DEVICE_OS_NAME": operatingSystemName,
             "DEVICE_OS": targetDevice.osVersion,
         ]
     }

--- a/Sources/XCTestHTMLReportCore/HTML/device.html
+++ b/Sources/XCTestHTMLReportCore/HTML/device.html
@@ -1,6 +1,6 @@
   <ul class="device-info" onclick="selectDevice('[[DEVICE_IDENTIFIER]]', this);">
     <li>[[DEVICE_RESULT]]<h3 class="device-name">[[DEVICE_NAME]]</h3></li>
-    <li class="device-os">iOS [[DEVICE_OS]]</li>
+    <li class="device-os">[[DEVICE_OS_NAME]] [[DEVICE_OS]]</li>
     <li class="device-model">Model: [[DEVICE_MODEL]]</li>
     <li class="device-identifier">Identifier: [[DEVICE_IDENTIFIER]]</li>
   </ul>

--- a/Tests/XCTestHTMLReportTests/CoreTests.swift
+++ b/Tests/XCTestHTMLReportTests/CoreTests.swift
@@ -16,6 +16,38 @@ final class CoreTests: XCTestCase {
             .url(forResource: "TestResults", withExtension: "xcresult")
     }
 
+    var macOSResultsUrl: URL? {
+        Bundle.testBundle
+            .url(forResource: "MacOSResults", withExtension: "xcresult")
+    }
+
+    func testRunDestinationUsesPlatformNameFromSDK() throws {
+        let fixtures = try [
+            (XCTUnwrap(testResultsUrl), "iOS"),
+            (XCTUnwrap(macOSResultsUrl), "macOS"),
+        ]
+
+        for (resultsUrl, platform) in fixtures {
+            let summary = Summary(
+                resultPaths: [resultsUrl.path],
+                renderingMode: .linking,
+                downsizeImagesEnabled: false,
+                downsizeScaleFactor: 0.5
+            )
+
+            let document = try SwiftSoup.parse(summary.html)
+            let deviceOS = try XCTUnwrap(document.select("li.device-os").first()).text()
+
+            XCTAssertNotNil(
+                deviceOS.range(
+                    of: #"^\#(platform) \d+(?:\.\d+)+$"#,
+                    options: .regularExpression
+                ),
+                "Expected the platform name and version from \(resultsUrl.lastPathComponent), got '\(deviceOS)'"
+            )
+        }
+    }
+
     func testMixedStatusFromTestRetries() throws {
         let retryResultsUrl = try getRetryResultsUrl()
 

--- a/XCTestHTMLReportSampleApp/MacOSResultFixture/Package.swift
+++ b/XCTestHTMLReportSampleApp/MacOSResultFixture/Package.swift
@@ -1,0 +1,13 @@
+// swift-tools-version:5.5
+
+import PackageDescription
+
+let package = Package(
+    name: "Fixture",
+    platforms: [.macOS(.v10_15)],
+    products: [.library(name: "Fixture", targets: ["Fixture"])],
+    targets: [
+        .target(name: "Fixture"),
+        .testTarget(name: "FixtureTests", dependencies: ["Fixture"]),
+    ]
+)

--- a/XCTestHTMLReportSampleApp/MacOSResultFixture/Sources/Fixture/Fixture.swift
+++ b/XCTestHTMLReportSampleApp/MacOSResultFixture/Sources/Fixture/Fixture.swift
@@ -1,0 +1,3 @@
+public func fixtureValue() -> Int {
+    42
+}

--- a/XCTestHTMLReportSampleApp/MacOSResultFixture/Tests/FixtureTests/FixtureTests.swift
+++ b/XCTestHTMLReportSampleApp/MacOSResultFixture/Tests/FixtureTests/FixtureTests.swift
@@ -1,0 +1,8 @@
+@testable import Fixture
+import XCTest
+
+final class FixtureTests: XCTestCase {
+    func testFixtureValue() {
+        XCTAssertEqual(fixtureValue(), 42)
+    }
+}

--- a/prepareTestResults.sh
+++ b/prepareTestResults.sh
@@ -128,4 +128,21 @@ if [[ $XCODE_VERSION != 12.* && $XCODE_VERSION != 11.* ]]; then
     mv "$RETRY_FILENAME" "../Tests/XCTestHTMLReportTests/Resources/"
 fi
 
+# Create a real macOS run destination fixture. The report used to hardcode
+# every destination as iOS, which an iPhone-only fixture suite could not catch.
+MACOS_FILENAME='MacOSResults.xcresult'
+rm -rf "$MACOS_FILENAME"
+SAMPLE_APP_DIR="$PWD"
+(
+    cd MacOSResultFixture
+    xcodebuild test \
+        -scheme Fixture \
+        -destination 'platform=macOS' \
+        -resultBundlePath "$SAMPLE_APP_DIR/$MACOS_FILENAME"
+)
+
+echo "${MACOS_FILENAME} should identify the run destination as macOS"
+rm -rf "../Tests/XCTestHTMLReportTests/Resources/${MACOS_FILENAME}"
+mv "$MACOS_FILENAME" "../Tests/XCTestHTMLReportTests/Resources/"
+
 echo "$(tput setaf 2)$(basename "$0") successfully finished$(tput sgr 0)"


### PR DESCRIPTION
## Summary

- derive the destination platform name from `ActionSDKRecord.name` instead of hardcoding iOS
- strip the simulator prefix and SDK version before rendering it beside the actual device OS version
- generate a real macOS `.xcresult` alongside the existing iOS fixtures and assert both rendered platform names

## Validation

- [hosted macOS/Xcode validation](https://github.com/floze-the-genius/XCTestHTMLReport/actions/runs/31463584014): real iOS and macOS fixture generation, then 24 tests with 1 expected skip and 0 failures
- the same hosted run passes SwiftFormat, SwiftLint, and ShellCheck
- local `swift build --target XCTestHTMLReportCore` passes
- exported macOS metadata confirms `targetSDKRecord.name = macOS 15.5` and `operatingSystemVersion = 15.5`

My local machine only has Command Line Tools, so the full Xcode-only fixture and test pipeline was run on the linked hosted macOS runner before opening this PR.

Fixes #364

AI assistance: Codex helped with implementation and validation; I reviewed the diff and verified every result reported above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Reports now identify the device operating system dynamically, including macOS and iOS.
  - Device details display the correct platform name alongside the operating-system version.

- **Bug Fixes**
  - Corrected device labels that previously displayed “iOS” for non-iOS test results.
  - Improved handling of simulator and platform names in generated HTML reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->