### PR TITLE
fix: only fault attachments whose payload failed to resolve

### DIFF
--- a/Sources/XCTestHTMLReportCore/Classes/Models/Attachment.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Models/Attachment.swift
@@ -166,6 +166,21 @@ struct Attachment: HTML {
         self.content = content
     }
 
+    /// Whether this attachment represents a failure to resolve its payload.
+    ///
+    /// An attachment with no `payloadRef` has nothing to resolve: its content
+    /// is `.none` by construction, which is not degradation (#387). Only a
+    /// payload that existed and produced no content is a genuine failure.
+    var failedToResolve: Bool {
+        guard payloadId != nil else {
+            return false
+        }
+        guard case .none = content else {
+            return false
+        }
+        return true
+    }
+
     /// How this attachment is named in a `Fault` detail.
     ///
     /// `filename` is empty for nameless attachments, which would otherwise

--- a/Sources/XCTestHTMLReportCore/Classes/Models/Summary.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Models/Summary.swift
@@ -107,7 +107,9 @@ public struct Summary {
     /// Call-site checks catch failures XCResultKit surfaces as `nil`. They do
     /// not catch failures in *nested* decoding, where a parent object still
     /// decodes but a child field comes back empty. The observable symptom is an
-    /// attachment that resolved to no content, so check for that directly.
+    /// attachment whose payload resolved to no content, so check for that
+    /// directly. Attachments that never had a payload are skipped: their
+    /// content is empty by construction, not through degradation (#387).
     ///
     /// Idempotent across sequential calls: repeated calls do not duplicate
     /// faults. Dedup keys on `Attachment.faultDescription`, which assumes
@@ -123,7 +125,7 @@ public struct Summary {
         )
 
         for attachment in allAttachments {
-            guard case .none = attachment.content else {
+            guard attachment.failedToResolve else {
                 continue
             }
             let detail = attachment.faultDescription

--- a/Tests/XCTestHTMLReportTests/FaultReportingTests.swift
+++ b/Tests/XCTestHTMLReportTests/FaultReportingTests.swift
@@ -1,7 +1,64 @@
+import XCResultKit
 import XCTest
 @testable import XCTestHTMLReportCore
 
 final class FaultReportingTests: XCTestCase {
+    /// Build an `Attachment` through the production initializer from legacy
+    /// xcresulttool JSON, the same shape XCResultKit decodes from a bundle.
+    private func makeAttachment(json: [String: AnyObject]) throws -> Attachment {
+        let actionAttachment = try XCTUnwrap(
+            ActionTestAttachment(json),
+            "ActionTestAttachment did not parse from test JSON"
+        )
+        return Attachment(
+            attachment: actionAttachment,
+            file: ResultFile(
+                url: URL(fileURLWithPath: NSTemporaryDirectory() + "/DoesNotExist.xcresult"),
+                faultCollector: FaultCollector()
+            ),
+            renderingMode: .linking,
+            downsizeImagesEnabled: false,
+            downsizeScaleFactor: 0.25
+        )
+    }
+
+    private func string(_ value: String) -> [String: AnyObject] {
+        ["_type": ["_name": "String"], "_value": value] as [String: AnyObject]
+    }
+
+    func testAttachmentWithoutPayloadRefIsNotAResolutionFailure() throws {
+        // An attachment can legitimately carry no payload at all. Its content
+        // is `.none` by construction, not because an export failed (#387).
+        let attachment = try makeAttachment(json: [
+            "uniformTypeIdentifier": string("public.png") as AnyObject,
+            "lifetime": string("keepAlways") as AnyObject,
+            "name": string("Screenshot without payload") as AnyObject,
+        ])
+
+        XCTAssertNil(attachment.payloadId)
+        XCTAssertFalse(
+            attachment.failedToResolve,
+            "An attachment that never had a payload must not be reported as degradation"
+        )
+    }
+
+    func testAttachmentWhosePayloadCannotBeExportedIsAResolutionFailure() throws {
+        // The counterpart: a payload existed but exporting it produced
+        // nothing. That is genuine degradation and must still be flagged.
+        let attachment = try makeAttachment(json: [
+            "uniformTypeIdentifier": string("public.png") as AnyObject,
+            "lifetime": string("keepAlways") as AnyObject,
+            "name": string("Screenshot with unexportable payload") as AnyObject,
+            "payloadRef": ["id": string("0~bogus")] as AnyObject,
+        ])
+
+        XCTAssertNotNil(attachment.payloadId)
+        XCTAssertTrue(
+            attachment.failedToResolve,
+            "A payload that failed to export must still be reported as degradation"
+        )
+    }
+
     func testMissingInvocationRecordIsRecordedAsFault() {
         let bogusPath = NSTemporaryDirectory() + "/DoesNotExist.xcresult"
         let collector = FaultCollector()


### PR DESCRIPTION
Fixes #387.

## Problem

`Summary.validate()` flagged every attachment whose content is `RenderingContent.none`. But an attachment with no `payloadRef` has no content **by construction** — `Attachment.init` never attempts an export when there is no payload to export. A bundle containing payload-less attachments would exit 3 reporting degradation that did not occur: a false positive on the exact mechanism 3.0 asks users to trust.

Per the 4.0 design spec's guiding rule, a fault means a genuine failure to read something that should be there. An attachment that structurally has no payload is not a failure to export it.

## Fix

The per-attachment decision moves into `Attachment.failedToResolve`, which only reports failure when a payload existed (`payloadId != nil`) and resolving it produced no content. `validate()` now consults that predicate. Three files, +76/−2, no behavior change for any attachment that has a payload.

## Tests (written first, watched fail)

None of the generated fixtures contains a payload-less attachment (verified by walking all three bundles' legacy object graphs: 13 attachments, all with `payloadRef`), so the reproduction builds `Attachment` through the production initializer from the same legacy JSON shape XCResultKit decodes out of a bundle:

- `testAttachmentWithoutPayloadRefIsNotAResolutionFailure` — no `payloadRef` → must not fault. **Failed before the fix** (reproducing the issue), passes after.
- `testAttachmentWhosePayloadCannotBeExportedIsAResolutionFailure` — `payloadRef` present but unexportable → must still fault. Passes before and after, pinning the true-positive path.

Full suite on freshly generated fixtures: 30 tests, 0 failures (1 skipped, pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved attachment validation to distinguish between attachments with no payload and attachments whose referenced content cannot be resolved.
  * Prevented valid attachments without payloads from being incorrectly reported as unresolved.
  * Continued reporting unresolved payloads as deduplicated faults.

* **Tests**
  * Added coverage for both valid no-payload attachments and failed payload resolution scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->