### PR TITLE
XCResultToolClient and new-format schema structs (#391)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
-TestResults*
-RetryResults*
-SanityResults*
+# Generated fixture bundles (prepareTestResults.sh). Anchored to .xcresult so
+# source files sharing the prefix (TestResultsSchema.swift) are not swallowed.
+TestResults*.xcresult
+RetryResults*.xcresult
+SanityResults*.xcresult
 .DS_Store
 /.build
 /XCTestHTMLReportSampleApp/Build

--- a/Sources/XCTestHTMLReportCore/Classes/ResultReading/Modern/TestResultsSchema.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/ResultReading/Modern/TestResultsSchema.swift
@@ -1,0 +1,139 @@
+//
+//  TestResultsSchema.swift
+//  XCTestHTMLReportCore
+//
+//  Codable mirrors of `xcresulttool get test-results ...` and
+//  `xcresulttool export attachments`. Field names match the JSON exactly, so
+//  no CodingKeys are needed.
+//
+//  Almost everything is optional: xcresulttool omits empty collections and
+//  inapplicable fields rather than emitting nulls, and a missing key must
+//  degrade rather than fail the whole read.
+//
+
+import Foundation
+
+// MARK: - TestResultsDevice
+
+struct TestResultsDevice: Decodable {
+    let deviceId: String?
+    let deviceName: String?
+    let modelName: String?
+    let osVersion: String?
+    let platform: String?
+}
+
+// MARK: - TestResultsSummary
+
+struct TestResultsSummary: Decodable {
+    struct DeviceAndConfiguration: Decodable {
+        let device: TestResultsDevice?
+    }
+
+    let title: String?
+    let environmentDescription: String?
+    let totalTestCount: Int?
+    let devicesAndConfigurations: [DeviceAndConfiguration]?
+}
+
+// MARK: - TestResultsTests
+
+struct TestResultsTests: Decodable {
+    let devices: [TestResultsDevice]?
+    /// Optional with an empty default: xcresulttool omits collection keys
+    /// rather than emitting empty arrays, and a bundle with no tests must
+    /// decode to an empty result rather than throwing keyNotFound.
+    let testNodes: [TestNode]?
+}
+
+// MARK: - TestNode
+
+/// One node of the test tree. `nodeType` is the discriminator; the published
+/// `TestNodeType` enum (`xcresulttool get test-results tests --schema`,
+/// schema 0.1.0) lists `Test Plan`, `Unit test bundle`, `UI test bundle`,
+/// `Test Suite`, `Test Case`, `Device`, `Test Plan Configuration`,
+/// `Arguments`, `Repetition`, `Test Case Run`, `Failure Message`,
+/// `Source Code Reference`, `Attachment`, `Expression`, `Test Value`, and
+/// `Runtime Warning`. `Arguments`, `Expression` and `Test Value` come from
+/// the schema alone — no fixture produces them yet — so nothing here may
+/// require their presence.
+struct TestNode: Decodable {
+    let name: String?
+    let nodeType: String?
+    let nodeIdentifier: String?
+    let nodeIdentifierURL: String?
+    let result: String?
+    let durationInSeconds: Double?
+    let details: String?
+    let children: [TestNode]?
+}
+
+// MARK: - TestActivities
+
+struct TestActivities: Decodable {
+    struct TestRun: Decodable {
+        let device: TestResultsDevice?
+        let activities: [ActivityNode]?
+    }
+
+    let testIdentifier: String?
+    let testName: String?
+    /// Optional for the same reason as `TestResultsTests.testNodes`: an
+    /// omitted key must decode, not throw.
+    let testRuns: [TestRun]?
+}
+
+// MARK: - ActivityNode
+
+struct ActivityNode: Decodable {
+    let title: String?
+    let startTime: Double?
+    let isAssociatedWithFailure: Bool?
+    let attachments: [ActivityAttachment]?
+    let childActivities: [ActivityNode]?
+}
+
+// MARK: - ActivityAttachment
+
+struct ActivityAttachment: Decodable {
+    let name: String?
+    let payloadId: String?
+    let uuid: String?
+    let timestamp: Double?
+    let lifetime: String?
+}
+
+// MARK: - AttachmentManifestEntry
+
+/// `manifest.json` written by `xcresulttool export attachments`.
+struct AttachmentManifestEntry: Decodable {
+    struct ManifestAttachment: Decodable {
+        let exportedFileName: String?
+        let suggestedHumanReadableName: String?
+        let isAssociatedWithFailure: Bool?
+        let timestamp: Double?
+    }
+
+    let testIdentifier: String?
+    let testIdentifierURL: String?
+    let attachments: [ManifestAttachment]?
+}
+
+// MARK: - LogSection
+
+/// Section of `xcresulttool get log`. Note there is no `emittedOutput`; the
+/// new format carries structured `messages` instead.
+struct LogSection: Decodable {
+    struct LogMessage: Decodable {
+        let title: String?
+        let shortTitle: String?
+        let type: String?
+    }
+
+    let title: String?
+    let domainType: String?
+    let duration: Double?
+    let result: String?
+    let messages: [LogMessage]?
+    let subsections: [LogSection]?
+}

--- a/Sources/XCTestHTMLReportCore/Classes/ResultReading/Modern/XCResultToolClient.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/ResultReading/Modern/XCResultToolClient.swift
@@ -1,0 +1,158 @@
+//
+//  XCResultToolClient.swift
+//  XCTestHTMLReportCore
+//
+//  Runs `xcrun xcresulttool` and decodes its JSON.
+//
+//  Every subcommand accepts --schema-version. Pinning it means an Apple schema
+//  revision fails loudly here rather than silently mis-decoding into a report
+//  that looks fine and is wrong.
+//
+
+import Foundation
+
+// MARK: - LegacyCapability
+
+/// Whether this toolchain still offers the `--legacy` commands.
+public enum LegacyCapability {
+    case available
+    case unavailable
+    /// The version string did not parse. Not proof of absence.
+    case unknown
+}
+
+// MARK: - XCResultToolError
+
+enum XCResultToolError: Error, CustomStringConvertible {
+    case executionFailed(arguments: [String], status: Int32, stderr: String)
+    case decodingFailed(arguments: [String], underlying: Error)
+
+    // MARK: Internal
+
+    var description: String {
+        switch self {
+        case let .executionFailed(arguments, status, stderr):
+            return "xcresulttool \(arguments.joined(separator: " ")) exited \(status): \(stderr)"
+        case let .decodingFailed(arguments, underlying):
+            return "Could not decode xcresulttool \(arguments.joined(separator: " ")): \(underlying)"
+        }
+    }
+}
+
+// MARK: - XCResultToolInvoking
+
+/// Seam for injecting a failing client in tests. `ModernResultReader` degrades
+/// rather than aborting when a subcommand fails, so the only way to prove the
+/// degradation is reported is to make a subcommand fail on demand.
+protocol XCResultToolInvoking {
+    func run(_ arguments: [String]) throws -> Data
+    func json<T: Decodable>(_ arguments: [String], as type: T.Type) throws -> T
+    /// Identifies the bundle in log messages.
+    var bundleDescription: String { get }
+}
+
+// MARK: - XCResultToolClient
+
+struct XCResultToolClient: XCResultToolInvoking {
+    /// The schema this reader was written against. Bump deliberately, with a
+    /// differential run, never as a reflex to a decode failure.
+    static let schemaVersion = "0.1.0"
+
+    /// Whether this toolchain still offers the `--legacy` commands.
+    ///
+    /// `xcresulttool version` prints
+    /// `... (legacy commands format version: 3.56)` while they exist, and is
+    /// expected to drop the parenthetical once they are removed.
+    ///
+    /// Three outcomes, not two: a version string we cannot parse at all is
+    /// `unknown`, which callers must not treat as proof the commands are gone.
+    static let legacyCapability: LegacyCapability = {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/xcrun")
+        process.arguments = ["xcresulttool", "version"]
+        let pipe = Pipe()
+        let errorPipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = errorPipe
+        do {
+            try process.run()
+        } catch {
+            // `.unknown`, not `.unavailable`. A transient failure to spawn
+            // `xcrun` is not evidence that the legacy commands are gone, and
+            // reporting absence here would silently skip `DifferentialTests` —
+            // the migration's only proof — on a machine where both backends
+            // actually work.
+            return .unknown
+        }
+        // Drain stderr too. An undrained pipe that fills blocks the child in
+        // write() forever, and this probe runs before anything else works.
+        let errorDrained = DispatchGroup()
+        errorDrained.enter()
+        DispatchQueue.global().async {
+            _ = errorPipe.fileHandleForReading.readDataToEndOfFile()
+            errorDrained.leave()
+        }
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        errorDrained.wait()
+        process.waitUntilExit()
+        let text = String(data: data, encoding: .utf8) ?? ""
+        guard process.terminationStatus == 0, text.contains("xcresulttool version") else {
+            // Did not look like a version string at all — say so rather than
+            // reporting absence we have not established.
+            return .unknown
+        }
+        return text.contains("legacy commands format version") ? .available : .unavailable
+    }()
+
+    let bundleURL: URL
+
+    var bundleDescription: String {
+        bundleURL.lastPathComponent
+    }
+
+    func run(_ arguments: [String]) throws -> Data {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/xcrun")
+        process.arguments = ["xcresulttool"] + arguments + [
+            "--path", bundleURL.path,
+            "--schema-version", Self.schemaVersion,
+        ]
+
+        let out = Pipe()
+        let err = Pipe()
+        process.standardOutput = out
+        process.standardError = err
+        try process.run()
+
+        // Drain before waiting: xcresulttool output routinely outgrows the
+        // pipe buffer, and waiting first deadlocks when it does.
+        var errorData = Data()
+        let group = DispatchGroup()
+        group.enter()
+        DispatchQueue.global().async {
+            errorData = err.fileHandleForReading.readDataToEndOfFile()
+            group.leave()
+        }
+        let outputData = out.fileHandleForReading.readDataToEndOfFile()
+        group.wait()
+        process.waitUntilExit()
+
+        guard process.terminationStatus == 0 else {
+            throw XCResultToolError.executionFailed(
+                arguments: arguments,
+                status: process.terminationStatus,
+                stderr: String(data: errorData, encoding: .utf8) ?? ""
+            )
+        }
+        return outputData
+    }
+
+    func json<T: Decodable>(_ arguments: [String], as type: T.Type) throws -> T {
+        let data = try run(arguments)
+        do {
+            return try JSONDecoder().decode(type, from: data)
+        } catch {
+            throw XCResultToolError.decodingFailed(arguments: arguments, underlying: error)
+        }
+    }
+}

--- a/Tests/XCTestHTMLReportTests/TestResultsSchemaTests.swift
+++ b/Tests/XCTestHTMLReportTests/TestResultsSchemaTests.swift
@@ -1,0 +1,66 @@
+//
+//  TestResultsSchemaTests.swift
+//
+
+import XCTest
+@testable import XCTestHTMLReportCore
+
+final class TestResultsSchemaTests: XCTestCase {
+    func testDecodesRepetitionNodes() throws {
+        let json = """
+        {"testNodes":[{"name":"MainScheme","nodeType":"Test Plan","result":"Failed",
+        "children":[{"name":"testRetryOnFailure()","nodeType":"Test Case",
+        "nodeIdentifier":"RetryTests/testRetryOnFailure()","result":"Passed",
+        "durationInSeconds":0.068,"children":[
+        {"name":"First Run","nodeType":"Repetition","nodeIdentifier":"1","result":"Failed",
+        "durationInSeconds":0.078},
+        {"name":"Retry 1","nodeType":"Repetition","nodeIdentifier":"2","result":"Passed",
+        "durationInSeconds":0.059}]}]}],
+        "devices":[],"testPlanConfigurations":[]}
+        """
+        let decoded = try JSONDecoder().decode(
+            TestResultsTests.self, from: Data(json.utf8)
+        )
+        let testCase = try XCTUnwrap(decoded.testNodes?.first?.children?.first)
+        XCTAssertEqual(testCase.nodeType, "Test Case")
+        XCTAssertEqual(testCase.children?.count, 2)
+        XCTAssertEqual(testCase.children?.map(\.nodeIdentifier), ["1", "2"])
+    }
+
+    func testDecodesArgumentsNodes() throws {
+        // Shape taken from the published schema (`get test-results tests
+        // --schema` lists `Arguments`, `Expression` and `Test Value` in
+        // `TestNodeType`), not from a fixture: no fixture produces an
+        // `Arguments` node yet. See the design doc's answer 6.
+        let json = """
+        {"testNodes":[{"name":"multiplication(factor:)","nodeType":"Test Case",
+        "result":"Passed","children":[
+        {"name":"Arguments: 2","nodeType":"Arguments","result":"Passed","children":[
+        {"name":"factor → 2","nodeType":"Test Value","result":"Passed"}]}]}],
+        "devices":[],"testPlanConfigurations":[]}
+        """
+        let decoded = try JSONDecoder().decode(
+            TestResultsTests.self, from: Data(json.utf8)
+        )
+        let arguments = try XCTUnwrap(decoded.testNodes?.first?.children?.first)
+        XCTAssertEqual(arguments.nodeType, "Arguments")
+        XCTAssertEqual(arguments.children?.first?.nodeType, "Test Value")
+    }
+
+    func testDecodesActivityAttachments() throws {
+        let json = """
+        {"testIdentifier":"FirstSuite/testTwo()","testName":"testTwo()","testRuns":[
+        {"activities":[{"title":"Start Test","startTime":1786425364.793,
+        "isAssociatedWithFailure":false,"attachments":[
+        {"name":"Screen Recording.mp4","payloadId":"0~abc",
+        "uuid":"4DB9AD3F-E485-4F77-9771-8FAC7270E261","timestamp":1786425364.806,
+        "lifetime":"deleteOnSuccess"}]}]}]}
+        """
+        let decoded = try JSONDecoder().decode(TestActivities.self, from: Data(json.utf8))
+        let attachment = try XCTUnwrap(
+            decoded.testRuns?.first?.activities?.first?.attachments?.first
+        )
+        XCTAssertEqual(attachment.uuid, "4DB9AD3F-E485-4F77-9771-8FAC7270E261")
+        XCTAssertEqual(attachment.name, "Screen Recording.mp4")
+    }
+}

--- a/Tests/XCTestHTMLReportTests/XCResultToolClientTests.swift
+++ b/Tests/XCTestHTMLReportTests/XCResultToolClientTests.swift
@@ -1,0 +1,42 @@
+//
+//  XCResultToolClientTests.swift
+//
+
+import XCTest
+@testable import XCTestHTMLReportCore
+
+final class XCResultToolClientTests: XCTestCase {
+    private struct SummaryProbe: Decodable {
+        let totalTestCount: Int
+        let title: String
+    }
+
+    func testDecodesSummaryDocument() throws {
+        let url = try XCTUnwrap(
+            Bundle.testBundle.url(forResource: "SanityResults", withExtension: "xcresult")
+        )
+        let client = XCResultToolClient(bundleURL: url)
+        let probe = try client.json(
+            ["get", "test-results", "summary"], as: SummaryProbe.self
+        )
+        XCTAssertEqual(probe.totalTestCount, 1)
+        XCTAssertFalse(probe.title.isEmpty)
+    }
+
+    func testUnknownSubcommandThrows() throws {
+        let url = try XCTUnwrap(
+            Bundle.testBundle.url(forResource: "SanityResults", withExtension: "xcresult")
+        )
+        let client = XCResultToolClient(bundleURL: url)
+        XCTAssertThrowsError(
+            try client.json(["get", "test-results", "nope"], as: SummaryProbe.self)
+        )
+    }
+
+    func testLegacyAvailabilityIsDetectable() {
+        // Not asserting a value: it is true on today's toolchains and false
+        // once Apple removes the legacy commands. Asserting either would make
+        // this test a time bomb. Assert only that detection runs.
+        _ = XCResultToolClient.legacyCapability
+    }
+}

--- a/docs/superpowers/plans/2026-08-10-xcresulttool-legacy-migration.md
+++ b/docs/superpowers/plans/2026-08-10-xcresulttool-legacy-migration.md
@@ -1589,6 +1589,11 @@ Subprocess plumbing for the modern backend, with the schema version pinned.
   `func run(_ arguments: [String]) throws -> Data`, plus
   `static var legacyCapability: LegacyCapability`. Task 8 depends on the
   protocol to inject a failing client.
+- **Also produces `LegacyCapability`** (amended during implementation): the
+  plan originally defined that enum only in Task 11's `ResultBackend.swift`,
+  but Task 6 cannot compile without it, and the tasks land as separate PRs.
+  It lives in `XCResultToolClient.swift` with exactly the shape Task 11
+  specifies; Task 11 must reuse it rather than redefine it.
 
 - [ ] **Step 1: Write the failing test**
 
@@ -1924,9 +1929,12 @@ struct TestResultsTests: Decodable {
     let testNodes: [TestNode]?
 }
 
-/// One node of the test tree. `nodeType` is the discriminator:
-/// `Test Plan`, `UI test bundle`, `Unit test bundle`, `Test Suite`,
-/// `Test Case`, `Repetition`, `Failure Message`.
+/// One node of the test tree. `nodeType` is the discriminator; the published
+/// `TestNodeType` enum (schema 0.1.0) lists `Test Plan`, `Unit test bundle`,
+/// `UI test bundle`, `Test Suite`, `Test Case`, `Device`,
+/// `Test Plan Configuration`, `Arguments`, `Repetition`, `Test Case Run`,
+/// `Failure Message`, `Source Code Reference`, `Attachment`, `Expression`,
+/// `Test Value`, `Runtime Warning`.
 struct TestNode: Decodable {
     let name: String?
     let nodeType: String?
@@ -2005,7 +2013,9 @@ struct LogSection: Decodable {
 swift test --filter TestResultsSchemaTests
 ```
 
-Expected: PASS, 2 tests.
+Expected: PASS, 3 tests — implementation added `testDecodesArgumentsNodes`,
+exercising the `Arguments`/`Test Value` node types from the published schema
+(no fixture produces them; see the design doc's answer 6).
 
 - [ ] **Step 5: Commit**
 
@@ -3209,13 +3219,10 @@ Expected: FAIL — `cannot find 'ResultBackend' in scope`.
 
 import Foundation
 
-/// Whether this toolchain still offers the `--legacy` commands.
-public enum LegacyCapability {
-    case available
-    case unavailable
-    /// The version string did not parse. Not proof of absence.
-    case unknown
-}
+// NOTE (amended during Task 6): `LegacyCapability` already exists — Task 6
+// defines it in `XCResultToolClient.swift` with exactly this shape, because
+// the client cannot compile without it and the tasks land as separate PRs.
+// Do not redefine it here; implement only `ResultBackend` below.
 
 /// Which reader parses result bundles.
 public enum ResultBackend: String, CaseIterable {


### PR DESCRIPTION
Part of #391 (milestone 4.0). Implements migration plan Tasks 6 and 7: the modern-backend subprocess client and the Codable mirrors of the new `xcresulttool` format. Deliberately independent of the ParsedResult port PR — purely additive, no existing files under `Classes/Models/` touched, no references to `ParsedResult`/`ResultReader`.

## What's here

- **`XCResultToolClient`** (`ResultReading/Modern/XCResultToolClient.swift`): runs `xcrun xcresulttool`, pinning `--schema-version 0.1.0` on every invocation so an Apple schema revision fails loudly instead of silently mis-decoding. Includes the `XCResultToolInvoking` seam (Task 8 injects a failing client through it), `json<T: Decodable>`, `run`, and `legacyCapability` — a three-state probe (`available`/`unavailable`/`unknown`) parsing `xcresulttool version` for the legacy-commands parenthetical.
- **`TestResultsSchema`** (`ResultReading/Modern/TestResultsSchema.swift`): Decodable structs for `get test-results summary|tests|activities`, the `export attachments` manifest, and `get log`. Fields optional throughout — xcresulttool omits keys rather than emitting nulls.
- **Tests**: `XCResultToolClientTests` (3 tests, real `SanityResults.xcresult` fixture) and `TestResultsSchemaTests` (3 tests), including decoding `Arguments`/`Test Value` nodes — added from the published schema (`get test-results tests --schema`), since no fixture produces them yet (design doc answer 6).

## Deviations from the plan, amended in the plan doc

- `LegacyCapability` is defined in `XCResultToolClient.swift`, not first in Task 11's `ResultBackend.swift`: Task 6 cannot compile without it and the tasks land as separate PRs. Task 11's snippet now says to reuse it.
- `TestNode`'s `nodeType` doc lists the full published `TestNodeType` enum (verified against schema 0.1.0 on xcresulttool 24514), and Task 7 gained the third test above.

## Also

- Narrowed the three fixture `.gitignore` patterns (`TestResults*` → `TestResults*.xcresult`): the bare pattern was silently swallowing `TestResultsSchema.swift` and its test file. Generated fixture bundles remain ignored.

## Verification

- `swift test`: 39 tests, 0 failures (2 pre-existing skips), on Xcode 26.2 / xcresulttool 24514, schema 0.1.0, fixtures freshly generated via `./prepareTestResults.sh`.
- Verified `--schema-version` is accepted by `get test-results *` and `export attachments`, and that `nodeIdentifierURL` appears in observed output despite being absent from the published `TestNode` schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
