### PR TITLE
Backend selection and the --result-reader flag (#391, Task 11)

### DIFF
--- a/Sources/XCTestHTMLReport/XCTestHtmlReport.swift
+++ b/Sources/XCTestHTMLReport/XCTestHtmlReport.swift
@@ -79,6 +79,14 @@ struct SummaryOptions: ParsableArguments {
         }
         return .linking
     }
+
+    @Option(
+        name: .long,
+        help: ArgumentHelp(
+            "Which result reader to use: auto, legacy, or modern. Defaults to auto, which prefers the legacy reader while the toolchain still supports it."
+        )
+    )
+    var resultReader: ResultBackend = .auto
 }
 
 @main
@@ -131,7 +139,8 @@ struct XCTestHtmlReport: ParsableCommand {
             renderingMode: summaryOptions.finalRenderingMode,
             downsizeImagesEnabled: summaryOptions.downsizeImages,
             downsizeScaleFactor: summaryOptions.downsizeScaleFactor,
-            faultCollector: faultCollector
+            faultCollector: faultCollector,
+            backend: summaryOptions.resultReader
         )
 
         Logger.step("Building HTML..")
@@ -213,8 +222,19 @@ struct XCTestHtmlReport: ParsableCommand {
                 throw ValidationError("Bundle \(result) not found")
             }
         }
+
+        // An explicit `legacy` request the toolchain cannot honour is an
+        // error, never a silent substitution with the modern reader.
+        if case .legacyUnavailable = summaryOptions.resultReader.resolve() {
+            throw ValidationError(
+                "--result-reader legacy was requested, but this toolchain no longer "
+                    + "provides the legacy xcresulttool commands."
+            )
+        }
     }
 }
+
+extension ResultBackend: ExpressibleByArgument {}
 
 extension Summary.RenderingMode: ExpressibleByArgument {
     public init?(argument: String) {

--- a/Sources/XCTestHTMLReportCore/Classes/Helpers/FaultCollector.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Helpers/FaultCollector.swift
@@ -31,6 +31,11 @@ public struct Fault: Equatable {
         /// XCResultKit could not produce a log section, or it could not be
         /// written next to the report. The log is missing from the report.
         case logExportFailed
+        /// An explicit `legacy` reader was requested on a toolchain that no
+        /// longer provides the legacy commands. The report was produced with
+        /// the modern reader instead, which is a different reader than the
+        /// caller asked for.
+        case legacyReaderUnavailable
     }
 
     public let kind: Kind

--- a/Sources/XCTestHTMLReportCore/Classes/Models/Summary.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Models/Summary.swift
@@ -28,18 +28,44 @@ public struct Summary {
         renderingMode: RenderingMode,
         downsizeImagesEnabled: Bool,
         downsizeScaleFactor: CGFloat,
-        faultCollector: FaultCollector = FaultCollector()
+        faultCollector: FaultCollector = FaultCollector(),
+        backend: ResultBackend = .auto
     ) {
         var runs: [Run] = []
         var resultFiles: [ResultFile] = []
         self.faultCollector = faultCollector
+
+        // The CLI already rejects an explicit `legacy` the toolchain cannot
+        // honour in `validate()`. This arm is defence in depth for library
+        // consumers who never pass through the CLI: a non-throwing init
+        // cannot raise the error, so it records a fault — which reaches
+        // exit 3 through the existing path, and is therefore still not a
+        // silent substitution.
+        let resolved: ResultBackend
+        switch backend.resolve() {
+        case let .use(concrete):
+            resolved = concrete
+        case .legacyUnavailable:
+            faultCollector.record(
+                .legacyReaderUnavailable,
+                "legacy reader requested but unavailable on this toolchain"
+            )
+            resolved = .modern
+        }
 
         for (resultIndex, resultPath) in resultPaths.enumerated() {
             Logger.step("Parsing \(resultPath)")
             let url = URL(fileURLWithPath: resultPath)
             let resultFile = ResultFile(url: url, faultCollector: faultCollector)
             resultFiles.append(resultFile)
-            guard let parsed = LegacyResultReader(file: resultFile).read() else {
+
+            let (reader, payloads) = Self.makeReader(
+                resolved: resolved,
+                resultFile: resultFile,
+                faultCollector: faultCollector
+            )
+
+            guard let parsed = reader.read() else {
                 Logger.warning("Can't find invocation record for : \(resultPath)")
                 faultCollector.record(.missingInvocationRecord, resultPath)
                 // Previously `break`, which silently abandoned every remaining
@@ -57,7 +83,7 @@ public struct Summary {
                         identifierPath: IdentifierPath.root
                             .appending("bundle\(resultIndex)")
                             .appending("action\(actionIndex)"),
-                        file: resultFile,
+                        file: payloads,
                         renderingMode: renderingMode,
                         downsizeImagesEnabled: downsizeImagesEnabled,
                         downsizeScaleFactor: downsizeScaleFactor
@@ -67,6 +93,30 @@ public struct Summary {
         }
         self.runs = runs
         self.resultFiles = resultFiles
+    }
+
+    /// Reader and payload provider for one bundle on the resolved backend.
+    private static func makeReader(
+        resolved: ResultBackend,
+        resultFile: ResultFile,
+        faultCollector: FaultCollector
+    ) -> (reader: ResultReader, payloads: PayloadProviding) {
+        switch resolved {
+        case .legacy, .auto:
+            // `resolve()` never returns `.use(.auto)`, so the `.auto` arm is
+            // unreachable; it exists because `ResultBackend` is the parameter
+            // type and Swift requires exhaustiveness.
+            return (LegacyResultReader(file: resultFile), resultFile)
+        case .modern:
+            let client = XCResultToolClient(bundleURL: resultFile.url)
+            let store = ModernPayloadStore(
+                client: client, bundleURL: resultFile.url, faultCollector: faultCollector
+            )
+            let reader = ModernResultReader(
+                client: client, payloadStore: store, faultCollector: faultCollector
+            )
+            return (reader, store)
+        }
     }
 
     /// Generate HTML report

--- a/Sources/XCTestHTMLReportCore/Classes/ResultReading/ResultBackend.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/ResultReading/ResultBackend.swift
@@ -1,0 +1,50 @@
+//
+//  ResultBackend.swift
+//  XCTestHTMLReportCore
+//
+
+import Foundation
+
+/// Which reader parses result bundles.
+///
+/// `LegacyCapability` lives in `XCResultToolClient.swift`: the client probes
+/// the toolchain once per process and caches the answer there.
+public enum ResultBackend: String, CaseIterable {
+    /// Prefer `legacy` while the toolchain still offers the legacy commands.
+    case auto
+    case legacy
+    case modern
+
+    /// Outcome of resolving a request against the toolchain's capability.
+    public enum Resolution: Equatable {
+        case use(ResultBackend)
+        /// An explicit `legacy` request the toolchain cannot honour.
+        case legacyUnavailable
+    }
+
+    /// Only `auto` ever substitutes.
+    ///
+    /// An explicit `--result-reader legacy` that cannot be honoured is an
+    /// error, never a silent downgrade. Substituting would let a modern-only
+    /// host run the modern reader twice and report the differential as
+    /// passing — comparing a backend against itself and calling it parity.
+    ///
+    /// `unknown` (an unparseable version string) is not proof of absence:
+    /// `auto` degrades to `.modern` because working beats broken, while an
+    /// explicit `legacy` attempts legacy anyway and lets any resulting command
+    /// failure surface as a fault rather than as a capability signal.
+    public func resolve() -> Resolution {
+        switch (self, XCResultToolClient.legacyCapability) {
+        case (.modern, _):
+            return .use(.modern)
+        case (.legacy, .available), (.legacy, .unknown):
+            return .use(.legacy)
+        case (.legacy, .unavailable):
+            return .legacyUnavailable
+        case (.auto, .available):
+            return .use(.legacy)
+        case (.auto, .unknown), (.auto, .unavailable):
+            return .use(.modern)
+        }
+    }
+}

--- a/Tests/XCTestHTMLReportTests/ResultBackendTests.swift
+++ b/Tests/XCTestHTMLReportTests/ResultBackendTests.swift
@@ -1,0 +1,112 @@
+//
+//  ResultBackendTests.swift
+//
+
+import XCTest
+@testable import XCTestHTMLReportCore
+
+final class ResultBackendTests: XCTestCase {
+    func testModernAlwaysResolvesToModern() {
+        XCTAssertEqual(ResultBackend.modern.resolve(), .use(.modern))
+    }
+
+    func testExplicitLegacyIsNeverSilentlySubstituted() {
+        // The hazard this guards: if an explicit `legacy` quietly became
+        // `modern`, a modern-only host would run the modern reader twice and
+        // the differential would report parity against itself.
+        switch XCResultToolClient.legacyCapability {
+        case .available, .unknown:
+            XCTAssertEqual(ResultBackend.legacy.resolve(), .use(.legacy))
+        case .unavailable:
+            XCTAssertEqual(ResultBackend.legacy.resolve(), .legacyUnavailable)
+        }
+        // Never modern, on any host.
+        XCTAssertNotEqual(ResultBackend.legacy.resolve(), .use(.modern))
+    }
+
+    func testAutoNeverResolvesToAuto() {
+        XCTAssertNotEqual(ResultBackend.auto.resolve(), .use(.auto))
+        XCTAssertNotEqual(ResultBackend.auto.resolve(), .legacyUnavailable)
+    }
+
+    func testAutoPrefersLegacyWhileTheToolchainOffersIt() {
+        // Conditional on the host toolchain rather than asserted outright, so
+        // this keeps passing rather than becoming a time bomb after removal.
+        if XCResultToolClient.legacyCapability == .available {
+            XCTAssertEqual(ResultBackend.auto.resolve(), .use(.legacy))
+        } else {
+            XCTAssertEqual(ResultBackend.auto.resolve(), .use(.modern))
+        }
+    }
+
+    func testBothBackendsProduceAReportForTheSameBundle() throws {
+        let url = try XCTUnwrap(
+            Bundle.testBundle.url(forResource: "SanityResults", withExtension: "xcresult")
+        )
+        for backend in [ResultBackend.legacy, .modern] {
+            let summary = Summary(
+                resultPaths: [url.path],
+                renderingMode: .linking,
+                downsizeImagesEnabled: false,
+                downsizeScaleFactor: 0.5,
+                backend: backend
+            )
+            XCTAssertFalse(
+                summary.generatedHtmlReport().isEmpty,
+                "\(backend) produced no report"
+            )
+            // Format limitations must never be recorded as faults; if they
+            // were, every modern run would exit 3.
+            XCTAssertEqual(summary.faults, [], "\(backend) reported faults")
+        }
+    }
+
+    func testResultReaderFlagWorksOutOfProcess() throws {
+        // Task 12's differential forces each reader through the CLI, so the
+        // flag has to work from a separate process via `xchtmlreportCmd`, not
+        // only through `Summary.init` in this one.
+        let url = try XCTUnwrap(
+            Bundle.testBundle.url(forResource: "SanityResults", withExtension: "xcresult")
+        )
+
+        func groupCount(reader: String) throws -> Int {
+            let outputDir = FileManager.default.temporaryDirectory
+                .appendingPathComponent("result-reader-\(reader)-\(UUID().uuidString)")
+            try FileManager.default.createDirectory(
+                at: outputDir, withIntermediateDirectories: true
+            )
+            defer { try? FileManager.default.removeItem(at: outputDir) }
+            let (status, maybeStdOut, maybeStdErr) = try xchtmlreportCmd(args: [
+                url.path, "-o", outputDir.path, "--result-reader", reader,
+            ])
+            let stdErr = maybeStdErr ?? ""
+            XCTAssertEqual(
+                status, 0,
+                "--result-reader \(reader) exited \(status). stderr:\n\(stdErr)"
+            )
+            let combined = (maybeStdOut ?? "") + stdErr
+            XCTAssertFalse(
+                combined.contains("Report is degraded"),
+                "\(reader) run was degraded:\n\(combined)"
+            )
+            let html = try String(
+                contentsOf: outputDir.appendingPathComponent("index.html"),
+                encoding: .utf8
+            )
+            return html.components(separatedBy: "test-summary-group").count - 1
+        }
+
+        let modernGroups = try groupCount(reader: "modern")
+        XCTAssertGreaterThan(modernGroups, 0, "modern rendered no test groups")
+
+        if XCResultToolClient.legacyCapability == .available {
+            // Legacy interposes the wrapper levels the modern tree omits, so
+            // equal counts mean the flag never reached `Summary` and both runs
+            // used one backend.
+            XCTAssertNotEqual(
+                try groupCount(reader: "legacy"), modernGroups,
+                "legacy and modern rendered identical group counts — the flag is not reaching Summary"
+            )
+        }
+    }
+}

--- a/Tests/XCTestHTMLReportTests/ResultBackendTests.swift
+++ b/Tests/XCTestHTMLReportTests/ResultBackendTests.swift
@@ -43,7 +43,17 @@ final class ResultBackendTests: XCTestCase {
         let url = try XCTUnwrap(
             Bundle.testBundle.url(forResource: "SanityResults", withExtension: "xcresult")
         )
-        for backend in [ResultBackend.legacy, .modern] {
+        // The legacy arm only where the toolchain can honour it: an explicit
+        // `legacy` on a modern-only host records `legacyReaderUnavailable` by
+        // design, and on an `unknown` host the legacy commands themselves may
+        // fail. Same anti-time-bomb reasoning as
+        // `testAutoPrefersLegacyWhileTheToolchainOffersIt`; parity stays fully
+        // asserted on every host that has both backends.
+        var backends: [ResultBackend] = [.modern]
+        if XCResultToolClient.legacyCapability == .available {
+            backends.insert(.legacy, at: 0)
+        }
+        for backend in backends {
             let summary = Summary(
                 resultPaths: [url.path],
                 renderingMode: .linking,

--- a/docs/superpowers/plans/2026-08-10-xcresulttool-legacy-migration.md
+++ b/docs/superpowers/plans/2026-08-10-xcresulttool-legacy-migration.md
@@ -3327,7 +3327,16 @@ final class ResultBackendTests: XCTestCase {
         let url = try XCTUnwrap(
             Bundle.testBundle.url(forResource: "SanityResults", withExtension: "xcresult")
         )
-        for backend in [ResultBackend.legacy, .modern] {
+        // Amended during Task 11 (review finding): the loop was unconditional,
+        // which fails by design on a modern-only host — the explicit `legacy`
+        // arm records `legacyReaderUnavailable`. Guard it on capability, the
+        // same anti-time-bomb reasoning the other tests already use; parity
+        // stays fully asserted on every host that has both backends.
+        var backends: [ResultBackend] = [.modern]
+        if XCResultToolClient.legacyCapability == .available {
+            backends.insert(.legacy, at: 0)
+        }
+        for backend in backends {
             let summary = Summary(
                 resultPaths: [url.path],
                 renderingMode: .linking,

--- a/docs/superpowers/plans/2026-08-10-xcresulttool-legacy-migration.md
+++ b/docs/superpowers/plans/2026-08-10-xcresulttool-legacy-migration.md
@@ -3344,6 +3344,55 @@ final class ResultBackendTests: XCTestCase {
             XCTAssertEqual(summary.faults, [], "\(backend) reported faults")
         }
     }
+
+    // Amended during Task 11: Task 12's differential forces each reader
+    // through the CLI, so the flag has to work from a separate process via
+    // `xchtmlreportCmd`, not only through `Summary.init` in this one.
+    func testResultReaderFlagWorksOutOfProcess() throws {
+        let url = try XCTUnwrap(
+            Bundle.testBundle.url(forResource: "SanityResults", withExtension: "xcresult")
+        )
+
+        func groupCount(reader: String) throws -> Int {
+            let outputDir = FileManager.default.temporaryDirectory
+                .appendingPathComponent("result-reader-\(reader)-\(UUID().uuidString)")
+            try FileManager.default.createDirectory(
+                at: outputDir, withIntermediateDirectories: true
+            )
+            defer { try? FileManager.default.removeItem(at: outputDir) }
+            let (status, maybeStdOut, maybeStdErr) = try xchtmlreportCmd(args: [
+                url.path, "-o", outputDir.path, "--result-reader", reader,
+            ])
+            let stdErr = maybeStdErr ?? ""
+            XCTAssertEqual(
+                status, 0,
+                "--result-reader \(reader) exited \(status). stderr:\n\(stdErr)"
+            )
+            let combined = (maybeStdOut ?? "") + stdErr
+            XCTAssertFalse(
+                combined.contains("Report is degraded"),
+                "\(reader) run was degraded:\n\(combined)"
+            )
+            let html = try String(
+                contentsOf: outputDir.appendingPathComponent("index.html"),
+                encoding: .utf8
+            )
+            return html.components(separatedBy: "test-summary-group").count - 1
+        }
+
+        let modernGroups = try groupCount(reader: "modern")
+        XCTAssertGreaterThan(modernGroups, 0, "modern rendered no test groups")
+
+        if XCResultToolClient.legacyCapability == .available {
+            // Legacy interposes the wrapper levels the modern tree omits, so
+            // equal counts mean the flag never reached `Summary` and both runs
+            // used one backend.
+            XCTAssertNotEqual(
+                try groupCount(reader: "legacy"), modernGroups,
+                "legacy and modern rendered identical group counts — the flag is not reaching Summary"
+            )
+        }
+    }
 }
 ```
 
@@ -3522,7 +3571,9 @@ let summary = Summary(
 swift test --filter ResultBackendTests && swift test 2>&1 | tail -5
 ```
 
-Expected: 4 new tests PASS; full suite green.
+Expected: 6 new tests PASS; full suite green. (Amended during Task 11: this
+originally said 4, but the snippet above defines 5 test functions, plus the
+out-of-process CLI test added for Task 12's differential.)
 
 **If `testBothBackendsProduceAReportForTheSameBundle` fails on the faults
 assertion**, the modern backend is recording format limitations as faults. Fix
@@ -3535,6 +3586,9 @@ out as the easiest way to get the migration wrong.
 set -o pipefail
 swift build
 for reader in legacy modern; do
+  # Amended during Task 11: xchtmlreport does not create the output
+  # directory, so without this both runs exit 1 having written nothing.
+  mkdir -p "/tmp/check-$reader"
   .build/debug/xchtmlreport --result-reader "$reader" \
     Tests/XCTestHTMLReportTests/Resources/TestResults.xcresult \
     -o "/tmp/check-$reader" >/dev/null

--- a/docs/superpowers/specs/2026-08-10-xcresulttool-legacy-migration-design.md
+++ b/docs/superpowers/specs/2026-08-10-xcresulttool-legacy-migration-design.md
@@ -236,10 +236,19 @@ advertises. Exposed as a CLI option (`--result-reader legacy|modern|auto`,
 default `auto`) so the harness can drive it through the existing
 `xchtmlreportCmd` helper.
 
-Demotion is scoped to **capability detection only**. `auto` and an explicit
-`legacy` both fall back to `modern` when the toolchain does not advertise the
-legacy commands, so a version string that changes shape unexpectedly degrades
-to working rather than broken.
+Demotion is scoped to **capability detection only**, and only `auto` ever
+substitutes. `auto` falls back to `modern` when the toolchain does not
+advertise the legacy commands or the version string does not parse, so a
+version string that changes shape unexpectedly degrades to working rather
+than broken. *(Amended during Task 11: this paragraph originally said an
+explicit `legacy` also falls back.)* An explicit `legacy` is never silently
+substituted — the CLI rejects it up front when the toolchain definitively
+lacks the legacy commands, and `Summary` records a `legacyReaderUnavailable`
+fault (reaching exit 3) for library consumers who never pass through the CLI.
+When the probe is merely inconclusive, an explicit `legacy` attempts legacy
+anyway and lets any command failure surface as a fault rather than as a
+capability signal. Substituting silently would let the differential run
+modern-vs-modern and report parity against itself.
 
 It is deliberately **not** "any hard failure of a legacy command demotes".
 A corrupt bundle, a permission error, a truncated `.xcresult`, or a subprocess


### PR DESCRIPTION
Part of #391 (milestone 4.0) — plan Task 11.

## What

- **`ResultBackend`** (`auto|legacy|modern`) with `resolve()`, which checks the requested backend against `XCResultToolClient.legacyCapability` (#441's probe):
  - `auto` prefers `legacy` while the toolchain advertises it, falls back to `modern` otherwise (including an unparseable version string). Never resolves to `auto`.
  - **Explicit `legacy` is never silently substituted.** On a toolchain that definitively lacks the legacy commands it resolves to `.legacyUnavailable`: the CLI rejects it in `validate()` with a clear error, and `Summary.init` (which cannot throw) records a new `legacyReaderUnavailable` fault that reaches exit 3 — otherwise the Task 12 differential could run modern-vs-modern and report parity against itself.
  - `unknown` capability treats legacy as available for explicit `legacy` (not proof of absence); any resulting command failure surfaces as a fault, not a capability signal.
- **Demotion is scoped to capability detection only.** Corrupt bundles, permission errors, and dead subprocesses still propagate through `FaultCollector` to exit 3 exactly as before; there is no retry-on-other-backend anywhere.
- **`Summary.init(..., backend: ResultBackend = .auto)`** appended after `faultCollector`, wiring per-bundle reader/payload-provider construction through the resolution (`LegacyResultReader`+`ResultFile` vs `ModernResultReader`+`ModernPayloadStore`).
- **`--result-reader legacy|modern|auto`** (default `auto`) on the CLI, drivable out of process through the existing `xchtmlreportCmd` helper — Task 12's differential forces each reader through the CLI.

## Tests

`ResultBackendTests` per the plan (resolution table, both-backends-render-with-zero-faults through the real `Summary` path), plus `testResultReaderFlagWorksOutOfProcess`: runs the built binary with `--result-reader modern` (and `legacy` where available) and asserts the rendered group counts differ, proving the flag reaches `Summary` from a separate process.

- `swift test`: 71 tests, 0 failures (2 pre-existing skips)
- Plan step-5 end-to-end check: `legacy exit=0 groups=14`, `modern exit=0 groups=10` — counts differ as required

## Plan/spec amendments (in this PR)

- Plan Task 11 step 5: added `mkdir -p` — `xchtmlreport` does not create the output directory, so the snippet as written exited 1 for both readers.
- Plan Task 11 step 4: expected test count corrected (said 4; snippet defines 5, now 6 with the CLI test).
- Plan Task 11 step 1: added the out-of-process CLI test to the canonical test file.
- Spec "Backend selection": the paragraph still said an explicit `legacy` falls back to `modern`; rewritten to the never-silently-substituted semantics the plan's tests encode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added options to choose automatic, legacy, or modern result reading.
  - Automatic selection uses the legacy reader when available and otherwise uses the modern reader.
  - Reports can now be generated using either supported reading mode.

- **Bug Fixes**
  - Explicit legacy selection now clearly handles unavailable readers with an appropriate error or fallback.

- **Tests**
  - Added coverage for reader selection, fallback behavior, faults, and report output consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->