### PR TITLE
fix: Ignore payload-less attachments during validation

### DIFF
--- a/Sources/XCTestHTMLReportCore/Classes/Models/Summary.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Models/Summary.swift
@@ -107,7 +107,9 @@ public struct Summary {
     /// Call-site checks catch failures XCResultKit surfaces as `nil`. They do
     /// not catch failures in *nested* decoding, where a parent object still
     /// decodes but a child field comes back empty. The observable symptom is an
-    /// attachment that resolved to no content, so check for that directly.
+    /// attachment whose referenced payload resolved to no content, so check
+    /// for that directly. Attachments without a payload reference legitimately
+    /// have no content and require no resolution.
     ///
     /// Idempotent across sequential calls: repeated calls do not duplicate
     /// faults. Dedup keys on `Attachment.faultDescription`, which assumes
@@ -123,7 +125,7 @@ public struct Summary {
         )
 
         for attachment in allAttachments {
-            guard case .none = attachment.content else {
+            guard attachment.payloadId != nil, case .none = attachment.content else {
                 continue
             }
             let detail = attachment.faultDescription

--- a/Tests/XCTestHTMLReportTests/CoreTests.swift
+++ b/Tests/XCTestHTMLReportTests/CoreTests.swift
@@ -78,11 +78,11 @@ final class CoreTests: XCTestCase {
             // because a run still depends on the simulator behaving, and an
             // exact split would measure that rather than this project.
             //
-            // 17 = 14 XCTest methods + 3 Swift Testing `@Test` functions in
-            // SwiftTestingSuite (SampleAppUnitTests target). The 14th is
-            // FirstSuite.testAttachScreenshot, added by #393 to give the image
-            // rendering path a fixture.
-            XCTAssertEqual(all, 17, "One row per test method; fixed by the sample sources")
+            // 18 = 15 XCTest methods + 3 Swift Testing `@Test` functions in
+            // SwiftTestingSuite (SampleAppUnitTests target). The latest is
+            // FirstSuite.testAttachDeletedOnSuccess, whose passing attachment
+            // retains metadata but has no payload.
+            XCTAssertEqual(all, 18, "One row per test method; fixed by the sample sources")
             XCTAssertEqual(
                 skipped,
                 1,

--- a/Tests/XCTestHTMLReportTests/FaultReportingTests.swift
+++ b/Tests/XCTestHTMLReportTests/FaultReportingTests.swift
@@ -36,7 +36,7 @@ final class FaultReportingTests: XCTestCase {
         XCTAssertEqual(summary.faults, [], "Clean fixture must not produce faults")
     }
 
-    func testValidateFlagsUnresolvedAttachments() throws {
+    func testValidateIgnoresPayloadlessAttachments() throws {
         let url = try XCTUnwrap(
             Bundle.testBundle.url(forResource: "TestResults", withExtension: "xcresult")
         )
@@ -49,14 +49,27 @@ final class FaultReportingTests: XCTestCase {
             downsizeScaleFactor: 0.25,
             faultCollector: collector
         )
+
+        let payloadlessAttachments = summary.allAttachments.filter { attachment in
+            guard attachment.payloadId == nil else {
+                return false
+            }
+            if case .none = attachment.content {
+                return true
+            }
+            return false
+        }
+        XCTAssertFalse(
+            payloadlessAttachments.isEmpty,
+            "Fixture must contain an attachment whose payload was deleted after a passing test"
+        )
+
         summary.validate()
 
-        // Every attachment the model knows about must have resolved to real
-        // content. An unresolved one renders as an empty src.
         let unresolved = summary.faults.filter { $0.kind == .unresolvedAttachment }
         XCTAssertEqual(
             unresolved, [],
-            "Unresolved attachments: \(unresolved.map(\.detail))"
+            "Payload-less attachments must not be reported as unresolved: \(unresolved.map(\.detail))"
         )
     }
 

--- a/XCTestHTMLReportSampleApp/SampleAppUITests/FirstSuite.swift
+++ b/XCTestHTMLReportSampleApp/SampleAppUITests/FirstSuite.swift
@@ -65,6 +65,13 @@ class FirstSuite: XCTestCase {
         add(screenshot)
     }
 
+    func testAttachDeletedOnSuccess() {
+        let attachment = XCTAttachment(string: "This payload is removed after the test passes")
+        attachment.name = "Deleted on Success"
+        attachment.lifetime = .deleteOnSuccess
+        add(attachment)
+    }
+
     func testOne() {
         XCTContext.runActivity(named: "Text Attachment") { activity in
             let logs = """


### PR DESCRIPTION
## Summary by CodeRabbit

Tighten the post-condition in `Summary.validate()` so `.none` is fault-worthy only when the attachment also has a payload identifier, preserving the existing idempotent fault deduplication and genuine unresolved-payload behavior. Add a passing sample UI test that records an attachment with XCTest's payload-removing lifetime so `prepareTestResults.sh` produces a real attachment entry without a `payloadRef`; keep fixture generation and production parsing unchanged. Strengthen `FaultReportingTests` by first proving the generated fixture contains that payload-less attachment, then asserting validation does not report it as unresolved, so the regression test cannot pass vacuously.

## Verification

- Generate `TestResults.xcresult` from the sample project and verify the fixture contains at least one attachment whose `payloadId` is absent and whose rendered content is `.none`.
- Validate that fixture and verify the payload-less attachment produces no `unresolvedAttachment` fault; running the CLI against the same fixture must continue to exit 0 without a degradation warning.
- Verify attachments with a non-nil payload reference and successfully exported content remain fault-free in both linking and downsized fixture paths.
- Preserve the existing failure rule and idempotency: an attachment that has a payload reference but resolves to `.none` is still reported as unresolved, and repeated validation does not duplicate that fault or disturb previously collected faults.

## Why

`Summary.validate()` currently records an `unresolvedAttachment` fault whenever an attachment's rendering content is `.none`. `Attachment` also uses `.none` for attachments that never had a `payloadRef`, so a valid payload-less attachment is misclassified as failed resolution and can make the CLI exit 3. The model already retains `Attachment.payloadId`, which distinguishes an attempted payload resolution from the absence of a payload without adding a new state or test-only abstraction. The current generated fixtures contain no payload-less attachment, leaving this false-positive path untested.

Closes #387


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved attachment validation so attachments without payload references are ignored rather than incorrectly reported as unresolved.
  - Clarified diagnostics for attachments whose payloads cannot be resolved.

- **Tests**
  - Added coverage for attachments configured to be deleted after successful test completion.
  - Updated test result expectations and validation checks to reflect the expanded sample test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->