### PR TITLE
State a contribution policy for agent-generated pull requests

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+## What this changes
+
+<!-- What problem does this solve? Link the issue, e.g. Fixes #123 -->
+
+## How you verified it
+
+<!-- What did you actually run? Paste the output that matters. -->
+
+- [ ] `./prepareTestResults.sh && swift test` passes locally
+
+## AI assistance
+
+<!--
+Using an assistant is fine — name it and say what it did.
+Write "none" if you wrote this by hand.
+See CONTRIBUTING.md for the full policy.
+-->
+
+- [ ] I read every line of this diff and can answer questions about it

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,7 @@ Please read it before you start participating.
 
 * [Reporting Issues](#reporting-issues)
 * [Submitting Pull Requests](#submitting-pull-requests)
+* [AI-assisted contributions](#ai-assisted-contributions)
 
 ## Reporting Issues
 
@@ -36,6 +37,9 @@ This information will help  review and fix your issue faster.
 Pull requests are welcome, and greatly encouraged. When submitting a pull request, please add a description that explains what the changes are about. Link the ticket whenever possible.
 
 * As usual, anyone can clone the repository. Then do the fixes/improvements as needed in own repository. When it is finished you can start the request to pull code from your own repo to XCTestHTMLReport repo. 
+
+If you want to take an open issue, comment on it first and I will assign it to
+you. That costs you one line and guarantees your work gets read.
 
 ### Building and testing
 
@@ -79,6 +83,29 @@ changes you have not read. To skip it for one commit:
 git commit --no-verify
 ```
 
+## AI-assisted contributions
 
+Using an AI assistant to write a patch is fine. Much of this project's recent
+work was written that way. What is not fine is submitting code you have not
+read, have not run, or cannot explain.
+
+If you used an assistant, say so in the pull request description. One line is
+enough: which tool, and what it did.
+
+Every pull request, however it was written, clears the same bar:
+
+* You ran `./prepareTestResults.sh && swift test` and the suite passes.
+* You read every line of the diff and can answer questions about it.
+* The change addresses a problem you actually have, or an issue you asked for.
+
+Pull requests that look like automated volume submissions are closed without
+review. The signals are opening against issues you have no stake in, describing
+verification you did not perform, and doing the same thing across many unrelated
+repositories on the same day.
+
+This is not a judgment about machine-written code. Reviewing a patch costs more
+than generating one, and a maintainer's review time is the scarce resource here.
+A patch nobody asked for spends that resource without consent, and it does so
+whether or not the code is any good.
 
 *Some of the ideas and wording for the statements above were based on [AFNetworking](https://github.com/AFNetworking/AFNetworking).


### PR DESCRIPTION
## What this changes

Adds an **AI-assisted contributions** section to `CONTRIBUTING.md` and a pull request template that asks for verification and AI disclosure up front.

## Why

Three of the five open PRs from non-maintainers are from accounts running automated contribution farms:

| PR | Account | PRs authored on GitHub |
|---|---|---|
| #432 | `mvanhorn` | ~4,350 |
| #429 | `floze-the-genius` | ~315, nearly all on one day |
| #420 | `sunnnn2005` | 9, others to agent-playground repos |

They are not the classic spam shape. The diffs are coherent, tested, lint-clean, and target real open issues — #387 and #389 are mine, #364 is a genuine user's. That is what makes them expensive: none can be dismissed without a full read.

The policy is deliberately not an AI ban. Most recent work here is agent-assisted, so a ban would be both hypocritical and wrong. It draws the line at accountability and consent instead: disclose the tool, run the suite, be able to explain the diff, and don't open patches nobody asked for.

Paired with a repo setting change (not in this diff): fork PR workflows now require approval for all external contributors rather than only first-time ones, so unreviewed PRs no longer consume Actions minutes on the >10min fixture pipeline.

## How you verified it

Docs only — no code paths touched. Rendered headings and the new `#ai-assisted-contributions` anchor match the Topics list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added contribution guidance for responsible AI-assisted work, including disclosure, verification, and quality expectations.
  * Added a recommendation to discuss proposed changes on an open issue before starting.
* **Chores**
  * Added a pull request template covering change descriptions, testing, AI assistance, and diff review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->