### PR TITLE
fix: derive report identifiers from bundle content so runs are reproducible

### DIFF
--- a/Sources/XCTestHTMLReportCore/Classes/Helpers/IdentifierPath.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Helpers/IdentifierPath.swift
@@ -1,0 +1,68 @@
+//
+//  IdentifierPath.swift
+//  XCTestHTMLReport
+//
+//  Created for #411: reports must be reproducible.
+//
+
+import CryptoKit
+import Foundation
+
+/// A location in the report tree, used to mint the element identifiers that
+/// end up in HTML `id` attributes and in the JavaScript handles the report
+/// navigates itself with (`selectDevice('…')`, `toggle(this, '…')`).
+///
+/// These identifiers used to be `UUID()`, which made the same bundle render
+/// differently on every run. They are now a digest of the path to the element,
+/// so the same bundle always renders the same bytes.
+///
+/// ## Why a digest and not the path itself
+///
+/// The path is built from bundle content — target names, suite and test
+/// identifiers — and those are free-form: Swift test names can contain quotes,
+/// angle brackets, spaces and non-ASCII. The templates interpolate identifiers
+/// into an unquoted-by-them `id` attribute *and* into a single-quoted
+/// JavaScript string, neither of which is escaped, so the raw path cannot be
+/// used. A hex digest is safe in both.
+///
+/// ## Why the identifiers are unique within a report
+///
+/// Uniqueness comes from the path, not from the digest being collision-free.
+/// Each node appends a component that distinguishes it from its siblings:
+///
+/// - runs: the index of the bundle and of the action within it
+/// - devices: one per run, under that run's path
+/// - target summaries and suites: their index among their siblings
+/// - test cases: their test identifier, which is unique among a suite's cases
+///   because `TestGroup` dedupes them into a `Set` keyed on exactly that
+/// - iterations: their index within the owning test case, assigned after any
+///   merging and sorting has happened
+///
+/// Distinct sibling components therefore give distinct paths, and no
+/// name-based collision is possible — the same test name under two suites,
+/// two targets or two devices sits at two different paths. Components are
+/// length-prefixed when joined so that a component containing the separator
+/// (test identifiers such as `MySuite/testFoo()` do) cannot forge a different
+/// node's path.
+struct IdentifierPath {
+    private let path: String
+
+    static let root = IdentifierPath(path: "")
+
+    func appending(_ component: String) -> IdentifierPath {
+        // Length-prefixed, so the mapping from component list to string is
+        // injective: "ab" + "c" and "a" + "bc" cannot both become "/ab/c".
+        IdentifierPath(path: "\(path)\(component.utf8.count):\(component)/")
+    }
+
+    /// The first 128 bits of the path's SHA-256, hex encoded.
+    ///
+    /// Matches `[0-9a-f]{32}`: no quotes, angle brackets, or anything else that
+    /// would need escaping in an HTML attribute or a JavaScript string literal.
+    var identifier: String {
+        SHA256.hash(data: Data(path.utf8))
+            .prefix(16)
+            .map { String(format: "%02x", $0) }
+            .joined()
+    }
+}

--- a/Sources/XCTestHTMLReportCore/Classes/Models/Iteration.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Models/Iteration.swift
@@ -9,7 +9,15 @@ import Foundation
 import XCResultKit
 
 struct Iteration: Test {
-    let uuid = UUID().uuidString
+    /// Assigned by the owning `TestCase`, which is the only place that knows
+    /// this iteration's final position — see `TestCase.assignIterationIdentifiers()`.
+    var uuid: String = ""
+
+    /// Position of the metadata this was built from within its suite. Only
+    /// used to break ties when ordering iterations: they are built
+    /// concurrently, and repetition numbers can repeat or be absent.
+    let sourceIndex: Int
+
     let title: String
     let identifier: String
     let objectClass: ObjectClass = .testSummary // TODO: Modify html template
@@ -24,11 +32,13 @@ struct Iteration: Test {
 
     init(
         metadata: ActionTestMetadata,
+        sourceIndex: Int,
         resultFile: ResultFile,
         renderingMode: Summary.RenderingMode,
         downsizeImagesEnabled: Bool,
         downsizeScaleFactor: CGFloat
     ) {
+        self.sourceIndex = sourceIndex
         title = metadata.name ?? ""
         identifier = metadata.identifier ?? ""
         status = Status(rawValue: metadata.testStatus) ?? .unknown

--- a/Sources/XCTestHTMLReportCore/Classes/Models/Run.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Models/Run.swift
@@ -58,13 +58,17 @@ struct Run: HTML {
 
     init?(
         action: ActionRecord,
+        identifierPath: IdentifierPath,
         file: ResultFile,
         renderingMode: Summary.RenderingMode,
         downsizeImagesEnabled: Bool,
         downsizeScaleFactor: CGFloat
     ) {
         self.file = file
-        runDestination = RunDestination(record: action.runDestination)
+        runDestination = RunDestination(
+            record: action.runDestination,
+            identifierPath: identifierPath
+        )
 
         guard
             let testReference = action.actionResult.testsRef,
@@ -92,21 +96,25 @@ struct Run: HTML {
 
         let queue = DispatchQueue(label: "com.xchtmlreport.lock")
 
-        var summaries = [TestSummary]()
+        // Keyed by source position: these are built concurrently, so the order
+        // they land in is whatever order the operations happened to finish in.
+        var summaries = [Int: TestSummary]()
 
         testPlanSummaries.summaries
             .flatMap(\.testableSummaries)
-            .forEach { testableSummary in
+            .enumerated()
+            .forEach { index, testableSummary in
                 let operation = BlockOperation {
                     let summary = TestSummary(
                         summary: testableSummary,
+                        identifierPath: identifierPath.appending("target\(index)"),
                         file: file,
                         renderingMode: renderingMode,
                         downsizeImagesEnabled: downsizeImagesEnabled,
                         downsizeScaleFactor: downsizeScaleFactor
                     )
                     queue.sync {
-                        summaries.append(summary)
+                        summaries[index] = summary
                     }
                 }
                 operationQueue.addOperation(operation)
@@ -114,7 +122,13 @@ struct Run: HTML {
 
         operationQueue.waitUntilAllOperationsAreFinished()
 
-        testSummaries = summaries.sorted { $0.testName < $1.testName }
+        // Sorting on `testName` alone is not a total order — a test plan with
+        // several configurations yields several summaries for one target — and
+        // `sorted(by:)` is not stable, so ties would resolve differently from
+        // run to run. Break them on source position.
+        testSummaries = summaries
+            .sorted { ($0.value.testName, $0.key) < ($1.value.testName, $1.key) }
+            .map(\.value)
     }
 
     private var logSource: String? {

--- a/Sources/XCTestHTMLReportCore/Classes/Models/RunDestination.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Models/RunDestination.swift
@@ -43,10 +43,13 @@ struct RunDestination: HTML {
     let targetDevice: TargetDevice
     let status: Status
 
-    init(record: ActionRunDestinationRecord) {
+    init(record: ActionRunDestinationRecord, identifierPath: IdentifierPath) {
         Logger.substep("Parsing ActionRunDestinationRecord")
         name = record.displayName
-        targetDevice = TargetDevice(record: record.targetDeviceRecord)
+        targetDevice = TargetDevice(
+            record: record.targetDeviceRecord,
+            identifierPath: identifierPath.appending("device")
+        )
         status = .unknown // TODO: (Pierre Felgines) 04/10/2019 Find the correct value
     }
 

--- a/Sources/XCTestHTMLReportCore/Classes/Models/Summary.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Models/Summary.swift
@@ -35,7 +35,7 @@ public struct Summary {
         var resultFiles: [ResultFile] = []
         self.faultCollector = faultCollector
 
-        for resultPath in resultPaths {
+        for (resultIndex, resultPath) in resultPaths.enumerated() {
             Logger.step("Parsing \(resultPath)")
             let url = URL(fileURLWithPath: resultPath)
             let resultFile = ResultFile(url: url, faultCollector: faultCollector)
@@ -47,15 +47,23 @@ public struct Summary {
                 // bundle when multiple were passed.
                 continue
             }
-            let resultRuns = invocationRecord.actions.compactMap {
-                Run(
-                    action: $0,
-                    file: resultFile,
-                    renderingMode: renderingMode,
-                    downsizeImagesEnabled: downsizeImagesEnabled,
-                    downsizeScaleFactor: downsizeScaleFactor
-                )
-            }
+            // Identifiers are derived from the bundle's position in the
+            // argument list rather than from its path, so moving a bundle
+            // between directories still renders the same report. See
+            // `IdentifierPath`.
+            let resultRuns = invocationRecord.actions.enumerated()
+                .compactMap { actionIndex, action in
+                    Run(
+                        action: action,
+                        identifierPath: IdentifierPath.root
+                            .appending("bundle\(resultIndex)")
+                            .appending("action\(actionIndex)"),
+                        file: resultFile,
+                        renderingMode: renderingMode,
+                        downsizeImagesEnabled: downsizeImagesEnabled,
+                        downsizeScaleFactor: downsizeScaleFactor
+                    )
+                }
             runs.append(contentsOf: resultRuns)
         }
         self.runs = runs

--- a/Sources/XCTestHTMLReportCore/Classes/Models/TargetDevice.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Models/TargetDevice.swift
@@ -11,14 +11,25 @@ import XCResultKit
 
 struct TargetDevice {
     let identifier: String
+
+    /// Addresses this device's run in the rendered page: the run element is
+    /// `id="device_<uniqueIdentifier>"` and the device selector calls
+    /// `selectDevice('<uniqueIdentifier>')`.
+    ///
+    /// Not `record.identifier` on its own. One report can hold several runs
+    /// against the same physical device — merged bundles, or a bundle passed
+    /// twice — and they would then share an element id, which fails silently:
+    /// `querySelectorAll('#device_…')[0]` picks the first match, so selecting
+    /// the second device would activate the first one's results.
     let uniqueIdentifier: String
+
     let osVersion: String
     let model: String
 
-    init(record: ActionDeviceRecord) {
+    init(record: ActionDeviceRecord, identifierPath: IdentifierPath) {
         Logger.substep("Parsing ActionDeviceRecord")
         identifier = record.identifier
-        uniqueIdentifier = UUID().uuidString
+        uniqueIdentifier = identifierPath.appending(record.identifier).identifier
         osVersion = record.operatingSystemVersion
         model = record.modelName
     }

--- a/Sources/XCTestHTMLReportCore/Classes/Models/Test.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Models/Test.swift
@@ -55,7 +55,7 @@ enum ObjectClass: String {
 
 /// A grouping of test cases, typically representing a single XCTestCase class or test suite
 public struct TestGroup: Test {
-    let uuid = UUID().uuidString
+    let uuid: String
     let title: String
     let identifier: String
     let objectClass: ObjectClass = .testSummaryGroup
@@ -89,6 +89,7 @@ public struct TestGroup: Test {
 
     init(
         group: ActionTestSummaryGroup,
+        identifierPath: IdentifierPath,
         resultFile: ResultFile,
         renderingMode: Summary.RenderingMode,
         downsizeImagesEnabled: Bool,
@@ -97,6 +98,7 @@ public struct TestGroup: Test {
         title = group.name ?? "---group-name-not-found---"
         identifier = group.identifier ?? "---group-identifier-not-found---"
         duration = group.duration
+        uuid = identifierPath.appending(identifier).identifier
 
         Logger.substep("Initializing TestGroup \(identifier)")
 
@@ -106,42 +108,44 @@ public struct TestGroup: Test {
             let queue = DispatchQueue(label: "com.xchtmlreport.subtest.lock")
             var subTestSet: Set<TestCase> = []
 
-            for metadata in group.subtests {
+            for (sourceIndex, metadata) in group.subtests.enumerated() {
                 let operation = BlockOperation {
                     let newTest = TestCase(
                         metadata: metadata,
+                        sourceIndex: sourceIndex,
+                        identifierPath: identifierPath,
                         resultFile: resultFile,
                         renderingMode: renderingMode,
                         downsizeImagesEnabled: downsizeImagesEnabled,
                         downsizeScaleFactor: downsizeScaleFactor
                     )
                     queue.sync {
-                        if let index = subTestSet.firstIndex(of: newTest) {
-                            var existingTest = subTestSet[index]
-                            existingTest.iterations.append(contentsOf: newTest.iterations)
-                            existingTest.iterations
-                                .sort(by: {
-                                    $0.repetitionPolicy?.iteration ?? 0 < $1.repetitionPolicy?
-                                        .iteration ?? 0
-                                })
-                            subTestSet.update(with: existingTest)
-                        } else {
+                        guard let index = subTestSet.firstIndex(of: newTest) else {
                             subTestSet.insert(newTest)
+                            return
                         }
+                        var existingTest = subTestSet[index]
+                        existingTest.merge(newTest)
+                        subTestSet.update(with: existingTest)
                     }
                 }
                 operationQueue.addOperation(operation)
             }
 
             operationQueue.waitUntilAllOperationsAreFinished()
-            var subTestList = Array(subTestSet)
-            subTestList.sort(by: { $0.title < $1.title })
-            subTests.append(contentsOf: subTestList)
+
+            // `Set` iteration order is seeded per process, so this sort has to
+            // be a total order or the rendered order changes between runs. Test
+            // identifiers are unique here — they are the set's own dedupe key —
+            // which makes them a sufficient tiebreaker for equal titles.
+            subTests += subTestSet
+                .sorted(by: { ($0.title, $0.identifier) < ($1.title, $1.identifier) })
         }
 
         if !group.subtestGroups.isEmpty {
-            subTests += group.subtestGroups.map { TestGroup(
-                group: $0,
+            subTests += group.subtestGroups.enumerated().map { index, subGroup in TestGroup(
+                group: subGroup,
+                identifierPath: identifierPath.appending("group\(index)"),
                 resultFile: resultFile,
                 renderingMode: renderingMode,
                 downsizeImagesEnabled: downsizeImagesEnabled,
@@ -181,9 +185,15 @@ extension TestGroup: ContainingAttachment {
 /// Contains one or more `Iteration`s as defined by the RepetitionPolicy. When only one iteration is
 /// present, the activities will be bubbled up to `TestCase`.
 struct TestCase: Test {
-    let uuid = UUID().uuidString
+    let uuid: String
     let title: String
     let identifier: String
+
+    /// Where this test case sits in the report, kept so that iteration
+    /// identifiers can be reassigned once iterations from a repeated run have
+    /// been merged in and re-sorted.
+    private let identifierPath: IdentifierPath
+
     var objectClass: ObjectClass = .testSummary
     var duration: TimeInterval {
         iterations.reduce(0) { $0 + $1.duration }
@@ -223,6 +233,8 @@ struct TestCase: Test {
 
     init(
         metadata: ActionTestMetadata,
+        sourceIndex: Int,
+        identifierPath: IdentifierPath,
         resultFile: ResultFile,
         renderingMode: Summary.RenderingMode,
         downsizeImagesEnabled: Bool,
@@ -230,16 +242,52 @@ struct TestCase: Test {
     ) {
         title = metadata.name ?? ""
         identifier = metadata.identifier ?? ""
+        // Keyed on the test identifier rather than on position: `TestGroup`
+        // dedupes its cases on exactly that, so it is unique among a group's
+        // cases, and it survives the merging that position would not.
+        self.identifierPath = identifierPath.appending("case").appending(identifier)
+        uuid = self.identifierPath.identifier
 
         Logger.substep("Initializing TestCase \(identifier)")
 
         iterations = [Iteration(
             metadata: metadata,
+            sourceIndex: sourceIndex,
             resultFile: resultFile,
             renderingMode: renderingMode,
             downsizeImagesEnabled: downsizeImagesEnabled,
             downsizeScaleFactor: downsizeScaleFactor
         )]
+        assignIterationIdentifiers()
+    }
+
+    /// Folds another run of this same test into this one's iterations.
+    ///
+    /// `other` is the same test — callers reach this through the `Set` that
+    /// dedupes on `identifier` — so both sides share an `identifierPath` and
+    /// the merged iterations can simply be renumbered.
+    mutating func merge(_ other: TestCase) {
+        iterations.append(contentsOf: other.iterations)
+        // Repetition numbers are not necessarily distinct (older bundles have
+        // none at all), and the iterations arrive in whatever order the
+        // operations finished in — so break ties on source position to keep
+        // this a total order.
+        iterations.sort(by: {
+            ($0.repetitionPolicy?.iteration ?? 0, $0.sourceIndex) <
+                ($1.repetitionPolicy?.iteration ?? 0, $1.sourceIndex)
+        })
+        assignIterationIdentifiers()
+    }
+
+    /// Numbers the iterations by their rendered position.
+    ///
+    /// Must run again after iterations are merged in from a repeated run:
+    /// merging changes both which iterations are present and their order, and
+    /// each `iterations-<uuid>` element the page toggles has to stay unique.
+    private mutating func assignIterationIdentifiers() {
+        for index in iterations.indices {
+            iterations[index].uuid = identifierPath.appending("iteration\(index)").identifier
+        }
     }
 }
 
@@ -268,7 +316,12 @@ extension TestCase {
                 "ICON_CLASS": status.cssClass,
                 "ITEM_CLASS": objectClass.cssClass,
                 "ITERATIONS": iterations.reduce("") { $0 + $1.html },
-                "RESULT_STRING": iterationStatusCount().map { "\($0.value) \($0.key.cssClass)" }
+                // Sorted because `Dictionary` iteration order is seeded per
+                // process: unsorted, "1 failed, 1 succeeded" renders as
+                // "1 succeeded, 1 failed" on some runs and not others.
+                "RESULT_STRING": iterationStatusCount()
+                    .sorted { $0.key.cssClass < $1.key.cssClass }
+                    .map { "\($0.value) \($0.key.cssClass)" }
                     .joined(separator: ", "),
                 // Add something for repetition policy/results breakdown
             ]

--- a/Sources/XCTestHTMLReportCore/Classes/Models/TestSummary.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Models/TestSummary.swift
@@ -43,17 +43,21 @@ struct TestSummary: HTML {
 
     init(
         summary: ActionTestableSummary,
+        identifierPath: IdentifierPath,
         file: ResultFile,
         renderingMode: Summary.RenderingMode,
         downsizeImagesEnabled: Bool,
         downsizeScaleFactor: CGFloat
     ) {
-        uuid = UUID().uuidString
-        testName = summary.targetName ?? ""
+        let targetName = summary.targetName ?? ""
+        let path = identifierPath.appending(targetName)
+        uuid = path.identifier
+        testName = targetName
         // TODO: Reduce this with iterations & accum with hashmap
-        tests = summary.tests.map {
+        tests = summary.tests.enumerated().map { index, group in
             TestGroup(
-                group: $0,
+                group: group,
+                identifierPath: path.appending("group\(index)"),
                 resultFile: file,
                 renderingMode: renderingMode,
                 downsizeImagesEnabled: downsizeImagesEnabled,

--- a/Tests/XCTestHTMLReportTests/ReproducibilityTests.swift
+++ b/Tests/XCTestHTMLReportTests/ReproducibilityTests.swift
@@ -1,0 +1,323 @@
+import class Foundation.Bundle
+import SwiftSoup
+import XCTest
+
+/// The same bundle rendered twice by the same binary must produce the same
+/// bytes (#411).
+///
+/// Every check here runs the binary in a **separate process** on purpose.
+/// Two of the three causes of drift this guards against — `Set` iteration
+/// order and `Dictionary` iteration order — are seeded once per process by
+/// Swift's hash seed, so rendering twice inside one test process cannot
+/// observe them. Only re-running the executable can.
+final class ReproducibilityTests: XCTestCase {
+    private var testResultsUrl: URL? {
+        Bundle.testBundle.url(forResource: "TestResults", withExtension: "xcresult")
+    }
+
+    private var retryResultsUrl: URL? {
+        Bundle.testBundle.url(forResource: "RetryResults", withExtension: "xcresult")
+    }
+
+    /// How many times each bundle is rendered. Identifier drift shows up on
+    /// every run, but ordering drift is sampled — a rendering that is stable
+    /// four runs out of five needs more than one comparison to catch.
+    private let renderCount = 5
+
+    // MARK: - Byte identity
+
+    func testRenderingTheSameBundleTwiceProducesIdenticalBytes() throws {
+        let testResultsUrl = try XCTUnwrap(testResultsUrl)
+        try assertRendersIdentically(bundles: [testResultsUrl])
+    }
+
+    /// `RetryResults` is the interesting bundle: it is the only fixture with a
+    /// test case that has several iterations, so it exercises the iteration
+    /// identifiers and the per-status counts that the other bundles do not.
+    func testRenderingARetriedBundleTwiceProducesIdenticalBytes() throws {
+        let retryResultsUrl = try XCTUnwrap(
+            retryResultsUrl,
+            "RetryResults.xcresult not found, this likely means Xcode < 13.0"
+        )
+        try assertRendersIdentically(bundles: [retryResultsUrl])
+    }
+
+    // MARK: - Uniqueness
+
+    /// Passing one bundle twice is the worst case for content-derived
+    /// identifiers: two runs whose device, target, suite, test and iteration
+    /// names are byte-for-byte equal. Anything derived from names alone
+    /// collides here, and a collision is silent — `getElementById` and
+    /// `querySelectorAll(...)[0]` both just return the first match, so the
+    /// second device's rows stop responding without anything failing to parse.
+    func testIdentifiersStayUniqueWhenOneBundleAppearsTwiceInAReport() throws {
+        let document = try parseReportDocument(
+            xchtmlreportArgs: ["-o", makeOutputDirectory().path] + collidingBundlePaths()
+        )
+
+        let identifiers = try mintedIdentifiers(in: document)
+        // Each kind is asserted present rather than assumed: a selector that
+        // silently stops matching would turn the uniqueness check below into a
+        // check of nothing.
+        for kind in IdentifierKind.allCases {
+            XCTAssertGreaterThan(
+                identifiers[kind]?.count ?? 0, 0,
+                "No \(kind.rawValue) identifiers found — this test is vacuous for that kind"
+            )
+        }
+        assertNoDuplicates(in: identifiers.values.flatMap { $0 })
+
+        // Every device handle must address exactly one run element, including
+        // the two runs that share a device identifier.
+        let deviceIdentifiers = try XCTUnwrap(identifiers[.device])
+        XCTAssertGreaterThanOrEqual(deviceIdentifiers.count, 2, "Expected at least two runs")
+        for deviceIdentifier in deviceIdentifiers {
+            let runs = try document.select("div.run#device_\(deviceIdentifier)")
+            XCTAssertEqual(
+                runs.count, 1,
+                "selectDevice('\(deviceIdentifier)') must resolve to exactly one run element"
+            )
+        }
+
+        // Every toggle handle must address the element it is meant to open.
+        for handle in try mintedIdentifiers(in: document, kinds: [.testCase, .iteration])
+            .values.flatMap({ $0 })
+        {
+            XCTAssertEqual(
+                try document.select("#activities-\(handle), #iterations-\(handle)").count, 1,
+                "toggle(this, '\(handle)') must resolve to exactly one element"
+            )
+        }
+    }
+
+    // MARK: - Escaping
+
+    /// These identifiers land in two places at once: an HTML `id` attribute and
+    /// a single-quoted JavaScript string literal (`toggle(this, '…')`,
+    /// `selectDevice('…')`). Neither is escaped by the templates, so a
+    /// derivation that ever embedded a raw test name — Swift test names can
+    /// contain quotes, angle brackets and spaces — would break the page.
+    func testMintedIdentifiersNeedNoEscapingInHTMLOrJavaScript() throws {
+        let document = try parseReportDocument(
+            xchtmlreportArgs: ["-o", makeOutputDirectory().path] + collidingBundlePaths()
+        )
+
+        let identifiers = try mintedIdentifiers(in: document)
+        for kind in IdentifierKind.allCases {
+            XCTAssertGreaterThan(
+                identifiers[kind]?.count ?? 0, 0,
+                "No \(kind.rawValue) identifiers found — this test is vacuous for that kind"
+            )
+        }
+
+        for identifier in identifiers.values.flatMap({ $0 }) {
+            XCTAssertNotNil(
+                identifier.range(of: "^[A-Za-z0-9_-]+$", options: .regularExpression),
+                "Identifier <\(identifier)> contains characters that need escaping"
+            )
+        }
+    }
+
+    // MARK: - Ordering
+
+    /// A test case with mixed iteration results renders its per-status counts
+    /// as "1 failed, 1 succeeded". Those counts come out of a dictionary, whose
+    /// iteration order Swift seeds per process — so without an explicit sort
+    /// this line reorders between runs. Assert the order is canonical
+    /// (alphabetical by status class) rather than pinning the counts, which
+    /// depend on how the simulator behaved when the fixture was recorded.
+    func testMixedIterationCountsAreListedInACanonicalOrder() throws {
+        let retryResultsUrl = try XCTUnwrap(
+            retryResultsUrl,
+            "RetryResults.xcresult not found, this likely means Xcode < 13.0"
+        )
+        let document = try parseReportDocument(
+            xchtmlreportArgs: ["-o", makeOutputDirectory().path, retryResultsUrl.path]
+        )
+
+        let mixedRows = try document.select("div.test-summary.mixed > p.list-item")
+        XCTAssertGreaterThan(
+            mixedRows.count, 0,
+            "RetryResults is expected to contain at least one mixed test case"
+        )
+
+        for row in mixedRows {
+            let text = try row.text()
+            let statuses = try statusWords(in: text)
+            XCTAssertGreaterThanOrEqual(
+                statuses.count, 2,
+                "A mixed row lists at least two statuses, got <\(text)>"
+            )
+            XCTAssertEqual(
+                statuses, statuses.sorted(),
+                "Status counts must be in a fixed order, got <\(text)>"
+            )
+        }
+    }
+}
+
+// MARK: - Helpers
+
+/// The kinds of node this project mints an identifier for, and how to find
+/// each one's identifier in the rendered page.
+enum IdentifierKind: String, CaseIterable {
+    case device
+    case targetSummary
+    case suite
+    case testCase
+    case iteration
+
+    var selector: String {
+        switch self {
+        case .device: return "ul.device-info"
+        case .targetSummary: return "div.summary[id]"
+        case .suite: return "div.test-summary-group > p > span.drop-down-icon"
+        case .testCase: return "div.test-summary > p.list-item > span.drop-down-icon"
+        case .iteration: return "div.iteration > p.list-item > span.drop-down-icon"
+        }
+    }
+}
+
+private extension ReproducibilityTests {
+    func assertRendersIdentically(
+        bundles: [URL],
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws {
+        let arguments = bundles.map(\.path)
+        let first = try renderReport(arguments: arguments)
+
+        for run in 2 ... renderCount {
+            let next = try renderReport(arguments: arguments)
+            guard first != next else {
+                continue
+            }
+            XCTFail(
+                "Run \(run) differs from run 1: \(describeFirstDifference(first, next))",
+                file: file,
+                line: line
+            )
+            return
+        }
+    }
+
+    /// Renders into a fresh directory each time so no run can read back
+    /// anything the previous one left behind.
+    func renderReport(arguments: [String]) throws -> Data {
+        let outputDirectory = try makeOutputDirectory()
+        let (status, maybeStdOut, maybeStdErr) = try xchtmlreportCmd(
+            args: ["-o", outputDirectory.path] + arguments
+        )
+        let stdOut = try XCTUnwrap(maybeStdOut)
+        XCTAssertEqual(
+            status, 0,
+            "xchtmlreport exited \(status).\nstdout:\n\(stdOut)\nstderr:\n\(maybeStdErr ?? "")"
+        )
+        let htmlUrl = try XCTUnwrap(urlFromXCHtmlreportStdout(stdOut))
+        return try Data(contentsOf: htmlUrl)
+    }
+
+    func makeOutputDirectory() throws -> URL {
+        let url = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("XCHTMLReportReproducibility-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: url) }
+        return url
+    }
+
+    /// The bundles to render when the point is collisions: one bundle listed
+    /// twice (identical device, target, suite and test names across two runs)
+    /// plus the retried bundle, which is the only fixture with iterations.
+    func collidingBundlePaths() throws -> [String] {
+        let testResultsUrl = try XCTUnwrap(testResultsUrl)
+        let retryResultsUrl = try XCTUnwrap(
+            retryResultsUrl,
+            "RetryResults.xcresult not found, this likely means Xcode < 13.0"
+        )
+        return [testResultsUrl.path, retryResultsUrl.path, testResultsUrl.path]
+    }
+
+    /// The identifiers this project mints for the test tree, by the kind of
+    /// node they belong to. Activity identifiers are deliberately excluded —
+    /// those are read from the bundle rather than minted here.
+    func mintedIdentifiers(
+        in document: Document,
+        kinds: [IdentifierKind] = IdentifierKind.allCases
+    ) throws -> [IdentifierKind: [String]] {
+        var identifiers = [IdentifierKind: [String]]()
+        for kind in kinds {
+            let elements = try document.select(kind.selector)
+            identifiers[kind] = try elements.map { element in
+                switch kind {
+                case .targetSummary: return try element.attr("id")
+                case .device: return try selectDeviceArgument(of: element)
+                default: return try toggleArgument(of: element)
+                }
+            }
+        }
+        return identifiers
+    }
+
+    /// `onclick="toggle(this, 'abc')"` -> `abc`
+    func toggleArgument(of element: Element) throws -> String {
+        let onClick = try element.attr("onclick")
+        return try XCTUnwrap(
+            onClick.groupMatch("toggle\\(this, '([^']*)'\\)"),
+            "Could not read a toggle() identifier out of <\(onClick)>"
+        )
+    }
+
+    /// `onclick="selectDevice('abc', this);"` -> `abc`
+    func selectDeviceArgument(of element: Element) throws -> String {
+        let onClick = try element.attr("onclick")
+        return try XCTUnwrap(
+            onClick.groupMatch("selectDevice\\('([^']*)'"),
+            "Could not read a selectDevice() identifier out of <\(onClick)>"
+        )
+    }
+
+    func assertNoDuplicates(
+        in identifiers: [String],
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let counts = identifiers.reduce(into: [String: Int]()) { $0[$1, default: 0] += 1 }
+        let duplicates = counts.filter { $0.value > 1 }.keys.sorted()
+        XCTAssertTrue(
+            duplicates.isEmpty,
+            "\(duplicates.count) identifier(s) used more than once: \(duplicates.prefix(5))",
+            file: file,
+            line: line
+        )
+    }
+
+    /// Pulls the status words out of "testRetryOnFailure() 1 failed, 1 succeeded (0.16s)".
+    func statusWords(in text: String) throws -> [String] {
+        let pattern = "\\d+ (failed|succeeded|skipped|mixed)"
+        let regex = try NSRegularExpression(pattern: pattern)
+        let range = NSRange(text.startIndex ..< text.endIndex, in: text)
+        return regex.matches(in: text, range: range).compactMap { match in
+            Range(match.range(at: 1), in: text).map { String(text[$0]) }
+        }
+    }
+
+    func describeFirstDifference(_ lhs: Data, _ rhs: Data) -> String {
+        guard lhs.count == rhs.count else {
+            return "lengths differ: \(lhs.count) vs \(rhs.count) bytes"
+        }
+        guard let offset = Array(zip(lhs, rhs)).firstIndex(where: !=) else {
+            return "no differing byte found"
+        }
+        let window = 80
+        let start = max(0, offset - window / 2)
+        let end = min(lhs.count, offset + window)
+        func excerpt(_ data: Data) -> String {
+            String(bytes: data[start ..< end], encoding: .utf8) ?? "<not valid UTF-8>"
+        }
+        return """
+        first differing byte at offset \(offset)
+          run 1: \(excerpt(lhs))
+          run n: \(excerpt(rhs))
+        """
+    }
+}


### PR DESCRIPTION
Fixes #411.

## The problem

Five call sites minted a fresh `UUID()` at parse time for use as DOM ids and JavaScript handles, so the same binary run twice on the same `.xcresult` produced different HTML. Reproduced before touching anything:

```
$ diff a/index.html b/index.html | head -2
616c616
<   <ul class="device-info" onclick="selectDevice('95D46FBA-398C-489C-981F-CE7D72A3A993', this);">
---
>   <ul class="device-info" onclick="selectDevice('1F066FF7-7ECF-41F6-90E4-B798C2C7746A', this);">
```

## The fix

Identifiers are now a digest of the element's path through the report, built from the bundle's own content (device identifier, target name, suite and test identifiers) plus enough positional information to keep them unique. `IdentifierPath` carries the full argument; the short version:

| node | path component | why it is unique among siblings |
|---|---|---|
| run | bundle index + action index | position in the argument list |
| device | `device` + device identifier | one device per run |
| target summary | index + target name | position among testable summaries |
| suite | index + suite identifier | position among sibling groups |
| test case | `case` + test identifier | `TestGroup` dedupes its cases on exactly this key |
| iteration | index within the test case | assigned after merging and sorting |

Components are length-prefixed when joined, so the component list → string mapping is injective and a test identifier containing the separator (`MySuite/testFoo()` does) cannot forge another node's path.

**Why not hash the names alone.** A report can hold several runs against the same device — merged bundles, or one bundle passed twice — and a duplicate id fails silently: `getElementById` and `querySelectorAll(...)[0]` both return the first match, so the second device's rows stop responding without anything failing to parse. There is a test for this, and it is not hypothetical: swapping in the naive `hash(record.identifier)` derivation makes all three device entries resolve to the same run element, and the test catches it.

**Why a digest rather than the path.** These land unescaped in both an HTML `id` attribute and a single-quoted JavaScript string. Test names can contain quotes, angle brackets and spaces; a 32-character lowercase hex digest cannot.

## Two more sources of drift, found while verifying

Fixing the UUIDs alone did **not** make the report reproducible. Both remaining causes are seeded once per process by Swift's hash seed, which is why they only show up across separate processes:

1. **Per-status counts on a mixed test case came out of a `Dictionary`.** The same fixture rendered `1 failed, 1 succeeded` on four runs out of five and `1 succeeded, 1 failed` on the fifth — user-visible text. Now sorted by status class.
2. **`Set` iteration order and non-total sort comparators.** Ties (equal test names across test-plan configurations, equal titles, equal or absent repetition numbers) resolved differently between runs. Each comparator now has a deterministic tiebreaker; the pre-existing order is preserved wherever the old comparator already decided it.

## Verification

Renders are byte-identical, not merely equivalent:

```
$ diff x1/index.html x2/index.html
$ echo $?
0
$ shasum -a 256 x1/index.html x2/index.html
46a27ef2e20c87671bd9f4056e955d757fb9907191507f457f1dd0d12f28fad1  x1/index.html
46a27ef2e20c87671bd9f4056e955d757fb9907191507f457f1dd0d12f28fad1  x2/index.html
```

20 renders of each case, one distinct output each (5 would have been enough for the UUIDs, but the ordering drift was only sampled — it needed repetition to surface reliably):

```
TestResults      : 20 runs -> 1 distinct output(s)
RetryResults     : 20 runs -> 1 distinct output(s)
SanityResults    : 20 runs -> 1 distinct output(s)
all three merged : 20 runs -> 1 distinct output(s)
same bundle twice: 20 runs -> 1 distinct output(s)
```

**Rendering is otherwise unchanged.** Diffing this branch's output against `main`'s with identifiers normalised reports no differences, for both `TestResults` and `RetryResults`. The one visible consequence is that the device panel's `Identifier:` line now shows a stable digest instead of a fresh random UUID — the same place, the same shape, and it was never stable to begin with.

**The report still navigates.** Checked in Chrome against a four-run report (including the same bundle twice, so two runs share a device identifier):

- clicking the 4th device entry activates the 4th run, exactly one run carries `.active`, and the clicked handle equals the active run's element id;
- clicking a test row's disclosure triangle expands that row's activities;
- expanding iteration 1 of the retried test leaves iteration 2 collapsed, and collapsing 1 leaves 2 open — i.e. the iteration ids address their own elements;
- no console errors.

**The new tests fail without the fix.** They run the executable in separate processes on purpose, since two of the three causes cannot be observed inside one process. Both guards were mutation-checked:

- naive `hash(device identifier)` → `("3") is not equal to ("1") - selectDevice('…') must resolve to exactly one run element`
- dropping the iteration renumbering after a merge → `2 identifier(s) used more than once`

The uniqueness and escaping tests assert that each kind of identifier (device, target summary, suite, test case, iteration) was actually found, so a selector that stops matching fails the test instead of quietly making it vacuous.

`swift test`: 28 tests, 1 skipped, 0 failures — the 23-test baseline plus 5 new. SwiftFormat, SwiftLint and shellcheck clean; no lint findings in the changed files beyond the ones already on `main`.

## Note, not fixed here

Passing literally the same bundle twice also duplicates `id="activities-<uuid>"` on *activities*, whose ids are read from the bundle (`ActionTestActivitySummary.uuid`) rather than minted here. That is pre-existing on `main` and out of scope for this issue; genuinely merged bundles from different runs carry distinct activity uuids and are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
