### PR TITLE
ModernResultReader, ModernPayloadStore, and extension-based attachment typing (#391, Tasks 8–10)

### DIFF
--- a/Sources/XCTestHTMLReportCore/Classes/Helpers/FaultCollector.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Helpers/FaultCollector.swift
@@ -20,6 +20,10 @@ public struct Fault: Equatable {
         /// `Summary.validate()` after the model is assembled, which catches
         /// nested decode failures that the call sites below cannot see.
         case unresolvedAttachment
+        /// The activity tree for a test could not be read, so the test appears
+        /// in the report with no activities. A genuine read failure, distinct
+        /// from a backend that structurally cannot provide a field.
+        case missingActivities
         /// XCResultKit could not produce an attachment's payload, or the
         /// exported file could not be moved into the bundle. The attachment is
         /// missing from the report.

--- a/Sources/XCTestHTMLReportCore/Classes/ResultReading/Legacy/LegacyResultReader.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/ResultReading/Legacy/LegacyResultReader.swift
@@ -224,6 +224,9 @@ struct LegacyResultReader: ResultReader {
         case "com.apple.log": return "log"
         case "public.html": return "html"
         case "public.zip-archive": return "zip"
+        // `public.data` is itself an `AttachmentType` raw value; without this
+        // entry an extensionless data attachment degrades `.data` → `.unknown`.
+        case "public.data": return "dat"
         default: return nil
         }
     }

--- a/Sources/XCTestHTMLReportCore/Classes/ResultReading/Modern/ModernPayloadStore.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/ResultReading/Modern/ModernPayloadStore.swift
@@ -1,0 +1,200 @@
+//
+//  ModernPayloadStore.swift
+//  XCTestHTMLReportCore
+//
+//  `xcresulttool export attachments` exports every attachment in the bundle in
+//  a single call, naming each file after its attachment uuid and writing a
+//  manifest alongside. That replaces the legacy one-subprocess-per-payload
+//  export, and with it the per-id locking the legacy path needs: there is no
+//  shared temp path to race on here. Only the one-shot export itself is
+//  guarded, so concurrent parsing does not trigger it twice.
+//
+
+import Foundation
+
+final class ModernPayloadStore: PayloadProviding {
+    // MARK: Lifecycle
+
+    /// `export attachments` writes a full copy of every attachment, including
+    /// screen recordings. Without this the temp directory outlives the process
+    /// and each run leaks tens of megabytes into NSTemporaryDirectory().
+    deinit {
+        if let directory = exportDirectory {
+            try? FileManager.default.removeItem(at: directory)
+        }
+    }
+
+    init(client: XCResultToolClient, bundleURL: URL, faultCollector: FaultCollector) {
+        self.client = client
+        self.faultCollector = faultCollector
+        url = bundleURL
+        relativeURL = URL(fileURLWithPath: bundleURL.lastPathComponent)
+    }
+
+    // MARK: Internal
+
+    /// The bundle directory — `PayloadProviding` exposes it so attachment
+    /// downsizing can reconstruct absolute paths from relative ones.
+    let url: URL
+
+    /// The manifest name of the exported payload for an attachment uuid, or
+    /// nil when the bundle exported nothing under that uuid. The reader uses
+    /// it to type attachments whose own filename carries no extension.
+    func exportedFileName(uuid: String) -> String? {
+        ensureExported()
+        lock.lock()
+        defer { lock.unlock() }
+        return fileNamesByUUID[uuid]
+    }
+
+    func exportPayload(reference: String, fileName: String?) -> URL? {
+        guard let source = sourceURL(for: reference) else {
+            faultCollector.record(.payloadExportFailed, "attachment \(reference)")
+            return nil
+        }
+        let resolved = fileName ?? source.lastPathComponent
+        let destination = url.appendingPathComponent(resolved)
+        do {
+            try? FileManager.default.removeItem(at: destination)
+            try FileManager.default.copyItem(at: source, to: destination)
+            return relativeURL.appendingPathComponent(resolved)
+        } catch {
+            // Another writer may have raced us to the destination (a second
+            // xchtmlreport over the same bundle): if the payload is sitting
+            // there, it was exported, and losing the race is not degradation.
+            if FileManager.default.fileExists(atPath: destination.path) {
+                return relativeURL.appendingPathComponent(resolved)
+            }
+            Logger.warning("Can't copy \(source) to \(destination): \(error)")
+            faultCollector.record(.payloadExportFailed, "attachment \(reference)")
+            return nil
+        }
+    }
+
+    func exportPayloadData(reference: String) -> Data? {
+        guard let source = sourceURL(for: reference) else {
+            faultCollector.record(.payloadExportFailed, "attachment \(reference)")
+            return nil
+        }
+        do {
+            return try Data(contentsOf: source)
+        } catch {
+            // An exported file we cannot read is a real failure, not a format
+            // limitation, so it earns a fault rather than a silent nil.
+            Logger.warning("Can't read exported attachment \(source): \(error)")
+            faultCollector.record(.payloadExportFailed, "attachment \(reference)")
+            return nil
+        }
+    }
+
+    func exportLogs(reference: String) -> URL? {
+        guard let text = logText(reference: reference) else {
+            return nil
+        }
+        let fileName = "\(reference).log"
+        let destination = url.appendingPathComponent(fileName)
+        do {
+            try? FileManager.default.removeItem(at: destination)
+            try text.write(to: destination, atomically: true, encoding: .utf8)
+            return relativeURL.appendingPathComponent(fileName)
+        } catch {
+            // A log we read but could not write is a genuine failure. Without
+            // the fault the report ships without it and still exits 0.
+            Logger.warning("Can't write log to \(destination): \(error)")
+            faultCollector.record(.logExportFailed, "log \(reference)")
+            return nil
+        }
+    }
+
+    func exportLogsData(reference: String) -> Data? {
+        logText(reference: reference)?.data(using: .utf8)
+    }
+
+    // MARK: Private
+
+    private let client: XCResultToolClient
+    private let relativeURL: URL
+    private let faultCollector: FaultCollector
+
+    private let lock = NSLock()
+    private var exportDirectory: URL?
+    private var fileNamesByUUID: [String: String] = [:]
+    private var exportAttempted = false
+
+    /// The new format has no `emittedOutput`, so the run log is rendered from
+    /// the structured `messages` instead, keeping the legacy indentation shape.
+    private static func format(_ section: LogSection, depth: Int = 0) -> String {
+        let indent = String(repeating: "\t", count: depth)
+        var lines = ["\(indent)-------- \(section.title ?? "") --------"]
+        for message in section.messages ?? [] {
+            lines.append("\(indent)\(message.title ?? message.shortTitle ?? "")")
+        }
+        for subsection in section.subsections ?? [] {
+            lines.append(format(subsection, depth: depth + 1))
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    private func sourceURL(for uuid: String) -> URL? {
+        ensureExported()
+        lock.lock()
+        defer { lock.unlock() }
+        guard let directory = exportDirectory, let name = fileNamesByUUID[uuid] else {
+            return nil
+        }
+        return directory.appendingPathComponent(name)
+    }
+
+    private func ensureExported() {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !exportAttempted else {
+            return
+        }
+        exportAttempted = true
+
+        let directory = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("xchtmlreport-attachments-\(UUID().uuidString)")
+        do {
+            try FileManager.default.createDirectory(
+                at: directory, withIntermediateDirectories: true
+            )
+            _ = try client.run([
+                "export", "attachments", "--output-path", directory.path,
+            ])
+            let manifestData = try Data(
+                contentsOf: directory.appendingPathComponent("manifest.json")
+            )
+            let manifest = try JSONDecoder().decode(
+                [AttachmentManifestEntry].self, from: manifestData
+            )
+            exportDirectory = directory
+            for entry in manifest {
+                for attachment in entry.attachments ?? [] {
+                    guard let file = attachment.exportedFileName else {
+                        continue
+                    }
+                    // Files are named "<attachment-uuid>.<ext>"; the uuid is
+                    // the join key back to the activities document.
+                    fileNamesByUUID[(file as NSString).deletingPathExtension] = file
+                }
+            }
+        } catch {
+            Logger.warning("Can't export attachments: \(error)")
+            faultCollector.record(.payloadExportFailed, "attachment export")
+        }
+    }
+
+    private func logText(reference: String) -> String? {
+        do {
+            let section = try client.json(
+                ["get", "log", "--type", reference], as: LogSection.self
+            )
+            return Self.format(section)
+        } catch {
+            Logger.warning("Can't get logs (\(reference)): \(error)")
+            faultCollector.record(.logExportFailed, "log \(reference)")
+            return nil
+        }
+    }
+}

--- a/Sources/XCTestHTMLReportCore/Classes/ResultReading/Modern/ModernResultReader.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/ResultReading/Modern/ModernResultReader.swift
@@ -1,0 +1,338 @@
+//
+//  ModernResultReader.swift
+//  XCTestHTMLReportCore
+//
+//  Builds ParsedResult from `xcresulttool get test-results`.
+//
+//  The new tree omits the two wrapper levels legacy interposes
+//  ("Selected tests" / "All tests", then "<target>.xctest"). We render the
+//  natural flat tree rather than synthesising them: whether the wrapper is
+//  "Selected tests" or "All tests" depends on run filtering, which the new
+//  format does not expose, so one of the two labels would always be invented.
+//
+
+import Foundation
+
+struct ModernResultReader: ResultReader {
+    // MARK: Internal
+
+    let client: XCResultToolInvoking
+    let payloadStore: ModernPayloadStore?
+    /// The collector `Summary.init` owns, so a fault recorded here reaches
+    /// `summary.faults` and drives the CLI's exit-3 degradation path.
+    let faultCollector: FaultCollector
+
+    /// Modern vocabulary into the neutral enum — the mirror of
+    /// `LegacyResultReader.status`. Neither reader emits the other's
+    /// spelling; that was the point of the design spec's answer 5.
+    ///
+    /// The full `TestResult` enum is `Passed`, `Failed`, `Skipped`,
+    /// `Expected Failure`, `unknown`, taken from
+    /// `xcresulttool get test-results tests --schema`. No fixture produces
+    /// `unknown`, so it is handled from the published schema rather than from
+    /// observed data.
+    static func status(_ result: String?) -> ParsedStatus {
+        switch result {
+        case "Passed": return .passed
+        case "Failed": return .failed
+        case "Skipped": return .skipped
+        case "Expected Failure": return .expectedFailure
+        default: return .unknown
+        }
+    }
+
+    /// Swift Testing `@Test(arguments:)` values.
+    ///
+    /// `Arguments` is one of the documented `TestNodeType` values, and since
+    /// the sample app gained a parameterized `@Test` it is also exercised by
+    /// the `TestResults` fixture: one child node per argument set, whose
+    /// `name` is the argument's value.
+    static func arguments(of node: TestNode) -> [String] {
+        (node.children ?? [])
+            .filter { $0.nodeType == "Arguments" }
+            .compactMap(\.name)
+    }
+
+    func read() -> ParsedResult? {
+        do {
+            let tests = try client.json(
+                ["get", "test-results", "tests"], as: TestResultsTests.self
+            )
+
+            // A decodable document that yields no destinations is a failed
+            // read, not an empty result. Returning `ParsedResult(runs: [])`
+            // here would satisfy `Summary.init`'s `guard let`, record no
+            // fault, and let `--lenient` write an empty report and exit 0 —
+            // where legacy's equivalent failure records
+            // `.missingInvocationRecord` and reaches exit 3. Returning nil
+            // routes it to the same fault.
+            //
+            // The general rule, which every reader follows: a structurally
+            // empty but successfully decoded read is a failure. Decoding
+            // succeeding is not evidence that the bundle had content.
+            let devices = tests.devices ?? []
+            guard !devices.isEmpty else {
+                Logger.warning("No destinations reported for \(client.bundleDescription)")
+                return nil
+            }
+
+            // One run per destination, matching legacy's one-run-per-ActionRecord.
+            return ParsedResult(runs: devices.map { device in
+                ParsedRun(
+                    destination: ParsedDestination(
+                        displayName: device.deviceName ?? "",
+                        deviceIdentifier: device.deviceId ?? "",
+                        modelName: device.modelName ?? "",
+                        operatingSystemVersion: device.osVersion ?? ""
+                    ),
+                    // The action log has no reference id in the new format;
+                    // the payload store forwards this to `get log --type`.
+                    logReference: "action",
+                    testables: testables(on: device, from: tests)
+                )
+            })
+        } catch {
+            Logger.warning("Modern reader failed: \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    // MARK: Private
+
+    private static let bundleNodeTypes: Set<String> = [
+        "UI test bundle", "Unit test bundle",
+    ]
+
+    /// The test tree as it ran on one destination.
+    ///
+    /// With a single destination — every fixture in this suite — this is the
+    /// whole tree. With several, the tree must be filtered to the device,
+    /// because `ParsedRun` is per-destination and duplicating the full tree
+    /// under each run doubles every header total.
+    ///
+    /// `Device` is itself a `TestNodeType`, so a multi-destination document
+    /// nests device nodes inside the tree. **Verify the shape against a real
+    /// two-destination bundle before implementing this** — no fixture here
+    /// produces one, and the single-destination case (no `Device` nodes,
+    /// return the tree as-is) is the only shape confirmed on Xcode 26.2.
+    private func testables(
+        on _: TestResultsDevice,
+        from tests: TestResultsTests
+    ) -> [ParsedTestable] {
+        (tests.testNodes ?? [])
+            .flatMap { $0.children ?? [] }
+            .filter { Self.bundleNodeTypes.contains($0.nodeType ?? "") }
+            .map { bundle in
+                ParsedTestable(
+                    targetName: bundle.name ?? "",
+                    groups: (bundle.children ?? []).map(parseGroup)
+                )
+            }
+    }
+
+    private func parseGroup(_ node: TestNode) -> ParsedGroup {
+        let children: [ParsedNode] = (node.children ?? []).compactMap { child in
+            switch child.nodeType {
+            case "Test Case": return .testCase(parseTestCase(child))
+            case "Test Suite": return .group(parseGroup(child))
+            default: return nil
+            }
+        }
+        return ParsedGroup(
+            name: node.name ?? "---group-name-not-found---",
+            identifier: node.nodeIdentifier ?? node.name ?? "---group-identifier-not-found---",
+            // `durationInSeconds` is null on every Test Suite, Test Plan and
+            // *test bundle node in all three fixtures, so this is always 0 for
+            // groups while legacy reports a real value. Not a bug to fix here —
+            // the format does not carry it — but it is why `durations` is an
+            // allow-list entry. Do not synthesise a sum of children: that would
+            // be a fabricated number, and it would make the two backends agree
+            // by inventing data rather than by sharing it.
+            duration: node.durationInSeconds ?? 0,
+            children: children
+        )
+    }
+
+    private func parseTestCase(_ node: TestNode) -> ParsedTestCase {
+        let repetitions = (node.children ?? []).filter { $0.nodeType == "Repetition" }
+        let identifier = node.nodeIdentifier ?? ""
+
+        let iterations: [ParsedIteration]
+        if repetitions.isEmpty {
+            iterations = [ParsedIteration(
+                iterationNumber: nil,
+                status: Self.status(node.result),
+                duration: node.durationInSeconds ?? 0,
+                activities: mergingFailureMessages(
+                    failureMessages(of: node),
+                    into: activities(for: identifier, iteration: nil)
+                )
+            )]
+        } else {
+            // The parent node's own `result` summarises the retries and is not
+            // the legacy status: a test that failed then passed reports
+            // "Passed" here while legacy reports mixed. Derive from children.
+            iterations = repetitions.enumerated().map { index, repetition in
+                ParsedIteration(
+                    iterationNumber: repetition.nodeIdentifier.flatMap(Int.init)
+                        ?? (index + 1),
+                    status: Self.status(repetition.result),
+                    duration: repetition.durationInSeconds ?? 0,
+                    activities: mergingFailureMessages(
+                        failureMessages(of: repetition),
+                        into: activities(for: identifier, iteration: index)
+                    )
+                )
+            }
+        }
+
+        return ParsedTestCase(
+            name: node.name ?? "",
+            identifier: identifier,
+            arguments: Self.arguments(of: node),
+            iterations: iterations
+        )
+    }
+
+    private func failureMessages(of node: TestNode) -> [String] {
+        (node.children ?? [])
+            .filter { $0.nodeType == "Failure Message" }
+            .compactMap(\.name)
+    }
+
+    /// Joins the tests document's `Failure Message` nodes onto the activity
+    /// tree.
+    ///
+    /// Both documents describe the same failure, each holding half of it. The
+    /// `Failure Message` node keeps the `file:line` prefix
+    /// (`"FirstSuite.swift:86: XCTAssertTrue failed - Test failed"`) but has
+    /// no timestamp; the activities document reports the failure as a
+    /// failure-flagged activity row — positioned and timestamped, nested
+    /// inside the user's own activity when the assertion fired there — but
+    /// drops the prefix. Sourcing titles from activities loses `file:line`
+    /// everywhere; appending messages unconditionally renders two rows per
+    /// failure.
+    ///
+    /// So: each message claims the first failure-flagged activity — pre-order,
+    /// document order, first-unmatched-first, which pairs repeated identical
+    /// assertions deterministically — whose title is an exact suffix of the
+    /// message, and that activity is retitled with the message as given,
+    /// keeping its position, nesting, start, attachments and children. The
+    /// string is never parsed apart: rebuilding `fileName`/`lineNumber` from
+    /// it would put visible UI on an inferred parse of a format Apple can
+    /// reformat without notice (see the spec's "Failure location").
+    ///
+    /// Messages that match nothing still append as failure rows at the end —
+    /// skip reasons and expected-failure notes ride the same node type, and
+    /// their activity twins are not failure-flagged, so they have no row to
+    /// claim and no timestamp to interleave on.
+    private func mergingFailureMessages(
+        _ messages: [String],
+        into activities: [ParsedActivity]
+    ) -> [ParsedActivity] {
+        guard !messages.isEmpty else {
+            return activities
+        }
+
+        var candidates: [(path: [Int], title: String)] = []
+        func collect(_ activities: [ParsedActivity], _ prefix: [Int]) {
+            for (index, activity) in activities.enumerated() {
+                let path = prefix + [index]
+                if activity.isFailure, !activity.title.isEmpty {
+                    candidates.append((path, activity.title))
+                }
+                collect(activity.subActivities, path)
+            }
+        }
+        collect(activities, [])
+
+        var retitles: [[Int]: String] = [:]
+        var appended: [ParsedActivity] = []
+        for message in messages {
+            if let match = candidates.first(where: {
+                retitles[$0.path] == nil && message.hasSuffix($0.title)
+            }) {
+                retitles[match.path] = message
+            } else {
+                appended.append(ParsedActivity(
+                    title: message,
+                    isFailure: true,
+                    start: nil,
+                    attachments: [],
+                    subActivities: []
+                ))
+            }
+        }
+
+        func rebuild(_ activities: [ParsedActivity], _ prefix: [Int]) -> [ParsedActivity] {
+            activities.enumerated().map { index, activity in
+                let path = prefix + [index]
+                return ParsedActivity(
+                    title: retitles[path] ?? activity.title,
+                    isFailure: activity.isFailure,
+                    start: activity.start,
+                    attachments: activity.attachments,
+                    subActivities: rebuild(activity.subActivities, path)
+                )
+            }
+        }
+        return (retitles.isEmpty ? activities : rebuild(activities, [])) + appended
+    }
+
+    /// One `activities` subprocess per exact test-case id — suite and bundle
+    /// ids are rejected by the tool, so there is nothing to batch. `testRuns`
+    /// holds one entry per repetition, in order.
+    private func activities(for identifier: String, iteration: Int?) -> [ParsedActivity] {
+        guard !identifier.isEmpty else {
+            return []
+        }
+        do {
+            let document = try client.json(
+                ["get", "test-results", "activities", "--test-id", identifier],
+                as: TestActivities.self
+            )
+            let runs = document.testRuns ?? []
+            let run: TestActivities.TestRun? = iteration
+                .flatMap { index in runs.indices.contains(index) ? runs[index] : nil }
+                ?? runs.first
+            return (run?.activities ?? []).map(parseActivity)
+        } catch {
+            // A failed activities query is a genuine read failure, not a
+            // format limitation: the test renders with no activities at all.
+            // Without a fault the CLI would exit 0 on a visibly gutted report.
+            Logger.warning("Can't read activities for \(identifier): \(error.localizedDescription)")
+            faultCollector.record(.missingActivities, identifier)
+            return []
+        }
+    }
+
+    private func parseActivity(_ node: ActivityNode) -> ParsedActivity {
+        ParsedActivity(
+            title: node.title ?? "",
+            isFailure: node.isAssociatedWithFailure ?? false,
+            start: node.startTime.map { Date(timeIntervalSince1970: $0) },
+            attachments: (node.attachments ?? []).map(parseAttachment),
+            subActivities: (node.childActivities ?? []).map(parseActivity)
+        )
+    }
+
+    private func parseAttachment(_ attachment: ActivityAttachment) -> ParsedAttachment {
+        let exported = attachment.uuid.flatMap { payloadStore?.exportedFileName(uuid: $0) }
+        // Prefer the attachment's own filename; fall back to the exported
+        // file. Both are `<something>.<ext>`, and this matches the order
+        // `LegacyResultReader.filenameExtension(forUTI:filename:)` uses, so
+        // the two backends type attachments identically.
+        let ext = [attachment.name, exported]
+            .compactMap { $0 }
+            .map { ($0 as NSString).pathExtension.lowercased() }
+            .first { !$0.isEmpty }
+        return ParsedAttachment(
+            // `name` in the new format holds what legacy calls `filename`; the
+            // user-supplied name is not exposed. Report it as filename only.
+            name: nil,
+            filename: attachment.name,
+            filenameExtension: ext,
+            payloadReference: attachment.uuid
+        )
+    }
+}

--- a/Sources/XCTestHTMLReportCore/Classes/ResultReading/Modern/XCResultToolClient.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/ResultReading/Modern/XCResultToolClient.swift
@@ -23,7 +23,7 @@ public enum LegacyCapability {
 
 // MARK: - XCResultToolError
 
-enum XCResultToolError: Error, CustomStringConvertible {
+enum XCResultToolError: Error, CustomStringConvertible, LocalizedError {
     case executionFailed(arguments: [String], status: Int32, stderr: String)
     case decodingFailed(arguments: [String], underlying: Error)
 
@@ -36,6 +36,13 @@ enum XCResultToolError: Error, CustomStringConvertible {
         case let .decodingFailed(arguments, underlying):
             return "Could not decode xcresulttool \(arguments.joined(separator: " ")): \(underlying)"
         }
+    }
+
+    /// Faults and log lines surface these through `localizedDescription`,
+    /// which without this conformance is the generic "The operation couldn't
+    /// be completed" instead of the diagnosis above.
+    var errorDescription: String? {
+        description
     }
 }
 

--- a/Tests/XCTestHTMLReportTests/AttachmentTypeTests.swift
+++ b/Tests/XCTestHTMLReportTests/AttachmentTypeTests.swift
@@ -1,0 +1,60 @@
+//
+//  AttachmentTypeTests.swift
+//
+
+import XCTest
+@testable import XCTestHTMLReportCore
+
+final class AttachmentTypeTests: XCTestCase {
+    func testMapsExtensionsToTypes() {
+        XCTAssertEqual(AttachmentType(filenameExtension: "png"), .png)
+        XCTAssertEqual(AttachmentType(filenameExtension: "PNG"), .png)
+        XCTAssertEqual(AttachmentType(filenameExtension: "jpeg"), .jpeg)
+        XCTAssertEqual(AttachmentType(filenameExtension: "jpg"), .jpeg)
+        XCTAssertEqual(AttachmentType(filenameExtension: "mp4"), .mp4)
+        XCTAssertEqual(AttachmentType(filenameExtension: "txt"), .text)
+        XCTAssertEqual(AttachmentType(filenameExtension: "log"), .log)
+        XCTAssertEqual(AttachmentType(filenameExtension: "html"), .html)
+        XCTAssertEqual(AttachmentType(filenameExtension: "htm"), .html)
+        XCTAssertEqual(AttachmentType(filenameExtension: "gif"), .gif)
+        XCTAssertEqual(AttachmentType(filenameExtension: "heic"), .heic)
+        XCTAssertEqual(AttachmentType(filenameExtension: "zip"), .zip)
+        XCTAssertEqual(AttachmentType(filenameExtension: "dat"), .data)
+    }
+
+    /// Both readers must land on the same type for the same attachment, which
+    /// is what answer 4 of the design spec bought. No fixture assertion
+    /// catches one drifting, because they run against different documents.
+    func testLegacyUTIsAndModernFilenamesAgree() {
+        let cases: [(uti: String, filename: String)] = [
+            ("public.png", "shot_0_ABC.png"),
+            ("public.jpeg", "shot_0_ABC.jpeg"),
+            ("public.heic", "shot_0_ABC.heic"),
+            ("com.compuserve.gif", "anim_0_ABC.gif"),
+            ("public.mpeg-4", "rec_0_ABC.mp4"),
+            ("public.plain-text", "log_0_ABC.txt"),
+            ("com.apple.log", "log_0_ABC.log"),
+            ("public.html", "page_0_ABC.html"),
+            ("public.zip-archive", "bundle_0_ABC.zip"),
+            ("public.data", "blob_0_ABC.dat"),
+        ]
+        for (uti, filename) in cases {
+            let viaLegacy = LegacyResultReader
+                .filenameExtension(forUTI: uti, filename: nil)
+                .flatMap(AttachmentType.init(filenameExtension:))
+            let viaModern = AttachmentType(
+                filenameExtension: (filename as NSString).pathExtension
+            )
+            XCTAssertNotNil(viaModern, "\(filename) typed as unknown")
+            XCTAssertEqual(viaLegacy, viaModern, "\(uti) vs \(filename)")
+        }
+    }
+
+    /// An unrecognised or absent extension fails the initializer, which
+    /// `Attachment.init` maps to `.unknown` — the same degradation the legacy
+    /// UTI path produced for an unknown identifier.
+    func testUnrecognisedExtensionIsNotTyped() {
+        XCTAssertNil(AttachmentType(filenameExtension: "xyz"))
+        XCTAssertNil(AttachmentType(filenameExtension: ""))
+    }
+}

--- a/Tests/XCTestHTMLReportTests/CoreTests.swift
+++ b/Tests/XCTestHTMLReportTests/CoreTests.swift
@@ -78,11 +78,14 @@ final class CoreTests: XCTestCase {
             // because a run still depends on the simulator behaving, and an
             // exact split would measure that rather than this project.
             //
-            // 17 = 14 XCTest methods + 3 Swift Testing `@Test` functions in
-            // SwiftTestingSuite (SampleAppUnitTests target). The 14th is
-            // FirstSuite.testAttachScreenshot, added by #393 to give the image
-            // rendering path a fixture.
-            XCTAssertEqual(all, 17, "One row per test method; fixed by the sample sources")
+            // 18 = 14 XCTest methods + 4 Swift Testing `@Test` functions in
+            // SwiftTestingSuite (SampleAppUnitTests target). The 14th XCTest
+            // method is FirstSuite.testAttachScreenshot, added by #393 to give
+            // the image rendering path a fixture; the 4th `@Test` is
+            // parameterizedAddition, added by the xcresulttool migration
+            // (Task 8) to exercise `Arguments` nodes — its three argument sets
+            // merge into one row, exactly like repetitions.
+            XCTAssertEqual(all, 18, "One row per test method; fixed by the sample sources")
             XCTAssertEqual(
                 skipped,
                 1,

--- a/Tests/XCTestHTMLReportTests/LegacyResultReaderTests.swift
+++ b/Tests/XCTestHTMLReportTests/LegacyResultReaderTests.swift
@@ -93,6 +93,13 @@ final class LegacyResultReaderTests: XCTestCase {
             ),
             "png"
         )
+        // `public.data` is a raw value of `AttachmentType`, so an
+        // extensionless attachment carrying it must keep typing as `.data`
+        // rather than degrading to `.unknown` for want of a table entry.
+        XCTAssertEqual(
+            LegacyResultReader.filenameExtension(forUTI: "public.data", filename: nil),
+            "dat"
+        )
         XCTAssertNil(
             LegacyResultReader.filenameExtension(forUTI: nil, filename: nil)
         )

--- a/Tests/XCTestHTMLReportTests/ModernPayloadStoreTests.swift
+++ b/Tests/XCTestHTMLReportTests/ModernPayloadStoreTests.swift
@@ -1,0 +1,90 @@
+//
+//  ModernPayloadStoreTests.swift
+//
+
+import XCTest
+@testable import XCTestHTMLReportCore
+
+final class ModernPayloadStoreTests: XCTestCase {
+    private func store(for resource: String) throws -> (ModernPayloadStore, URL) {
+        let source = try XCTUnwrap(
+            Bundle.testBundle.url(forResource: resource, withExtension: "xcresult")
+        )
+        // Copy: the store writes exported payloads into the bundle directory.
+        let copy = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathComponent(source.lastPathComponent)
+        try FileManager.default.createDirectory(
+            at: copy.deletingLastPathComponent(), withIntermediateDirectories: true
+        )
+        try FileManager.default.copyItem(at: source, to: copy)
+        return (
+            ModernPayloadStore(
+                client: XCResultToolClient(bundleURL: copy),
+                bundleURL: copy,
+                faultCollector: FaultCollector()
+            ),
+            copy
+        )
+    }
+
+    private func firstAttachmentUUID(in bundle: URL) throws -> String {
+        let document = try XCResultToolClient(bundleURL: bundle).json(
+            [
+                "get", "test-results", "activities",
+                "--test-id", "FirstSuite/testAttachHtmlData()",
+            ],
+            as: TestActivities.self
+        )
+        return try XCTUnwrap(
+            document.testRuns?.first?.activities?
+                .compactMap { $0.attachments?.first?.uuid }.first
+        )
+    }
+
+    func testResolvesExportedFileNameByUUID() throws {
+        let (store, bundle) = try store(for: "TestResults")
+        let uuid = try firstAttachmentUUID(in: bundle)
+        let name = try XCTUnwrap(store.exportedFileName(uuid: uuid))
+        XCTAssertTrue(name.hasPrefix(uuid), "Exported file is named after the uuid")
+        XCTAssertTrue(name.hasSuffix(".html"))
+    }
+
+    func testExportPayloadWritesNonEmptyFileIntoBundle() throws {
+        let (store, bundle) = try store(for: "TestResults")
+        let uuid = try firstAttachmentUUID(in: bundle)
+        let relative = try XCTUnwrap(
+            store.exportPayload(reference: uuid, fileName: "attached.html")
+        )
+        let written = bundle.appendingPathComponent(relative.lastPathComponent)
+        let data = try Data(contentsOf: written)
+        XCTAssertFalse(data.isEmpty)
+        XCTAssertTrue(
+            String(decoding: data, as: UTF8.self).contains("Sample attachment body")
+        )
+    }
+
+    func testExportPayloadDataReturnsTheBytes() throws {
+        let (store, bundle) = try store(for: "TestResults")
+        let uuid = try firstAttachmentUUID(in: bundle)
+        let data = try XCTUnwrap(store.exportPayloadData(reference: uuid))
+        XCTAssertTrue(
+            String(decoding: data, as: UTF8.self).contains("Sample attachment body")
+        )
+    }
+
+    func testUnknownReferenceReturnsNil() throws {
+        let (store, _) = try store(for: "SanityResults")
+        XCTAssertNil(store.exportPayload(reference: "not-a-uuid", fileName: nil))
+    }
+
+    func testActionLogExportsNextToTheBundle() throws {
+        let (store, bundle) = try store(for: "SanityResults")
+        // "action" is the fixed log reference the modern reader emits; the
+        // store forwards it to `xcresulttool get log --type action`.
+        let relative = try XCTUnwrap(store.exportLogs(reference: "action"))
+        let written = bundle.appendingPathComponent(relative.lastPathComponent)
+        let text = try String(contentsOf: written, encoding: .utf8)
+        XCTAssertFalse(text.isEmpty)
+    }
+}

--- a/Tests/XCTestHTMLReportTests/ModernResultReaderTests.swift
+++ b/Tests/XCTestHTMLReportTests/ModernResultReaderTests.swift
@@ -1,0 +1,325 @@
+//
+//  ModernResultReaderTests.swift
+//
+
+import XCTest
+@testable import XCTestHTMLReportCore
+
+final class ModernResultReaderTests: XCTestCase {
+    // MARK: - Helpers
+
+    private func read(_ resource: String) throws -> ParsedResult {
+        let url = try XCTUnwrap(
+            Bundle.testBundle.url(forResource: resource, withExtension: "xcresult")
+        )
+        let reader = ModernResultReader(
+            client: XCResultToolClient(bundleURL: url),
+            payloadStore: nil,
+            faultCollector: FaultCollector()
+        )
+        return try XCTUnwrap(reader.read())
+    }
+
+    private func testCases(in result: ParsedResult) -> [ParsedTestCase] {
+        func walk(_ node: ParsedNode) -> [ParsedTestCase] {
+            switch node {
+            case let .group(group): return group.children.flatMap(walk)
+            case let .testCase(testCase): return [testCase]
+            }
+        }
+        return result.runs
+            .flatMap(\.testables)
+            .flatMap(\.groups)
+            .flatMap { $0.children.flatMap(walk) }
+    }
+
+    private func flattened(_ activities: [ParsedActivity]) -> [ParsedActivity] {
+        activities.flatMap { [$0] + flattened($0.subActivities) }
+    }
+
+    // MARK: - Tree, status, iterations
+
+    func testRepetitionsBecomeIterationsAndParentResultIsIgnored() throws {
+        let retried = try XCTUnwrap(
+            try testCases(in: read("RetryResults"))
+                .first { $0.identifier == "RetryTests/testRetryOnFailure()" }
+        )
+        // The Test Case node says "Passed". Legacy reports mixed. Taking the
+        // parent result here would silently turn a mixed test green.
+        XCTAssertEqual(retried.iterations.count, 2)
+        XCTAssertEqual(retried.iterations.map(\.iterationNumber), [1, 2])
+        XCTAssertEqual(retried.iterations.map(\.status), [.failed, .passed])
+    }
+
+    func testStatusesMapIntoTheNeutralEnum() throws {
+        let cases = try testCases(in: read("TestResults"))
+        func status(_ identifier: String) throws -> ParsedStatus {
+            try XCTUnwrap(cases.first { $0.identifier == identifier })
+                .iterations[0].status
+        }
+        XCTAssertEqual(try status("FirstSuite/testOne()"), .passed)
+        XCTAssertEqual(try status("FirstSuite/testTwo()"), .failed)
+        XCTAssertEqual(try status("SampleAppUnitTests/testSkipped()"), .skipped)
+
+        // Both readers must agree on the vocabulary, which is the whole point
+        // of the enum: no fixture assertion can catch one reader drifting.
+        XCTAssertEqual(ModernResultReader.status("Passed"), LegacyResultReader.status("Success"))
+        XCTAssertEqual(ModernResultReader.status("Failed"), LegacyResultReader.status("Failure"))
+        XCTAssertEqual(ModernResultReader.status("Skipped"), LegacyResultReader.status("Skipped"))
+        XCTAssertEqual(
+            ModernResultReader.status("Expected Failure"),
+            LegacyResultReader.status("Expected Failure")
+        )
+        // `unknown` is in the published schema but in no fixture.
+        XCTAssertEqual(ModernResultReader.status("unknown"), .unknown)
+        XCTAssertEqual(ModernResultReader.status(nil), .unknown)
+    }
+
+    func testExpectedFailureStillRendersAsUnknown() throws {
+        let unknownState = try XCTUnwrap(
+            try testCases(in: read("RetryResults"))
+                .first { $0.identifier == "RetryTests/testInUnknownState()" }
+        )
+        // The model names the state; the renderer still flattens it to
+        // .unknown, which is what both backends do today. Preserve that
+        // rather than "fixing" it here.
+        XCTAssertEqual(unknownState.iterations[0].status, .expectedFailure)
+        XCTAssertNil(Status(rawValue: "Expected Failure"))
+    }
+
+    func testParameterizedTestCarriesItsArguments() throws {
+        // Requires the parameterized @Test in SwiftTestingSuite. Without that
+        // fixture, `arguments` would be a field no fixture ever populates,
+        // asserted by no test.
+        let parameterized = try XCTUnwrap(
+            try testCases(in: read("TestResults"))
+                .first { $0.identifier.contains("parameterizedAddition") },
+            "No parameterized test in the fixture — see Task 8 of the migration plan"
+        )
+        XCTAssertEqual(
+            parameterized.arguments.sorted(), ["1", "2", "3"],
+            "Arguments nodes exist in the bundle but did not reach the model"
+        )
+    }
+
+    func testTreeIsFlatWithoutLegacyWrapperGroups() throws {
+        let result = try read("TestResults")
+        let targets = result.runs.flatMap(\.testables).map(\.targetName).sorted()
+        XCTAssertEqual(targets, ["SampleAppUITests", "SampleAppUnitTests"])
+
+        let groupNames = result.runs
+            .flatMap(\.testables)
+            .flatMap(\.groups)
+            .map(\.name)
+        // Deliberately flat: no "Selected tests" / "All tests" / "*.xctest".
+        XCTAssertFalse(groupNames.contains("Selected tests"))
+        XCTAssertFalse(groupNames.contains("All tests"))
+        XCTAssertTrue(groupNames.contains("FirstSuite"))
+        XCTAssertTrue(groupNames.contains("SwiftTestingSuite"))
+    }
+
+    // MARK: - Failure text: file:line from the tests document
+
+    /// The activities document reports each assertion failure as an activity
+    /// row but drops the `file:line` prefix; the tests document's `Failure
+    /// Message` node keeps it. The reader joins the two — message text onto
+    /// the activity row's position — so losing either half is a regression.
+    func testFailureTitlesKeepFileAndLineFromTheTestsDocument() throws {
+        let failing = try XCTUnwrap(
+            try testCases(in: read("TestResults"))
+                .first { $0.identifier == "FirstSuite/testTwo()" }
+        )
+        let rows = flattened(failing.iterations[0].activities)
+            .filter { $0.title.hasSuffix("XCTAssertTrue failed - Test failed") }
+
+        XCTAssertEqual(
+            rows.count, 1,
+            "The same failure must not render as both the activity row and an appended message row"
+        )
+        let row = try XCTUnwrap(rows.first)
+        XCTAssertTrue(
+            row.title.hasPrefix("FirstSuite.swift:"),
+            "Failure text must come from the Failure Message node, which keeps file:line — got '\(row.title)'"
+        )
+        XCTAssertTrue(row.isFailure)
+        XCTAssertNotNil(
+            row.start,
+            "The retitled row keeps the activity's own timestamp and position"
+        )
+    }
+
+    /// The retried test's assertion fires inside the user's own activity, so
+    /// the activities document nests the failure row. The join must retitle it
+    /// in place — nested, positioned, timestamped — not append a duplicate.
+    func testNestedRetryFailureIsRetitledInPlace() throws {
+        let retried = try XCTUnwrap(
+            try testCases(in: read("RetryResults"))
+                .first { $0.identifier == "RetryTests/testRetryOnFailure()" }
+        )
+        let firstAttempt = retried.iterations[0]
+        let wrapper = try XCTUnwrap(
+            firstAttempt.activities.first { $0.title == "Retryable Activity" },
+            "The user-created activity must survive translation"
+        )
+        let nested = try XCTUnwrap(
+            flattened(wrapper.subActivities).first { $0.isFailure },
+            "The failure row stays nested under the activity it fired in"
+        )
+        XCTAssertTrue(
+            nested.title.hasPrefix("RetryTests.swift:"),
+            "Nested failure rows are retitled from the Failure Message node too — got '\(nested.title)'"
+        )
+        // And nothing appended a second copy at the top level.
+        XCTAssertEqual(
+            flattened(firstAttempt.activities).filter { $0.title.hasSuffix(": failed") }.count,
+            1
+        )
+    }
+
+    /// Failure Messages with no matching activity row — skip reasons and
+    /// expected-failure notes, whose activity rows are not failure-flagged —
+    /// still append, or the reason never reaches the report at all.
+    func testSkipReasonAppendsWhenNoActivityRowMatches() throws {
+        let skipped = try XCTUnwrap(
+            try testCases(in: read("TestResults"))
+                .first { $0.identifier == "SampleAppUnitTests/testSkipped()" }
+        )
+        XCTAssertTrue(
+            skipped.iterations[0].activities
+                .contains { $0.isFailure && $0.title.contains("Test skipped") },
+            "The skip reason rides a Failure Message node with no activity twin"
+        )
+    }
+
+    // MARK: - Fault discipline
+
+    /// A failed activities query degrades to an empty activity list. That is
+    /// only acceptable because it is *reported*: without the fault the CLI
+    /// exits 0 on a report whose tests have no activities at all.
+    func testFailedActivitiesQueryRecordsAFault() throws {
+        let url = try XCTUnwrap(
+            Bundle.testBundle.url(forResource: "SanityResults", withExtension: "xcresult")
+        )
+
+        // Passes everything through to the real tool except `activities`,
+        // which always fails.
+        struct ActivitiesFailingClient: XCResultToolInvoking {
+            let wrapped: XCResultToolClient
+
+            var bundleDescription: String {
+                wrapped.bundleDescription
+            }
+
+            func run(_ arguments: [String]) throws -> Data {
+                try wrapped.run(arguments)
+            }
+
+            func json<T: Decodable>(_ arguments: [String], as type: T.Type) throws -> T {
+                if arguments.contains("activities") {
+                    throw XCResultToolError.executionFailed(
+                        arguments: arguments, status: 1, stderr: "injected failure"
+                    )
+                }
+                return try wrapped.json(arguments, as: type)
+            }
+        }
+
+        let collector = FaultCollector()
+        let reader = ModernResultReader(
+            client: ActivitiesFailingClient(wrapped: XCResultToolClient(bundleURL: url)),
+            payloadStore: nil,
+            faultCollector: collector
+        )
+        let result = try XCTUnwrap(reader.read())
+
+        // The read still succeeds — degraded, not aborted.
+        XCTAssertFalse(testCases(in: result).isEmpty)
+        XCTAssertTrue(
+            collector.faults.contains { $0.kind == .missingActivities },
+            "A failed activities query must be reported, not swallowed"
+        )
+    }
+
+    /// A decodable document with no destinations is a failed read, not an
+    /// empty report: nil routes it to `.missingInvocationRecord` and exit 3,
+    /// exactly like the legacy reader's no-runs case.
+    func testEmptyButDecodableDocumentReadsAsNil() throws {
+        struct EmptyDocumentClient: XCResultToolInvoking {
+            var bundleDescription: String {
+                "Empty.xcresult"
+            }
+
+            func run(_: [String]) throws -> Data {
+                Data("{\"devices\":[],\"testNodes\":[]}".utf8)
+            }
+
+            func json<T: Decodable>(_ arguments: [String], as type: T.Type) throws -> T {
+                try JSONDecoder().decode(type, from: run(arguments))
+            }
+        }
+
+        let reader = ModernResultReader(
+            client: EmptyDocumentClient(),
+            payloadStore: nil,
+            faultCollector: FaultCollector()
+        )
+        XCTAssertNil(reader.read())
+    }
+
+    /// The trap the spec names: fields the modern backend structurally cannot
+    /// provide — attachment display names, activity types, suite durations,
+    /// finish times — must never fault. A full modern-path render of every
+    /// fixture, attachments and logs included, has to come out clean, or
+    /// every modern run exits 3.
+    func testModernRenderOfEveryFixtureRecordsNoFaults() throws {
+        for resource in ["TestResults", "SanityResults", "RetryResults"] {
+            let source = try XCTUnwrap(
+                Bundle.testBundle.url(forResource: resource, withExtension: "xcresult")
+            )
+            // Copy: rendering in linking mode writes payloads and logs into
+            // the bundle directory.
+            let copy = URL(fileURLWithPath: NSTemporaryDirectory())
+                .appendingPathComponent(UUID().uuidString)
+                .appendingPathComponent(source.lastPathComponent)
+            try FileManager.default.createDirectory(
+                at: copy.deletingLastPathComponent(), withIntermediateDirectories: true
+            )
+            try FileManager.default.copyItem(at: source, to: copy)
+
+            let collector = FaultCollector()
+            let client = XCResultToolClient(bundleURL: copy)
+            let store = ModernPayloadStore(
+                client: client, bundleURL: copy, faultCollector: collector
+            )
+            let reader = ModernResultReader(
+                client: client, payloadStore: store, faultCollector: collector
+            )
+            let parsed = try XCTUnwrap(reader.read(), "\(resource) must read")
+
+            let runs = parsed.runs.enumerated().compactMap { index, run in
+                Run(
+                    run: run,
+                    identifierPath: IdentifierPath.root
+                        .appending("bundle0")
+                        .appending("action\(index)"),
+                    file: store,
+                    renderingMode: .linking,
+                    downsizeImagesEnabled: false,
+                    downsizeScaleFactor: 1
+                )
+            }
+            XCTAssertFalse(runs.isEmpty, "\(resource) must render at least one run")
+
+            let unresolved = runs.flatMap(\.allAttachments).filter(\.failedToResolve)
+            XCTAssertTrue(
+                unresolved.isEmpty,
+                "\(resource): attachments failed to resolve on the modern path: "
+                    + unresolved.map(\.faultDescription).joined(separator: ", ")
+            )
+            XCTAssertTrue(
+                collector.faults.isEmpty,
+                "\(resource): modern render must be fault-free, got \(collector.faults)"
+            )
+        }
+    }
+}

--- a/Tests/XCTestHTMLReportTests/XCResultToolClientTests.swift
+++ b/Tests/XCTestHTMLReportTests/XCResultToolClientTests.swift
@@ -33,6 +33,19 @@ final class XCResultToolClientTests: XCTestCase {
         )
     }
 
+    func testErrorsCarryTheirDescriptionThroughLocalizedError() throws {
+        // Callers surface these through `error.localizedDescription` (Logger,
+        // faults). Without `LocalizedError` that prints the generic
+        // "The operation couldn't be completed" instead of the diagnosis.
+        let error = XCResultToolError.executionFailed(
+            arguments: ["get", "test-results", "tests"],
+            status: 64,
+            stderr: "unknown option"
+        )
+        XCTAssertEqual(error.localizedDescription, error.description)
+        try XCTAssertContains(error.localizedDescription, "exited 64")
+    }
+
     func testLegacyAvailabilityIsDetectable() {
         // Not asserting a value: it is true on today's toolchains and false
         // once Apple removes the legacy commands. Asserting either would make

--- a/XCTestHTMLReportSampleApp/SampleAppUnitTests/SwiftTestingSuite.swift
+++ b/XCTestHTMLReportSampleApp/SampleAppUnitTests/SwiftTestingSuite.swift
@@ -21,6 +21,14 @@ struct SwiftTestingSuite {
     func taggedMultiplication() {
         #expect(2 * 3 == 6)
     }
+
+    /// Exercises the modern format's `Arguments` nodes, which no other test
+    /// produces — see Task 8 of the xcresulttool migration plan. Without this,
+    /// `ParsedTestCase.arguments` would be a field no fixture populates.
+    @Test(arguments: [1, 2, 3])
+    func parameterizedAddition(value: Int) {
+        #expect(value + 0 == value)
+    }
 }
 
 extension Tag {

--- a/docs/superpowers/plans/2026-08-10-xcresulttool-legacy-migration.md
+++ b/docs/superpowers/plans/2026-08-10-xcresulttool-legacy-migration.md
@@ -2145,7 +2145,33 @@ this path is tested.
 them and **ignore the parent's `result`**. Only a childless Test Case uses its
 own.
 
-- [ ] **Step 1: Write the failing test**
+**Amendment (2026-08-12, PR D) — failure text is a join, not a choice.**
+Measured while executing this task: the activities document carries **every**
+assertion failure as a failure-flagged activity row of its own — positioned,
+timestamped, and *nested* when the assertion fired inside a user activity
+(`RetryResults`' failure is a sub-activity of `Retryable Activity`) — but with
+the `file:line` prefix stripped; the `Failure Message` node keeps the prefix
+but has no timestamp. This task's original anti-double-count guard kept the
+activity row and dropped the message, so the modern render lost `file:line`
+for every failing case — strictly less information than the spec's
+`failureTitlePrefix` entry documents. Coordinator ruling: **join the two
+documents.** Each message claims the first unclaimed failure-flagged activity
+— pre-order, document order, first-unmatched-first — whose title is an exact
+suffix of the message, and retitles it with the message as given, preserving
+position, nesting, `start`, attachments and children; unmatched messages
+(skip reasons, expected-failure notes — their activity twins are not
+failure-flagged) append as before; the string is never regex-parsed apart.
+The snippet below reflects the ruling (`mergingFailureMessages`). Shipped
+tests additionally pin: `file:line` presence on the plain and the nested
+retry case, no duplicate row, skip-reason append, empty-but-decodable → nil,
+and a zero-fault full modern render of all three fixtures.
+
+Two mechanical corrections from the same execution: Task 9 lands **before**
+Task 8 so each commit builds (the reader's `payloadStore` property references
+the store type), and `TestRun` shipped nested as `TestActivities.TestRun` in
+Task 7, so the snippet's type annotation reads accordingly.
+
+- [x] **Step 1: Write the failing test**
 
 ```swift
 //
@@ -2306,7 +2332,7 @@ final class ModernResultReaderTests: XCTestCase {
 }
 ```
 
-- [ ] **Step 2: Run to verify it fails**
+- [x] **Step 2: Run to verify it fails**
 
 ```bash
 swift test --filter ModernResultReaderTests
@@ -2314,7 +2340,7 @@ swift test --filter ModernResultReaderTests
 
 Expected: FAIL — `cannot find 'ModernResultReader' in scope`.
 
-- [ ] **Step 3: Implement the reader**
+- [x] **Step 3: Implement the reader**
 
 ```swift
 //
@@ -2441,62 +2467,81 @@ struct ModernResultReader: ResultReader {
         )
     }
 
-    /// `Failure Message` children carry `File.swift:66: message`, which the
-    /// activities document does not — its titles drop the file and line
-    /// entirely. Measured on `TestResults`: the tests tree gives
-    /// `"FirstSuite.swift:66: XCTAssertTrue failed - Test failed"` where
-    /// activities gives only `"XCTAssertTrue failed - Test failed"`. Sourcing
-    /// failures from here is strictly closer to legacy, which formats
-    /// `"<issueType> at <file>:<line>:<message>"`.
+    /// Joins the tests document's `Failure Message` nodes onto the activity
+    /// tree. (Amended 2026-08-12 — see the amendment note above; the original
+    /// guard kept the activity row's title and lost `file:line`.)
     ///
-    /// Skipped tests use the same node (`"Test skipped - Test skipped"`).
-    /// Failure rows from the `tests` document, **minus any the activities
-    /// document already supplied**.
+    /// Both documents describe the same failure, each holding half of it. The
+    /// `Failure Message` node keeps the `file:line` prefix
+    /// (`"FirstSuite.swift:86: XCTAssertTrue failed - Test failed"`) but has
+    /// no timestamp; the activities document reports the failure as a
+    /// failure-flagged activity row — positioned and timestamped, nested
+    /// inside the user's own activity when the assertion fired there — but
+    /// drops the prefix. Sourcing titles from activities loses `file:line`
+    /// everywhere; appending messages unconditionally renders two rows per
+    /// failure.
     ///
-    /// Both documents describe the same failure. On `FirstSuite/testTwo()` the
-    /// activities document carries `"XCTAssertTrue failed - Test failed"` with
-    /// `isAssociatedWithFailure: true`, and the tests document carries
-    /// `"FirstSuite.swift:86: XCTAssertTrue failed - Test failed"`. Appending
-    /// both unconditionally renders **two failure rows for every failing
-    /// test** — and the extra row is not something `failureTitlePrefix` can
-    /// mask, because it is a whole element rather than a prefix.
-    ///
-    /// Task 4 carries an explicit anti-double-count guard for the legacy
-    /// equivalent (`if activities.contains(where: hasFailure)`); this is its
-    /// counterpart. Matching is on the message tail, since the tests document
-    /// prefixes `<file>:<line>: ` and the activities document does not.
-    private func failureActivities(
-        _ node: TestNode,
-        existing: [ParsedActivity]
+    /// So: each message claims the first failure-flagged activity — pre-order,
+    /// document order, first-unmatched-first, which pairs repeated identical
+    /// assertions deterministically — whose title is an exact suffix of the
+    /// message, and that activity is retitled with the message as given,
+    /// keeping its position, nesting, start, attachments and children. The
+    /// string is never parsed apart. Messages that match nothing (skip
+    /// reasons, expected-failure notes) append as failure rows at the end.
+    private func mergingFailureMessages(
+        _ messages: [String],
+        into activities: [ParsedActivity]
     ) -> [ParsedActivity] {
-        func tail(_ text: String) -> String {
-            // Strip a leading `<file>.swift:<line>: ` if present.
-            guard let range = text.range(
-                of: #"^[\w.+-]+:\d+:\s*"#, options: .regularExpression
-            ) else {
-                return text
-            }
-            return String(text[range.upperBound...])
+        guard !messages.isEmpty else {
+            return activities
         }
-        func alreadyPresent(_ activities: [ParsedActivity], _ needle: String) -> Bool {
-            activities.contains { activity in
-                (activity.isFailure && tail(activity.title) == needle)
-                    || alreadyPresent(activity.subActivities, needle)
+
+        var candidates: [(path: [Int], title: String)] = []
+        func collect(_ activities: [ParsedActivity], _ prefix: [Int]) {
+            for (index, activity) in activities.enumerated() {
+                let path = prefix + [index]
+                if activity.isFailure, !activity.title.isEmpty {
+                    candidates.append((path, activity.title))
+                }
+                collect(activity.subActivities, path)
+            }
+        }
+        collect(activities, [])
+
+        var retitles: [[Int]: String] = [:]
+        var appended: [ParsedActivity] = []
+        for message in messages {
+            if let match = candidates.first(where: {
+                retitles[$0.path] == nil && message.hasSuffix($0.title)
+            }) {
+                retitles[match.path] = message
+            } else {
+                appended.append(ParsedActivity(
+                    title: message, isFailure: true, start: nil,
+                    attachments: [], subActivities: []
+                ))
             }
         }
 
-        return (node.children ?? [])
-            .filter { $0.nodeType == "Failure Message" }
-            .filter { !alreadyPresent(existing, tail($0.name ?? "")) }
-            .map { message in
-                ParsedActivity(
-                    title: message.name ?? "",
-                    isFailure: true,
-                    start: nil,
-                    attachments: [],
-                    subActivities: []
+        func rebuild(_ activities: [ParsedActivity], _ prefix: [Int]) -> [ParsedActivity] {
+            activities.enumerated().map { index, activity in
+                let path = prefix + [index]
+                return ParsedActivity(
+                    title: retitles[path] ?? activity.title,
+                    isFailure: activity.isFailure,
+                    start: activity.start,
+                    attachments: activity.attachments,
+                    subActivities: rebuild(activity.subActivities, path)
                 )
             }
+        }
+        return (retitles.isEmpty ? activities : rebuild(activities, [])) + appended
+    }
+
+    private func failureMessages(of node: TestNode) -> [String] {
+        (node.children ?? [])
+            .filter { $0.nodeType == "Failure Message" }
+            .compactMap(\.name)
     }
 
     private func parseTestCase(_ node: TestNode) -> ParsedTestCase {
@@ -2505,14 +2550,14 @@ struct ModernResultReader: ResultReader {
 
         let iterations: [ParsedIteration]
         if repetitions.isEmpty {
-            // Activities first, then the failure messages, matching the
-            // legacy reader's ordering of activitySummaries + failureSummaries.
-            let base = activities(for: identifier, iteration: nil)
             iterations = [ParsedIteration(
                 iterationNumber: nil,
                 status: Self.status(node.result),
                 duration: node.durationInSeconds ?? 0,
-                activities: base + failureActivities(node, existing: base)
+                activities: mergingFailureMessages(
+                    failureMessages(of: node),
+                    into: activities(for: identifier, iteration: nil)
+                )
             )]
         } else {
             // The parent node's own `result` summarises the retries and is not
@@ -2524,10 +2569,10 @@ struct ModernResultReader: ResultReader {
                         ?? (index + 1),
                     status: Self.status(repetition.result),
                     duration: repetition.durationInSeconds ?? 0,
-                    activities: {
-                        let base = activities(for: identifier, iteration: index)
-                        return base + failureActivities(repetition, existing: base)
-                    }()
+                    activities: mergingFailureMessages(
+                        failureMessages(of: repetition),
+                        into: activities(for: identifier, iteration: index)
+                    )
                 )
             }
         }
@@ -2589,11 +2634,11 @@ struct ModernResultReader: ResultReader {
                 as: TestActivities.self
             )
             let runs = document.testRuns ?? []
-            // Flattened deliberately: `iteration.map { ... }` already yields
-            // `TestRun?`, so `?? runs.first` produces `TestRun?`, not
+            // Flattened deliberately: `iteration.flatMap { ... }` already
+            // yields `TestRun?`, so `?? runs.first` produces `TestRun?`, not
             // `TestRun??`. Double-chaining here fails to compile with
             // "cannot use optional chaining on non-optional value".
-            let run: TestRun? = iteration
+            let run: TestActivities.TestRun? = iteration
                 .flatMap { index in runs.indices.contains(index) ? runs[index] : nil }
                 ?? runs.first
             return (run?.activities ?? []).map(parseActivity)
@@ -2639,7 +2684,7 @@ struct ModernResultReader: ResultReader {
 }
 ```
 
-- [ ] **Step 4: Run tests to verify they pass**
+- [x] **Step 4: Run tests to verify they pass**
 
 ```bash
 swift test --filter ModernResultReaderTests
@@ -2650,13 +2695,19 @@ Expected: PASS, 6 of 7 tests, with `testParameterizedTestCarriesItsArguments`
 what stops `arguments` from shipping as a field nothing populates and nothing
 checks.
 
+> Execution note (2026-08-12): fixtures are not committed, so a worker starting
+> from a clean checkout regenerates them anyway — applying Step 6's sample-app
+> change *before* the single generation run collapses the 6-of-7 intermediate
+> state, and all tests pass together at this step. The grep in Step 6 still
+> verifies the `Arguments` nodes are real (measured: 3).
+
 If `testRepetitionsBecomeIterations` reports one iteration, `repetitions` is
 not matching — confirm `nodeType` is exactly `"Repetition"`. If
 `testFailedActivitiesQueryRecordsAFault` fails, the collector reaching the
 reader is not the one recording — check that `Summary.init` passes its own
 collector rather than constructing a new one.
 
-- [ ] **Step 6: Give `arguments` a fixture that exercises it**
+- [x] **Step 6: Give `arguments` a fixture that exercises it**
 
 `ParsedTestCase.arguments` is added on the strength of the published schema —
 no bundle in the suite contains an `Arguments` node, because
@@ -2691,7 +2742,7 @@ This is also the first fixture change in the plan, so expect every count-based
 assertion in the existing suite to shift by the number of cases the
 parameterized test contributes. Update those counts from the actual run.
 
-- [ ] **Step 7: Commit**
+- [x] **Step 7: Commit**
 
 ```bash
 swiftformat . && git add Sources/XCTestHTMLReportCore/Classes/ResultReading/Modern/ModernResultReader.swift \
@@ -2724,7 +2775,18 @@ Export lazily, once, on first use. Unlike the legacy path there is no shared
 temp file per id, so no per-id lock is needed — but the one-shot export itself
 must be guarded so concurrent parsing does not run it twice.
 
-- [ ] **Step 1: Write the failing test**
+**Amendment (2026-08-12, PR D).** As built: the store exposes `let url: URL`
+(the bundle directory) because `PayloadProviding` requires it — attachment
+downsizing reconstructs absolute paths from it — so the snippet's private
+`bundleURL` is the protocol property instead. This task's commit lands
+*before* Task 8's so each commit builds. Two tests were added beyond the
+snippet: `exportPayloadData` returns the payload bytes, and the `"action"`
+log reference exports through `get log --type action` (verified to accept the
+client's pinned `--schema-version`, alongside `get test-results` and
+`export attachments` — the #441 review's invocation-shape concern needed no
+client change).
+
+- [x] **Step 1: Write the failing test**
 
 ```swift
 //
@@ -2803,7 +2865,7 @@ final class ModernPayloadStoreTests: XCTestCase {
 }
 ```
 
-- [ ] **Step 2: Run to verify it fails**
+- [x] **Step 2: Run to verify it fails**
 
 ```bash
 swift test --filter ModernPayloadStoreTests
@@ -2811,7 +2873,7 @@ swift test --filter ModernPayloadStoreTests
 
 Expected: FAIL — `cannot find 'ModernPayloadStore' in scope`.
 
-- [ ] **Step 3: Implement the store**
+- [x] **Step 3: Implement the store**
 
 ```swift
 //
@@ -3013,7 +3075,7 @@ Note: remove the duplicated `self.faultCollector` assignment in `init` — it is
 shown above only to flag that the property is assigned once; SwiftLint will
 catch the duplicate.
 
-- [ ] **Step 4: Run tests to verify they pass**
+- [x] **Step 4: Run tests to verify they pass**
 
 ```bash
 swift test --filter ModernPayloadStoreTests
@@ -3021,7 +3083,7 @@ swift test --filter ModernPayloadStoreTests
 
 Expected: PASS, 3 tests.
 
-- [ ] **Step 5: Wire the store into the reader and re-run Task 8's tests**
+- [x] **Step 5: Wire the store into the reader and re-run Task 8's tests**
 
 Pass a real `ModernPayloadStore` where Task 8 passed `nil`.
 
@@ -3031,7 +3093,7 @@ swift test --filter "ModernResultReaderTests|ModernPayloadStoreTests"
 
 Expected: PASS, 7 tests.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 swiftformat . && git add Sources/XCTestHTMLReportCore/Classes/ResultReading/Modern/ModernPayloadStore.swift \
@@ -3069,7 +3131,17 @@ MIME types; the extension mapping follows the same shape, with the explicit
 table below as the floor-safe path. Do not raise the deployment target for
 this.
 
-- [ ] **Step 1: Write the failing test**
+**Amendment (2026-08-12, PR D).** #443 shipped this initializer ahead of
+schedule as a *failable* `init?(filenameExtension:)` (including `"dat"` →
+`.data`), with `Attachment.init` flat-mapping nil to `.unknown` — same
+behaviour, different spelling, kept as landed rather than reshaped to the
+snippet. The tests below were adapted accordingly (unrecognised extensions
+assert `nil`, not `.unknown`). What this PR added on top: the cross-backend
+agreement test, and `public.data` → `"dat"` in the legacy UTI fallback table
+(the #443 review note) so an extensionless `public.data` attachment keeps
+typing `.data` instead of degrading to `.unknown`.
+
+- [x] **Step 1: Write the failing test**
 
 ```swift
 //
@@ -3128,7 +3200,7 @@ final class AttachmentTypeTests: XCTestCase {
 }
 ```
 
-- [ ] **Step 2: Run to verify it fails**
+- [x] **Step 2: Run to verify it fails**
 
 ```bash
 swift test --filter AttachmentTypeTests
@@ -3136,7 +3208,7 @@ swift test --filter AttachmentTypeTests
 
 Expected: FAIL — no such initializer.
 
-- [ ] **Step 3: Implement it**
+- [x] **Step 3: Implement it**
 
 Add to `AttachmentType` in `Attachment.swift`:
 
@@ -3172,7 +3244,7 @@ type = attachment.filenameExtension
 `UTType(rawValue:)` on macOS 11+, so the UTI strings remain useful as the
 enum's identity even though nothing constructs the type from one any more.
 
-- [ ] **Step 4: Run tests to verify they pass**
+- [x] **Step 4: Run tests to verify they pass**
 
 ```bash
 swift test --filter AttachmentTypeTests && swift test 2>&1 | tail -5
@@ -3183,7 +3255,7 @@ Expected: 3 new tests PASS; the full suite stays green. If
 type — fix the mapping rather than allow-listing the difference, since removing
 that allow-list entry is the reason this task exists.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 swiftformat . && git add Sources/XCTestHTMLReportCore/Classes/Models/Attachment.swift \

--- a/docs/superpowers/specs/2026-08-10-xcresulttool-legacy-migration-design.md
+++ b/docs/superpowers/specs/2026-08-10-xcresulttool-legacy-migration-design.md
@@ -406,10 +406,18 @@ equivalent — measured on `TestResults`:
 | `get test-results tests`, `Failure Message` node | `FirstSuite.swift:66: XCTAssertTrue failed - Test failed` |
 | `get test-results activities`, activity title | `XCTAssertTrue failed - Test failed` |
 
-The activities document drops the file and line entirely. The modern reader
-therefore sources failure text from the `Failure Message` nodes, which retain
-it, and appends those to the activity list. Skipped tests carry their reason on
-the same node (`Test skipped - Test skipped`).
+The activities document drops the file and line, **not the failure itself**
+(refined 2026-08-12, from Task 8's execution): it reports every assertion
+failure as a failure-flagged activity row of its own, positioned and
+timestamped, nested inside the user's activity when the assertion fired there
+— only the `file:line` prefix is missing from its title. The modern reader
+therefore *joins* the two documents rather than choosing one: each `Failure
+Message` retitles the first unclaimed failure-flagged activity row whose
+title is an exact suffix of the message (document order,
+first-unmatched-first), keeping the row's position, nesting and timestamp;
+messages with no matching row are appended to the activity list. Skipped
+tests carry their reason on the same node (`Test skipped - Test skipped`) and
+have no failure-flagged row, so they take the append path.
 
 What remains lost is the *structure*: the reader populates the title with the
 string as given and leaves `fileName`/`lineNumber`/`issueType` nil rather than


### PR DESCRIPTION
Part of #391 (milestone 4.0), phase 2 of the migration plan: the modern backend itself. Follows #441 (client + schema) and #443 (the port). The reader is reachable only through direct construction in tests — backend selection is Task 11, the next PR. **Do not expect render changes from this PR**; nothing routes through the new code yet.

## What's here

- **`ModernResultReader`** (Task 8): builds `ParsedResult` from `get test-results`. Statuses map into the neutral enum (`Expected Failure` still flattens to `unknown` downstream, deliberately); multi-repetition status derives from `Repetition` children, ignoring the parent Test Case's own `result` — `RetryResults` reports `Passed` there for a Failed-then-Passed test, so taking it would turn mixed tests green. The tree renders flat (no synthesized `All tests` / `*.xctest` wrappers). One `activities` subprocess per exact test-case id; a failed query records the new `.missingActivities` fault rather than shipping a silently gutted report.
- **`ModernPayloadStore`** (Task 9): one `export attachments` call per bundle + the `manifest.json` join (activity attachment `uuid` ↔ basename of `exportedFileName`). No per-payload subprocess, no lock table — only the one-shot export is guarded. Run logs come from `get log --type action`, rendered from structured `messages` (the format has no `emittedOutput`).
- **Attachment typing** (Task 10): the failable `AttachmentType(filenameExtension:)` landed in #443; this PR adds the cross-backend agreement test and fixes the carried review note — `public.data` was missing from the legacy UTI fallback table, degrading extensionless data attachments to `.unknown`.
- **Review notes from #441/#443**: `XCResultToolError` now conforms to `LocalizedError` (faults and warnings printed NSError boilerplate before); the client's unconditional `--path`/`--schema-version` is verified safe for all three invocation shapes used (`get test-results`, `export attachments`, `get log`) — no client change needed.
- **Sample app**: a parameterized `@Test(arguments: [1, 2, 3])` so `Arguments` nodes stop being fixture-unexercised (measured: 3 nodes in the regenerated fixture). Its argument sets merge into one rendered row; the `TestResults` header total moves 17 → 18 in `CoreTests`.

## Plan deviation, coordinator-approved: failure text is a join

Measured on Xcode 26.2 fixtures: the activities document carries **every assertion failure as a failure-flagged activity row** — positioned, timestamped, nested inside the user's activity when the assertion fired there — with only the `file:line` prefix missing; the tests document's `Failure Message` node keeps the prefix but has no timestamp. The plan's anti-double-count guard kept the activity title and dropped the message, losing `file:line` from every modern failure render — contradicting the spec's `failureTitlePrefix` allow-list entry and the "failure text sources from Failure Message nodes" rule.

As ruled: each message retitles the first unclaimed failure-flagged activity whose title is an exact suffix of the message (document order, first-unmatched-first, recursive so the nested `RetryResults` case retitles in place), keeping position, nesting, timestamp, attachments, and children. Unmatched messages (skip reasons, expected-failure notes) append as before. No regex extraction of file/line — the string renders as given. Plan and spec amended in this PR; regression tests pin `file:line` presence on both the plain and the nested case.

## Fault discipline

`testModernRenderOfEveryFixtureRecordsNoFaults` does a full modern-path render of all three fixtures — reader + store, attachments and logs resolved in linking mode — and asserts **zero faults** and zero unresolved attachments. Structurally absent fields (display names, activity types, suite durations, finish times) never fault; a failed activities query and a failed export still do.

## Verification

- Full suite: **65 tests, 0 failures, 2 pre-existing skips** (#378 JUnit drift, baseline capture) — legacy paths (`LegacyResultReaderTests`, `CoreTests`, `SanityTests`, fault tests) and modern paths (`ModernResultReaderTests` ×11, `ModernPayloadStoreTests` ×5, `AttachmentTypeTests` ×3) both green.
- Fixtures regenerated via `./prepareTestResults.sh` on Xcode 26.2 (17C52), xcresulttool 24514, schema 0.1.0 — the spec's measurement environment.

Refs #391.

🤖 Generated with [Claude Code](https://claude.com/claude-code)