### PR TITLE
ci: fix toolchain-drift false alarm — create --output dir, report exit code

### DIFF
--- a/.github/workflows/toolchain-drift.yml
+++ b/.github/workflows/toolchain-drift.yml
@@ -128,18 +128,29 @@ jobs:
       timeout-minutes: 45
       run: swift test -v
 
-    # The issue's core signal: since 3.0 the tool exits non-zero when the
-    # report is degraded (collected faults), so a clean exit against a bundle
-    # produced by this exact toolchain is the whole assertion.
+    # The issue's core signal: since 3.0 the tool exits 3 when the report is
+    # degraded (collected faults); any other non-zero exit is a hard error,
+    # not degradation. A clean exit against a bundle produced by this exact
+    # toolchain is the whole assertion. The exit code is captured as a step
+    # output so the drift report can tell those two failures apart.
+    # `mkdir -p` first: xchtmlreport does not create the --output directory
+    # and fails late with a misleading error when it is missing (#444).
     - name: Run xchtmlreport against a fresh bundle
       id: tool
       if: steps.build.outcome == 'success' && steps.fixtures.outcome == 'success'
       continue-on-error: true
       timeout-minutes: 15
       run: |
+        mkdir -p "$RUNNER_TEMP/drift-report"
+        exit_code=0
         swift run xchtmlreport \
           Tests/XCTestHTMLReportTests/Resources/TestResults.xcresult \
-          --output "$RUNNER_TEMP/drift-report"
+          --output "$RUNNER_TEMP/drift-report" || exit_code=$?
+        echo "exit_code=${exit_code}" >> "$GITHUB_OUTPUT"
+        if [ "$exit_code" -ne 0 ]; then
+          echo "::error::xchtmlreport exited with code ${exit_code}"
+          exit "$exit_code"
+        fi
 
     # This job regenerated fixtures for the newest toolchain anyway, so save
     # them under the same key test.yml computes (#436): after a toolchain bump
@@ -177,6 +188,7 @@ jobs:
         FIXTURES: ${{ steps.fixtures.outcome }}
         TESTS: ${{ steps.tests.outcome }}
         TOOL: ${{ steps.tool.outcome }}
+        TOOL_EXIT: ${{ steps.tool.outputs.exit_code }}
       run: |
         faults=()
         if [ "$LEGACY" = "failure" ]; then
@@ -199,7 +211,11 @@ jobs:
           faults+=("\`swift test\` failed against freshly generated fixtures.")
         fi
         if [ "$TOOL" = "failure" ]; then
-          faults+=("\`xchtmlreport\` exited non-zero against a fresh \`.xcresult\` — since 3.0 that means the report degraded (collected faults).")
+          if [ "$TOOL_EXIT" = "3" ]; then
+            faults+=("\`xchtmlreport\` exited 3 against a fresh \`.xcresult\` — since 3.0 that means the report degraded (collected faults).")
+          else
+            faults+=("\`xchtmlreport\` failed against a fresh \`.xcresult\` with a hard error (exit ${TOOL_EXIT:-unknown}) — not fault degradation; see the run log.")
+          fi
         fi
 
         {


### PR DESCRIPTION
Fixes the false alarm from the first scheduled toolchain-drift run (run 31652493537), triaged in #444. Workflow-only, same scoping as #442 — no product code touched.

## What happened

The `Run xchtmlreport against a fresh bundle` step passed `--output "$RUNNER_TEMP/drift-report"`, a directory nothing creates. `xchtmlreport` fails late when the output directory is missing ("An error has occured while creating the report" / "The file \"index.html\" doesn't exist") and exits 1. Reproduced on local Xcode 26.2 against a known-good bundle, so the failure is environment-independent — not drift, and Xcode 26.6 is exonerated.

## Changes

1. **Create the output directory** with `mkdir -p` before invoking `xchtmlreport`, and print the tool's exit code (`::error::` annotation) when it fails.
2. **Report fidelity**: the drift-issue template claimed any non-zero exit "means the report degraded (collected faults)" — false for this run (exit 1, not 3). The step now captures the exit code as a step output, and the report distinguishes exit 3 (degraded, faults collected — `ExitCode(3)` in `XCTestHtmlReport.swift`) from any other non-zero exit (hard error), including the actual code. Template structure otherwise unchanged.

The product-side behavior (`--output` pointing at a nonexistent directory failing late with a misleading error) is tracked separately — fix belongs in the CLI, not here.

## Verification

- `actionlint` clean (includes shellcheck on run blocks)
- standalone `shellcheck` clean on the modified step script
- `zizmor` clean (no findings; SHA-pinned actions untouched)
- The scheduled workflow can't execute from a branch — coordinator re-dispatches on main after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved toolchain drift reporting to distinguish report degradation from hard errors.
  * Preserved accurate failure status while ensuring report output is generated correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->