### PR TITLE
Download the release archive to a path the release step can find

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,6 +144,15 @@ jobs:
     steps:
     - name: Download
       uses: actions/download-artifact@v8
+      # Both are given explicitly because the default layout is not stable and
+      # the release step globs against it. Downloading everything unnamed put
+      # the archive in a directory per artifact under v4 and puts it straight
+      # in the workspace under v8 — the version bump in #404 silently moved it
+      # and nothing noticed, because the action this job used to publish with
+      # treats an unmatched file pattern as success.
+      with:
+        name: application
+        path: application
 
     - name: Release
       # The GitHub CLI is preinstalled on the runner and does everything the


### PR DESCRIPTION
The `3.0.1rc1` tag cut to verify #427 failed to publish:

```
no matches found for `application/xchtmlreport-*`
```

Build, sign, notarize and upload all succeeded. Only the publish step failed, and it failed on the asset path.

## The `application/` prefix has been stale since #404

`actions/download-artifact` with no `name` behaves differently across majors:

| run | version | destination |
|---|---|---|
| 3.0.0 (shipped fine) | v4 | `/home/runner/work/XCTestHTMLReport/XCTestHTMLReport/application` |
| 3.0.1rc1 (failed) | v8 | `/home/runner/work/XCTestHTMLReport/XCTestHTMLReport` |

v4 created a directory per artifact — that is where `application/` came from. v8 extracts straight into the workspace. Both versions log `An extra directory with the artifact name will be created for each download`; only v4 actually does it, so the log is no help.

#404 bumped v4 → v8 after 3.0.0 shipped. The archive has been landing one directory above the glob ever since.

## Why nothing caught it

`softprops/action-gh-release` defaults `fail_on_unmatched_files` to `false`. Fed a pattern matching nothing, it creates the release, uploads no assets, and exits 0.

So on `main` as of 3.0.0, **the next release would have published a Developer ID-signed, notarized release with no binary attached to it, and reported success.** No red check anywhere. That is the same false-green shape as the skipped-job problem in #414 — a step that cannot fail is not a check.

It surfaced now only because the `gh` CLI step from #427 fails on an unmatched pattern, which was a deliberate choice in that PR. The strictness paid for itself on its first real run.

## The fix

Name the artifact and its destination rather than inheriting whatever the current major does:

```yaml
- name: Download
  uses: actions/download-artifact@v8
  with:
    name: application
    path: application
```

With `name` set, the artifact extracts into `path` directly, so `application/xchtmlreport-*` resolves regardless of how the unnamed-download default changes again.

## Verification

Same constraint as #427 — the `release` job is `push`-only, so CI here proves nothing about it. `actionlint` is clean apart from the pre-existing SC2129 on the dry-run summary.

Real verification is re-cutting the rc tag once this merges. The `3.0.1rc1` attempt created **no release and no draft** (`gh` failed at pattern expansion, before any API call), so that tag is unused and will be re-pointed here rather than leaving a gap.
