### PR TITLE
THE DIFFERENTIAL: legacy/modern parity held to the declared allow-list + forced-modern CI leg (#391, Tasks 12–13)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,16 @@ permissions:
 jobs:
   test:
     runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # `auto` is what users get. The forced `modern` leg exercises the path
+        # that becomes the only path once Apple removes the legacy commands —
+        # without it, the modern reader is only ever covered by the
+        # differential tests, and never end to end.
+        result_reader: [auto, modern]
+    env:
+      XCHR_RESULT_READER: ${{ matrix.result_reader }}
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:

--- a/Package.swift
+++ b/Package.swift
@@ -38,6 +38,7 @@ let package = Package(
                 .process("Resources/TestResults.xcresult"),
                 .process("Resources/RetryResults.xcresult"),
                 .process("Resources/SanityResults.xcresult"),
+                .process("Resources/differential-allowlist.json"),
             ]
         ),
     ]

--- a/Sources/XCTestHTMLReport/XCTestHtmlReport.swift
+++ b/Sources/XCTestHTMLReport/XCTestHtmlReport.swift
@@ -83,10 +83,10 @@ struct SummaryOptions: ParsableArguments {
     @Option(
         name: .long,
         help: ArgumentHelp(
-            "Which result reader to use: auto, legacy, or modern. Defaults to auto, which prefers the legacy reader while the toolchain still supports it."
+            "Which result reader to use: auto, legacy, or modern. Defaults to $XCHR_RESULT_READER if set, else auto, which prefers the legacy reader while the toolchain supports it."
         )
     )
-    var resultReader: ResultBackend = .auto
+    var resultReader: ResultBackend = .fromEnvironment()
 }
 
 @main

--- a/Sources/XCTestHTMLReportCore/Classes/Models/Run.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Models/Run.swift
@@ -74,7 +74,18 @@ struct Run: HTML {
         if let logReference = run.logReference {
             logContent = file.exportLogsContent(
                 reference: logReference,
-                renderingMode: renderingMode
+                renderingMode: renderingMode,
+                // Named from the run's identifier path, not from `reference`:
+                // the reference is backend-internal (a CAS id on legacy, a
+                // `--type` selector on modern), so a file named after it can
+                // never agree across backends. The path digest is the same
+                // scheme every element id already uses (#430), identical on
+                // both backends, and unique per run — a multi-action bundle
+                // gets one log file per action instead of a shared name that
+                // would leave last-writer-wins. No fixture exercises multiple
+                // actions, so that property is asserted here rather than in a
+                // test.
+                fileName: "\(identifierPath.identifier).log"
             )
         } else {
             Logger.warning("Can't find log reference for run \(run.destination.displayName)")

--- a/Sources/XCTestHTMLReportCore/Classes/Models/Summary.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Models/Summary.swift
@@ -29,7 +29,7 @@ public struct Summary {
         downsizeImagesEnabled: Bool,
         downsizeScaleFactor: CGFloat,
         faultCollector: FaultCollector = FaultCollector(),
-        backend: ResultBackend = .auto
+        backend: ResultBackend = .fromEnvironment()
     ) {
         var runs: [Run] = []
         var resultFiles: [ResultFile] = []

--- a/Sources/XCTestHTMLReportCore/Classes/ResultReading/Legacy/LegacyResultReader.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/ResultReading/Legacy/LegacyResultReader.swift
@@ -87,7 +87,7 @@ struct LegacyResultReader: ResultReader {
                 identifier: identifier,
                 // Legacy has no counterpart to Swift Testing's Arguments nodes.
                 arguments: [],
-                iterations: iterations
+                iterations: Self.mergingArgumentExecutions(iterations)
             ))
         }
 
@@ -118,22 +118,35 @@ struct LegacyResultReader: ResultReader {
         // ActionTestActivitySummary, so failure summaries are interleaved by
         // start time. When failing sub-activities are already present we are
         // on an older tool and must not add them twice.
-        let combined: [ParsedActivity]
+        let failures: [ParsedActivity]
         if activities.contains(where: hasFailure) {
-            combined = activities
+            failures = []
         } else {
-            let failures = summary.failureSummaries.map(parseFailure)
-            // Ordered by `start`, which replaced `finish` as the ordering key
-            // under decision 1 — the modern format publishes no finish, so
-            // `start` is the only key both backends share. This sort is not
-            // cosmetic: it interleaves assertion-failure rows among the
-            // activities so a failure renders *where it occurred* rather than
-            // after everything else. Dropping it — rather than re-keying it —
-            // would silently append every failure row at the end of the test.
-            combined = (activities + failures).sorted {
-                ($0.start ?? .distantPast) < ($1.start ?? .distantPast)
-            }
+            failures = summary.failureSummaries.map(parseFailure)
         }
+
+        // The skip reason lives on its own summary object, which this reader
+        // previously never read — the modern reader has always surfaced the
+        // equivalent `Failure Message` node, so skipping it here was a reader
+        // gap, not a format limitation. Same shape as the modern append path:
+        // a failure row with no timestamp, which the shared interleaving
+        // orders after the timeline.
+        let skipNotice: [ParsedActivity] = (summary.skipNoticeSummary?.message).map {
+            [ParsedActivity(
+                title: $0, isFailure: true, start: nil, attachments: [], subActivities: []
+            )]
+        } ?? []
+
+        // The interleave — `start`-keyed, per decision 1 — is not cosmetic:
+        // it renders each failure row *where it occurred* rather than after
+        // everything else. It lives in the port
+        // (`ParsedActivity.interleavingFailureRows`) because both readers
+        // must place these rows identically, and one shared function is the
+        // only ordering rule that cannot drift.
+        let combined = ParsedActivity.interleavingFailureRows(
+            activities: activities,
+            failureRows: failures + skipNotice
+        )
 
         return ParsedIteration(
             iterationNumber: summary.repetitionPolicySummary?.iteration,
@@ -141,6 +154,51 @@ struct LegacyResultReader: ResultReader {
             duration: metadata.duration ?? 0,
             activities: combined
         )
+    }
+
+    /// Collapses Swift Testing argument executions into one iteration.
+    ///
+    /// A parameterized `@Test(arguments:)` reaches the legacy format as
+    /// duplicate sibling metadata entries sharing one identifier — the same
+    /// encoding as retries, except none of them carries a
+    /// `repetitionPolicySummary`. Rendering them as repetitions invents retry
+    /// semantics for what are argument variations ("3 succeeded", three
+    /// "Iteration 0" rows), and the modern format renders the same test as a
+    /// single case with `Arguments` children (answer 6). Merging on the
+    /// absence of repetition metadata makes both backends agree by
+    /// construction: durations sum (the rule answer 8 already sets), and
+    /// activities concatenate in source order.
+    ///
+    /// True retries are untouched: every `-retry-tests-on-failure` repetition
+    /// carries the policy summary, so at least one iteration has a number and
+    /// the merge does not fire. `RetryResults` pins that in the fixture suite.
+    static func mergingArgumentExecutions(
+        _ iterations: [ParsedIteration]
+    ) -> [ParsedIteration] {
+        guard iterations.count > 1,
+              iterations.allSatisfy({ $0.iterationNumber == nil })
+        else {
+            return iterations
+        }
+        let statuses = Set(iterations.map(\.status))
+        let merged: ParsedStatus
+        if statuses.count == 1 {
+            merged = statuses.first ?? .unknown
+        } else if statuses.contains(.failed) {
+            // Mirrors the modern parent node's own summary: passed only when
+            // every argument passed.
+            merged = .failed
+        } else if statuses.contains(.skipped) {
+            merged = .skipped
+        } else {
+            merged = .unknown
+        }
+        return [ParsedIteration(
+            iterationNumber: nil,
+            status: merged,
+            duration: iterations.reduce(0) { $0 + $1.duration },
+            activities: iterations.flatMap(\.activities)
+        )]
     }
 
     /// Legacy spellings into the neutral enum. The modern reader has the
@@ -188,16 +246,24 @@ struct LegacyResultReader: ResultReader {
     }
 
     private func parseAttachment(_ attachment: ActionTestAttachment) -> ParsedAttachment {
-        ParsedAttachment(
+        // The port carries no UTI (answer 4). Map it down to an extension
+        // here so both backends type attachments identically instead of
+        // the difference being allow-listed.
+        let ext = Self.filenameExtension(
+            forUTI: attachment.uniformTypeIdentifier,
+            filename: attachment.filename
+        )
+        return ParsedAttachment(
             name: attachment.name,
-            filename: attachment.filename,
-            // The port carries no UTI (answer 4). Map it down to an extension
-            // here so both backends type attachments identically instead of
-            // the difference being allow-listed.
-            filenameExtension: Self.filenameExtension(
-                forUTI: attachment.uniformTypeIdentifier,
-                filename: attachment.filename
-            ),
+            // Content-addressed, not `attachment.filename`: the legacy pretty
+            // name embeds a legacy-only uuid the modern format cannot see, so
+            // it can never agree across backends. The payload id can — see
+            // `ParsedAttachment.exportFileName`. An attachment with no payload
+            // has nothing to export and gets no filename, on both backends.
+            filename: attachment.payloadRef.map {
+                ParsedAttachment.exportFileName(payloadId: $0.id, filenameExtension: ext)
+            },
+            filenameExtension: ext,
             payloadReference: attachment.payloadRef?.id
         )
     }

--- a/Sources/XCTestHTMLReportCore/Classes/ResultReading/Legacy/ResultFile.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/ResultReading/Legacy/ResultFile.swift
@@ -133,13 +133,12 @@ extension ResultFile: PayloadProviding {
         }
     }
 
-    func exportLogs(reference: String) -> URL? {
+    func exportLogs(reference: String, fileName: String) -> URL? {
         guard let logSection = file.getLogs(id: reference) else {
             Logger.warning("Can't get logs with id \(reference)")
             faultCollector.record(.logExportFailed, "log id \(reference)")
             return nil
         }
-        let fileName = "\(reference).log"
         let url = url.appendingPathComponent(fileName)
         let fileManager = FileManager.default
         do {

--- a/Sources/XCTestHTMLReportCore/Classes/ResultReading/Modern/ModernPayloadStore.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/ResultReading/Modern/ModernPayloadStore.swift
@@ -54,14 +54,23 @@ final class ModernPayloadStore: PayloadProviding {
         }
         let resolved = fileName ?? source.lastPathComponent
         let destination = url.appendingPathComponent(resolved)
+        // Destinations are content-addressed (`ParsedAttachment.exportFileName`
+        // names them by payload id), so a file already at the destination *is*
+        // this payload and the export is idempotent: never remove, never
+        // rewrite. The predecessor removed-then-copied, which under Xcode
+        // 26.2's shared screen-recording display names raced concurrent
+        // exports on one path and intermittently recorded a spurious
+        // `.payloadExportFailed` (#449).
+        if FileManager.default.fileExists(atPath: destination.path) {
+            return relativeURL.appendingPathComponent(resolved)
+        }
         do {
-            try? FileManager.default.removeItem(at: destination)
             try FileManager.default.copyItem(at: source, to: destination)
             return relativeURL.appendingPathComponent(resolved)
         } catch {
-            // Another writer may have raced us to the destination (a second
-            // xchtmlreport over the same bundle): if the payload is sitting
-            // there, it was exported, and losing the race is not degradation.
+            // A concurrent writer of the same payload can still beat us to the
+            // creation; its bytes are our bytes, so losing that race is
+            // success, not degradation.
             if FileManager.default.fileExists(atPath: destination.path) {
                 return relativeURL.appendingPathComponent(resolved)
             }
@@ -87,11 +96,10 @@ final class ModernPayloadStore: PayloadProviding {
         }
     }
 
-    func exportLogs(reference: String) -> URL? {
+    func exportLogs(reference: String, fileName: String) -> URL? {
         guard let text = logText(reference: reference) else {
             return nil
         }
-        let fileName = "\(reference).log"
         let destination = url.appendingPathComponent(fileName)
         do {
             try? FileManager.default.removeItem(at: destination)

--- a/Sources/XCTestHTMLReportCore/Classes/ResultReading/Modern/ModernResultReader+FailureRows.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/ResultReading/Modern/ModernResultReader+FailureRows.swift
@@ -1,0 +1,172 @@
+//
+//  ModernResultReader+FailureRows.swift
+//  XCTestHTMLReportCore
+//
+//  How the tests document's `Failure Message` nodes and the activities
+//  document's failure-flagged rows become the port's failure rows: the join
+//  that reunites the two halves of one failure, its inversion for expected
+//  failures, and the hoist that puts the result where the legacy backend can
+//  agree with it.
+//
+
+import Foundation
+
+extension ModernResultReader {
+    /// Joins the tests document's `Failure Message` nodes onto the activity
+    /// tree.
+    ///
+    /// Both documents describe the same failure, each holding half of it. The
+    /// `Failure Message` node keeps the `file:line` prefix
+    /// (`"FirstSuite.swift:86: XCTAssertTrue failed - Test failed"`) but has
+    /// no timestamp; the activities document reports the failure as a
+    /// failure-flagged activity row — positioned and timestamped, nested
+    /// inside the user's own activity when the assertion fired there — but
+    /// drops the prefix. Sourcing titles from activities loses `file:line`
+    /// everywhere; appending messages unconditionally renders two rows per
+    /// failure.
+    ///
+    /// So: each message claims the first failure-flagged activity — pre-order,
+    /// document order, first-unmatched-first, which pairs repeated identical
+    /// assertions deterministically — whose title is an exact suffix of the
+    /// message, and that activity is retitled with the message as given,
+    /// keeping its position, nesting, start, attachments and children. The
+    /// string is never parsed apart: rebuilding `fileName`/`lineNumber` from
+    /// it would put visible UI on an inferred parse of a format Apple can
+    /// reformat without notice (see the spec's "Failure location").
+    ///
+    /// Messages that match nothing still append as failure rows at the end —
+    /// skip reasons ride the same node type, and their activity twins are not
+    /// failure-flagged, so they have no row to claim and no timestamp to
+    /// interleave on.
+    ///
+    /// **Expected failures invert the join.** The legacy report treats an
+    /// expected failure as a non-event — status flattens to `.unknown` and
+    /// nothing renders — while the modern documents carry both the `Failure
+    /// Message` (the `XCTExpectFailure` text) and a matching activity row.
+    /// For a test whose result is `Expected Failure`, each message therefore
+    /// claims and **removes** the first activity whose title equals the
+    /// message exactly — exact match only, never fuzzy — subtree included,
+    /// and messages that match nothing are suppressed rather than appended.
+    func joiningFailureMessages(
+        _ messages: [String],
+        into activities: [ParsedActivity],
+        status: ParsedStatus
+    ) -> [ParsedActivity] {
+        guard status != .expectedFailure else {
+            return removingExpectedFailureRows(messages, from: activities)
+        }
+        return mergingFailureMessages(messages, into: activities)
+    }
+
+    /// Hoists failure rows out of the nested tree and interleaves them at the
+    /// top level, through the same shared ordering the legacy reader uses.
+    ///
+    /// The new format nests an assertion row inside the activity it fired in;
+    /// the legacy format structurally cannot (post-3.39 failure summaries are
+    /// separate objects), and re-nesting them by `[start, finish]` window was
+    /// tested and rejected — at the format's millisecond granularity the
+    /// windows collide and the join misplaces rows. So the modern reader
+    /// discards the nesting instead: hoisted rows keep their own subtree,
+    /// title, timestamp and attachments, only their position changes. This is
+    /// a deliberate scaffold constraint, not a design preference — once the
+    /// legacy backend is removed, this hoist can be deleted and the report
+    /// may show the native nesting again.
+    func hoistingFailureRows(_ activities: [ParsedActivity]) -> [ParsedActivity] {
+        var failureRows: [ParsedActivity] = []
+        func strip(_ list: [ParsedActivity]) -> [ParsedActivity] {
+            list.compactMap { activity in
+                if activity.isFailure {
+                    failureRows.append(activity)
+                    return nil
+                }
+                return ParsedActivity(
+                    title: activity.title,
+                    isFailure: activity.isFailure,
+                    start: activity.start,
+                    attachments: activity.attachments,
+                    subActivities: strip(activity.subActivities)
+                )
+            }
+        }
+        let rest = strip(activities)
+        return ParsedActivity.interleavingFailureRows(
+            activities: rest, failureRows: failureRows
+        )
+    }
+
+    private func removingExpectedFailureRows(
+        _ messages: [String],
+        from activities: [ParsedActivity]
+    ) -> [ParsedActivity] {
+        var unclaimed = messages
+        func removeClaimed(_ activities: [ParsedActivity]) -> [ParsedActivity] {
+            activities.compactMap { activity in
+                if let index = unclaimed.firstIndex(of: activity.title) {
+                    unclaimed.remove(at: index)
+                    return nil
+                }
+                return ParsedActivity(
+                    title: activity.title,
+                    isFailure: activity.isFailure,
+                    start: activity.start,
+                    attachments: activity.attachments,
+                    subActivities: removeClaimed(activity.subActivities)
+                )
+            }
+        }
+        return removeClaimed(activities)
+    }
+
+    private func mergingFailureMessages(
+        _ messages: [String],
+        into activities: [ParsedActivity]
+    ) -> [ParsedActivity] {
+        guard !messages.isEmpty else {
+            return activities
+        }
+
+        var candidates: [(path: [Int], title: String)] = []
+        func collect(_ activities: [ParsedActivity], _ prefix: [Int]) {
+            for (index, activity) in activities.enumerated() {
+                let path = prefix + [index]
+                if activity.isFailure, !activity.title.isEmpty {
+                    candidates.append((path, activity.title))
+                }
+                collect(activity.subActivities, path)
+            }
+        }
+        collect(activities, [])
+
+        var retitles: [[Int]: String] = [:]
+        var appended: [ParsedActivity] = []
+        for message in messages {
+            if let match = candidates.first(where: {
+                retitles[$0.path] == nil && message.hasSuffix($0.title)
+            }) {
+                retitles[match.path] = message
+            } else {
+                appended.append(ParsedActivity(
+                    title: message,
+                    isFailure: true,
+                    start: nil,
+                    attachments: [],
+                    subActivities: []
+                ))
+            }
+        }
+
+        func rebuild(_ activities: [ParsedActivity], _ prefix: [Int]) -> [ParsedActivity] {
+            activities.enumerated().map { index, activity in
+                let path = prefix + [index]
+                return ParsedActivity(
+                    title: retitles[path] ?? activity.title,
+                    isFailure: activity.isFailure,
+                    start: activity.start,
+                    attachments: activity.attachments,
+                    subActivities: rebuild(activity.subActivities, path)
+                )
+            }
+        }
+        return (retitles.isEmpty ? activities : rebuild(activities, [])) + appended
+    }
+}

--- a/Sources/XCTestHTMLReportCore/Classes/ResultReading/Modern/ModernResultReader.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/ResultReading/Modern/ModernResultReader.swift
@@ -159,35 +159,49 @@ struct ModernResultReader: ResultReader {
 
         let iterations: [ParsedIteration]
         if repetitions.isEmpty {
+            let status = Self.status(node.result)
             iterations = [ParsedIteration(
                 iterationNumber: nil,
-                status: Self.status(node.result),
+                status: status,
                 duration: node.durationInSeconds ?? 0,
-                activities: mergingFailureMessages(
+                activities: hoistingFailureRows(joiningFailureMessages(
                     failureMessages(of: node),
-                    into: activities(for: identifier, iteration: nil)
-                )
+                    into: activities(for: identifier, iteration: nil),
+                    status: status
+                ))
             )]
         } else {
             // The parent node's own `result` summarises the retries and is not
             // the legacy status: a test that failed then passed reports
             // "Passed" here while legacy reports mixed. Derive from children.
             iterations = repetitions.enumerated().map { index, repetition in
-                ParsedIteration(
+                let status = Self.status(repetition.result)
+                return ParsedIteration(
                     iterationNumber: repetition.nodeIdentifier.flatMap(Int.init)
                         ?? (index + 1),
-                    status: Self.status(repetition.result),
+                    status: status,
                     duration: repetition.durationInSeconds ?? 0,
-                    activities: mergingFailureMessages(
+                    activities: hoistingFailureRows(joiningFailureMessages(
                         failureMessages(of: repetition),
-                        into: activities(for: identifier, iteration: index)
-                    )
+                        into: activities(for: identifier, iteration: index),
+                        status: status
+                    ))
                 )
             }
         }
 
         return ParsedTestCase(
-            name: node.name ?? "",
+            // The identifier's last component, not `node.name`. For XCTest the
+            // two are the same string; for Swift Testing `node.name` is the
+            // `@Test` display name ("Tagged multiplication check"), which the
+            // legacy format cannot see. A name only one backend can fill does
+            // not belong in the port (the same rule that removed
+            // `activityType`), so both readers carry the function-form name
+            // the identifier gives them. The display name is deliberately
+            // unused until the redesign models it.
+            name: identifier.isEmpty
+                ? (node.name ?? "")
+                : (identifier.components(separatedBy: "/").last ?? node.name ?? ""),
             identifier: identifier,
             arguments: Self.arguments(of: node),
             iterations: iterations
@@ -198,85 +212,6 @@ struct ModernResultReader: ResultReader {
         (node.children ?? [])
             .filter { $0.nodeType == "Failure Message" }
             .compactMap(\.name)
-    }
-
-    /// Joins the tests document's `Failure Message` nodes onto the activity
-    /// tree.
-    ///
-    /// Both documents describe the same failure, each holding half of it. The
-    /// `Failure Message` node keeps the `file:line` prefix
-    /// (`"FirstSuite.swift:86: XCTAssertTrue failed - Test failed"`) but has
-    /// no timestamp; the activities document reports the failure as a
-    /// failure-flagged activity row — positioned and timestamped, nested
-    /// inside the user's own activity when the assertion fired there — but
-    /// drops the prefix. Sourcing titles from activities loses `file:line`
-    /// everywhere; appending messages unconditionally renders two rows per
-    /// failure.
-    ///
-    /// So: each message claims the first failure-flagged activity — pre-order,
-    /// document order, first-unmatched-first, which pairs repeated identical
-    /// assertions deterministically — whose title is an exact suffix of the
-    /// message, and that activity is retitled with the message as given,
-    /// keeping its position, nesting, start, attachments and children. The
-    /// string is never parsed apart: rebuilding `fileName`/`lineNumber` from
-    /// it would put visible UI on an inferred parse of a format Apple can
-    /// reformat without notice (see the spec's "Failure location").
-    ///
-    /// Messages that match nothing still append as failure rows at the end —
-    /// skip reasons and expected-failure notes ride the same node type, and
-    /// their activity twins are not failure-flagged, so they have no row to
-    /// claim and no timestamp to interleave on.
-    private func mergingFailureMessages(
-        _ messages: [String],
-        into activities: [ParsedActivity]
-    ) -> [ParsedActivity] {
-        guard !messages.isEmpty else {
-            return activities
-        }
-
-        var candidates: [(path: [Int], title: String)] = []
-        func collect(_ activities: [ParsedActivity], _ prefix: [Int]) {
-            for (index, activity) in activities.enumerated() {
-                let path = prefix + [index]
-                if activity.isFailure, !activity.title.isEmpty {
-                    candidates.append((path, activity.title))
-                }
-                collect(activity.subActivities, path)
-            }
-        }
-        collect(activities, [])
-
-        var retitles: [[Int]: String] = [:]
-        var appended: [ParsedActivity] = []
-        for message in messages {
-            if let match = candidates.first(where: {
-                retitles[$0.path] == nil && message.hasSuffix($0.title)
-            }) {
-                retitles[match.path] = message
-            } else {
-                appended.append(ParsedActivity(
-                    title: message,
-                    isFailure: true,
-                    start: nil,
-                    attachments: [],
-                    subActivities: []
-                ))
-            }
-        }
-
-        func rebuild(_ activities: [ParsedActivity], _ prefix: [Int]) -> [ParsedActivity] {
-            activities.enumerated().map { index, activity in
-                let path = prefix + [index]
-                return ParsedActivity(
-                    title: retitles[path] ?? activity.title,
-                    isFailure: activity.isFailure,
-                    start: activity.start,
-                    attachments: activity.attachments,
-                    subActivities: rebuild(activity.subActivities, path)
-                )
-            }
-        }
-        return (retitles.isEmpty ? activities : rebuild(activities, [])) + appended
     }
 
     /// One `activities` subprocess per exact test-case id — suite and bundle
@@ -295,7 +230,7 @@ struct ModernResultReader: ResultReader {
             let run: TestActivities.TestRun? = iteration
                 .flatMap { index in runs.indices.contains(index) ? runs[index] : nil }
                 ?? runs.first
-            return (run?.activities ?? []).map(parseActivity)
+            return (run?.activities ?? []).map { parseActivity(pruning: $0) }
         } catch {
             // A failed activities query is a genuine read failure, not a
             // format limitation: the test renders with no activities at all.
@@ -306,13 +241,61 @@ struct ModernResultReader: ResultReader {
         }
     }
 
-    private func parseActivity(_ node: ActivityNode) -> ParsedActivity {
-        ParsedActivity(
+    /// Translates an activity node, dropping two families of bookkeeping rows
+    /// Xcode 26.2 nests inside real activities and the legacy tree never had:
+    ///
+    /// 1. **Symbol annotations** — children with no `startTime`, titled with
+    ///    the failing frame (`RetryTests.testJustFail()`, `closure #1 in …`).
+    ///    The timeline model orders on `start` (answer 1); a row without one
+    ///    is an annotation, not an event. A no-start row that carries
+    ///    attachments, a failure flag, or surviving children is **kept**, not
+    ///    dropped: dropping content because a future format variant stopped
+    ///    stamping times would silently gut real data, and rendering it
+    ///    unordered is the lesser harm.
+    ///
+    /// 2. **Attachment shadows** — for every attachment the document also
+    ///    emits one childless, non-failure child row whose `startTime` equals
+    ///    the attachment's `timestamp` (its title is the attachment's
+    ///    user-supplied name, which the spec deliberately does not mine — see
+    ///    "Reconstructing lost fields by heuristic"). The row is the
+    ///    attachment's shadow, so it is claimed by the timestamp join and
+    ///    dropped, mirroring the failure-message join below. The leaf and
+    ///    non-failure guards are load-bearing: a genuine failure row can share
+    ///    the attachment's millisecond (observed on
+    ///    `testWithSpecialChars()`), and must survive.
+    private func parseActivity(pruning node: ActivityNode) -> ParsedActivity {
+        let attachmentTimes = Set((node.attachments ?? []).compactMap(\.timestamp))
+        let children: [ParsedActivity] = (node.childActivities ?? []).compactMap { child in
+            let parsed = parseActivity(pruning: child)
+            let hasContent = parsed.isFailure || !parsed.attachments.isEmpty
+                || !parsed.subActivities.isEmpty
+            guard !hasContent else {
+                return parsed
+            }
+            if child.startTime == nil {
+                return nil // symbol annotation
+            }
+            if let start = child.startTime, attachmentTimes.contains(start) {
+                return nil // attachment shadow
+            }
+            return parsed
+        }
+        // Tip-of-chain, not the raw flag: the new format sets
+        // `isAssociatedWithFailure` on every ancestor of a failure, while the
+        // port's `isFailure` means "this row IS the assertion row". The tip is
+        // the flagged node with no flagged children; containers revert to
+        // plain activities, and the renderer derives containment itself. A
+        // chain with several assertion rows has several tips — each flagged
+        // node without flagged children qualifies independently.
+        let flagged = node.isAssociatedWithFailure ?? false
+        let childFlagged = (node.childActivities ?? [])
+            .contains { $0.isAssociatedWithFailure ?? false }
+        return ParsedActivity(
             title: node.title ?? "",
-            isFailure: node.isAssociatedWithFailure ?? false,
+            isFailure: flagged && !childFlagged,
             start: node.startTime.map { Date(timeIntervalSince1970: $0) },
             attachments: (node.attachments ?? []).map(parseAttachment),
-            subActivities: (node.childActivities ?? []).map(parseActivity)
+            subActivities: children
         )
     }
 
@@ -327,10 +310,19 @@ struct ModernResultReader: ResultReader {
             .map { ($0 as NSString).pathExtension.lowercased() }
             .first { !$0.isEmpty }
         return ParsedAttachment(
-            // `name` in the new format holds what legacy calls `filename`; the
-            // user-supplied name is not exposed. Report it as filename only.
+            // The user-supplied name is not exposed by the new format; the
+            // display name falls back to the type-derived label (the
+            // `attachmentDisplayNames` allow-list entry).
             name: nil,
-            filename: attachment.name,
+            // Content-addressed, not `attachment.name`: Xcode 26.2 gives every
+            // auto screen recording in a session one shared display name, so
+            // naming exports after it collapsed distinct payloads onto one
+            // path and raced concurrent copies (#449). `payloadId` is the same
+            // CAS id legacy calls `payloadRef.id`, so both backends derive the
+            // identical name — see `ParsedAttachment.exportFileName`.
+            filename: attachment.payloadId.map {
+                ParsedAttachment.exportFileName(payloadId: $0, filenameExtension: ext)
+            },
             filenameExtension: ext,
             payloadReference: attachment.uuid
         )

--- a/Sources/XCTestHTMLReportCore/Classes/ResultReading/ParsedResult.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/ResultReading/ParsedResult.swift
@@ -96,8 +96,13 @@ public struct ParsedIteration {
 
 public struct ParsedActivity {
     public let title: String
-    /// True when the backend marks this activity as a failure. Legacy derives
-    /// it from `activityType`; modern reads `isAssociatedWithFailure`.
+    /// True when this row *is* the failure row itself — the assertion (or the
+    /// appended failure message), not an activity that merely contains one.
+    /// Legacy derives it from `activityType ==
+    /// testAssertionFailure`; modern maps the tip of the
+    /// `isAssociatedWithFailure` chain, because the new format flags every
+    /// ancestor of a failure and the renderer already derives containment on
+    /// its own (`Activity.hasFailingSubActivities`).
     ///
     /// This is all that survives of the legacy activity taxonomy. The other
     /// four states have no modern source, so they are out of the port rather
@@ -108,6 +113,66 @@ public struct ParsedActivity {
     public let start: Date?
     public let attachments: [ParsedAttachment]
     public let subActivities: [ParsedActivity]
+
+    /// Interleaves an iteration's failure rows among its top-level activities.
+    ///
+    /// One function, called by **both** readers, is what makes the two
+    /// backends' failure-row placement agree by construction: legacy feeds it
+    /// the separate `failureSummaries` list its format keeps (post-3.39
+    /// xcresulttool no longer nests assertions inside activities), and the
+    /// modern reader feeds it the failure tips it hoists out of its natively
+    /// nested tree. Neither side may sort these rows independently.
+    ///
+    /// The order is **total** — `(start, kind, source index)`:
+    ///  - `start`, with `nil` sorting *last* (`.distantFuture`): a row with no
+    ///    timestamp is an unpositioned annotation (an appended failure
+    ///    message, a skip notice) and belongs after the timeline, which is
+    ///    where the modern reader's append path has always put it.
+    ///  - on equal starts, activities precede failure rows — assertion
+    ///    timestamps routinely equal their enclosing activity's start at the
+    ///    format's millisecond granularity, so this tie is hit in practice,
+    ///    not hypothetically.
+    ///  - source index last, so the order is deterministic even for identical
+    ///    rows. A non-total comparator here regressed once before (#443);
+    ///    `PortRuleTests` pins totality directly.
+    public static func interleavingFailureRows(
+        activities: [ParsedActivity],
+        failureRows: [ParsedActivity]
+    ) -> [ParsedActivity] {
+        struct Keyed {
+            let start: Date
+            let kind: Int
+            let index: Int
+            let row: ParsedActivity
+        }
+        let keyed = activities.enumerated().map {
+            Keyed(
+                start: $0.element.start ?? .distantFuture,
+                kind: 0,
+                index: $0.offset,
+                row: $0.element
+            )
+        }
+            + failureRows.enumerated().map {
+                Keyed(
+                    start: $0.element.start ?? .distantFuture,
+                    kind: 1,
+                    index: $0.offset,
+                    row: $0.element
+                )
+            }
+        return keyed
+            .sorted { lhs, rhs in
+                if lhs.start != rhs.start {
+                    return lhs.start < rhs.start
+                }
+                if lhs.kind != rhs.kind {
+                    return lhs.kind < rhs.kind
+                }
+                return lhs.index < rhs.index
+            }
+            .map(\.row)
+    }
 }
 
 public struct ParsedAttachment {
@@ -122,4 +187,30 @@ public struct ParsedAttachment {
     public let filenameExtension: String?
     /// Opaque handle the backend's payload provider resolves to bytes.
     public let payloadReference: String?
+
+    /// The on-disk name an exported payload gets, derived from the payload's
+    /// content-addressed store id — the one attachment identifier both formats
+    /// share (legacy `payloadRef.id`, modern `payloadId` — the same CAS id).
+    ///
+    /// Naming exports after backend-native pretty names is what this replaces,
+    /// and it broke two ways at once: legacy filenames embed a legacy-only
+    /// uuid the modern format cannot see, and Xcode 26.2 gives every auto
+    /// screen recording in a session one shared display name, so distinct
+    /// payloads collapsed onto one path and concurrent copies raced on it
+    /// (#449). A content-addressed name is unique per payload by construction,
+    /// makes the export idempotent, and both backends produce it from shared
+    /// data — filenames agree by construction rather than by mask.
+    ///
+    /// The id's alphabet is `0~` + base64url + `=` padding, all safe in a
+    /// POSIX filename; `/` is replaced defensively in case a future tool
+    /// switches to plain base64.
+    public static func exportFileName(
+        payloadId: String, filenameExtension: String?
+    ) -> String {
+        let stem = payloadId.replacingOccurrences(of: "/", with: "_")
+        guard let ext = filenameExtension, !ext.isEmpty else {
+            return stem
+        }
+        return "\(stem).\(ext)"
+    }
 }

--- a/Sources/XCTestHTMLReportCore/Classes/ResultReading/ResultBackend.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/ResultReading/ResultBackend.swift
@@ -22,6 +22,18 @@ public enum ResultBackend: String, CaseIterable {
         case legacyUnavailable
     }
 
+    /// The CI override: `XCHR_RESULT_READER=modern swift test` forces every
+    /// `Summary` the harness builds onto one backend, which is how the
+    /// forced-`modern` CI leg exercises the whole suite end to end. The CLI
+    /// flag stays the primary control — this is only the *default* when the
+    /// flag is absent — and an unrecognised value falls back to `.auto`
+    /// rather than failing, since an env var has no argument parser to reject
+    /// it.
+    public static func fromEnvironment() -> ResultBackend {
+        ProcessInfo.processInfo.environment["XCHR_RESULT_READER"]
+            .flatMap(ResultBackend.init(rawValue:)) ?? .auto
+    }
+
     /// Only `auto` ever substitutes.
     ///
     /// An explicit `--result-reader legacy` that cannot be honoured is an

--- a/Sources/XCTestHTMLReportCore/Classes/ResultReading/ResultReader.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/ResultReading/ResultReader.swift
@@ -21,7 +21,11 @@ protocol PayloadProviding {
     /// bundle-relative URL, or `nil` on failure.
     func exportPayload(reference: String, fileName: String?) -> URL?
     func exportPayloadData(reference: String) -> Data?
-    func exportLogs(reference: String) -> URL?
+    /// `reference` is backend-internal (a log ref id on legacy, a `--type`
+    /// selector on modern) and never names the file; `fileName` does, and the
+    /// caller derives it from backend-neutral data so both backends write the
+    /// same name — see `Run.init`.
+    func exportLogs(reference: String, fileName: String) -> URL?
     func exportLogsData(reference: String) -> Data?
 }
 
@@ -43,14 +47,16 @@ extension PayloadProviding {
 
     func exportLogsContent(
         reference: String,
-        renderingMode: Summary.RenderingMode
+        renderingMode: Summary.RenderingMode,
+        fileName: String
     ) -> RenderingContent {
         switch renderingMode {
         case .inline:
             return exportLogsData(reference: reference)
                 .map(RenderingContent.data) ?? .none
         case .linking:
-            return exportLogs(reference: reference).map(RenderingContent.url) ?? .none
+            return exportLogs(reference: reference, fileName: fileName)
+                .map(RenderingContent.url) ?? .none
         }
     }
 }

--- a/Tests/XCTestHTMLReportTests/DifferentialTests.swift
+++ b/Tests/XCTestHTMLReportTests/DifferentialTests.swift
@@ -1,0 +1,349 @@
+//
+//  DifferentialTests.swift
+//
+//  Renders each fixture through both readers and holds the difference to the
+//  declared allow-list. This is only possible while xcresulttool supports both
+//  formats; it skips itself, loudly, once it does not.
+//
+
+import XCTest
+@testable import XCTestHTMLReportCore
+
+final class DifferentialTests: XCTestCase {
+    private static let fixtures = ["TestResults", "SanityResults", "RetryResults"]
+
+    /// Linking-mode summaries and their normalized renders, one per
+    /// fixture-and-backend. Rendering is deterministic for a given backend
+    /// (#430), so sharing across test methods compares the same bytes the
+    /// other assertions held, and halves a suite dominated by `xcresulttool`
+    /// subprocess time.
+    private static var summaries: [String: Summary] = [:]
+    private static var normalizedRenders: [String: String] = [:]
+
+    private struct AllowList: Decodable {
+        struct Loss: Decodable {
+            let rule: String
+            let field: String
+            let effect: String
+        }
+
+        let knownLosses: [Loss]
+    }
+
+    private func allowList() throws -> AllowList {
+        let url = try XCTUnwrap(
+            Bundle.testBundle.url(
+                forResource: "differential-allowlist", withExtension: "json"
+            )
+        )
+        return try JSONDecoder().decode(AllowList.self, from: Data(contentsOf: url))
+    }
+
+    private func summary(_ resource: String, _ backend: ResultBackend) throws -> Summary {
+        let key = "\(resource)|\(backend.rawValue)"
+        if let cached = Self.summaries[key] {
+            return cached
+        }
+        let url = try XCTUnwrap(
+            Bundle.testBundle.url(forResource: resource, withExtension: "xcresult")
+        )
+        let summary = Summary(
+            resultPaths: [url.path],
+            renderingMode: .linking,
+            downsizeImagesEnabled: false,
+            downsizeScaleFactor: 0.5,
+            backend: backend
+        )
+        Self.summaries[key] = summary
+        return summary
+    }
+
+    /// The identifier-normalized `.linking` render. Only `.linking` renders
+    /// are safe to normalize: inline base64 can contain a 32-character hex
+    /// run, which the digest pattern would eat.
+    private func normalizedRender(
+        _ resource: String, _ backend: ResultBackend
+    ) throws -> String {
+        let key = "\(resource)|\(backend.rawValue)"
+        if let cached = Self.normalizedRenders[key] {
+            return cached
+        }
+        let render = try normalizeIdentifiers(
+            summary(resource, backend).generatedHtmlReport()
+        )
+        Self.normalizedRenders[key] = render
+        return render
+    }
+
+    /// Skips unless *both* backends can actually run, and proves it rather
+    /// than assuming it.
+    ///
+    /// Requesting `.legacy` on a modern-only host must not quietly hand back a
+    /// modern reader: the differential would then compare the modern backend
+    /// against itself and report parity. `resolve()` returns
+    /// `.legacyUnavailable` instead of substituting, and this asserts on that.
+    private func requireBothBackends() throws {
+        switch ResultBackend.legacy.resolve() {
+        case .legacyUnavailable:
+            throw XCTSkip(
+                "Toolchain has no legacy commands; the differential cannot run. "
+                    + "Delete LegacyResultReader and this test together."
+            )
+        case let .use(backend):
+            XCTAssertEqual(
+                backend, .legacy,
+                "Requested the legacy reader and resolved to \(backend). A "
+                    + "substituted backend would make every comparison below "
+                    + "a modern-vs-modern tautology."
+            )
+        }
+    }
+
+    /// Counts and statuses must match exactly. These are the assertions that
+    /// would catch the multi-repetition status regression.
+    func testStatusesAndCountsMatchAcrossBackends() throws {
+        try requireBothBackends()
+        for fixture in Self.fixtures {
+            let legacy = try summary(fixture, .legacy)
+            let modern = try summary(fixture, .modern)
+
+            func statuses(_ summary: Summary) -> [String: String] {
+                Dictionary(
+                    summary.runs.flatMap(\.allTests)
+                        .map { ($0.identifier, $0.status.rawValue) },
+                    uniquingKeysWith: { first, _ in first }
+                )
+            }
+            XCTAssertEqual(
+                statuses(legacy), statuses(modern),
+                "\(fixture): identifier→status differs between backends"
+            )
+
+            // Assert before zipping: `zip` truncates to the shorter sequence,
+            // so a backend that produced fewer runs would compare equal on the
+            // ones it did produce and pass.
+            XCTAssertEqual(
+                legacy.runs.count, modern.runs.count,
+                "\(fixture): backends disagree on the number of runs"
+            )
+
+            for (legacyRun, modernRun) in zip(legacy.runs, modern.runs) {
+                XCTAssertEqual(
+                    legacyRun.numberOfTests, modernRun.numberOfTests, "\(fixture): total"
+                )
+                XCTAssertEqual(
+                    legacyRun.numberOfPassedTests, modernRun.numberOfPassedTests,
+                    "\(fixture): passed"
+                )
+                XCTAssertEqual(
+                    legacyRun.numberOfFailedTests, modernRun.numberOfFailedTests,
+                    "\(fixture): failed"
+                )
+                XCTAssertEqual(
+                    legacyRun.numberOfSkippedTests, modernRun.numberOfSkippedTests,
+                    "\(fixture): skipped"
+                )
+                XCTAssertEqual(
+                    legacyRun.numberOfMixedTests, modernRun.numberOfMixedTests,
+                    "\(fixture): mixed"
+                )
+            }
+        }
+    }
+
+    /// The allow-list and the masker must name exactly the same rules, in both
+    /// directions. An entry with no implementation would silently mask
+    /// nothing, leaving the difference it claims to cover to fail somewhere
+    /// confusing; an implementation with no entry is dead masking code whose
+    /// justification nobody reviewed.
+    func testEveryAllowListRuleIsImplemented() throws {
+        let declared = try Set(allowList().knownLosses.map(\.rule))
+        XCTAssertEqual(
+            declared, KnownLossMasker.implementedRules,
+            "The allow-list and KnownLossMasker.implementedRules disagree. "
+                + "Every declared rule needs an implementation and vice versa."
+        )
+    }
+
+    /// The assertion the whole exercise exists for: mask exactly the declared
+    /// losses out of both renders, and require what remains to be identical.
+    ///
+    /// This is the strong form. Checking only that declared markers appear and
+    /// disappear would prove nothing about the lines nobody declared, and an
+    /// undeclared regression would sail straight through.
+    func testMaskedRendersAreIdenticalAcrossBackends() throws {
+        try requireBothBackends()
+        let rules = try allowList().knownLosses.map(\.rule)
+
+        for fixture in Self.fixtures {
+            let legacySummary = try summary(fixture, .legacy)
+            let legacy = try KnownLossMasker.mask(
+                normalizedRender(fixture, .legacy), rules: rules
+            )
+            let modern = try KnownLossMasker.mask(
+                normalizedRender(fixture, .modern), rules: rules
+            )
+
+            // Non-vacuity: the mask must not have erased the content being
+            // compared. Without this, a mask broad enough to delete everything
+            // would make the comparison below pass on any two inputs.
+            for title in legacySummary.runs.flatMap(\.allTests).map(\.title) {
+                XCTAssertTrue(
+                    legacy.contains(title),
+                    "\(fixture): masking removed test '\(title)' from the "
+                        + "comparison. The mask is too broad."
+                )
+            }
+
+            guard legacy != modern else {
+                continue
+            }
+            let legacyLines = legacy.split(separator: "\n").map(String.init)
+            let modernLines = modern.split(separator: "\n").map(String.init)
+            let differing = Set(legacyLines).symmetricDifference(Set(modernLines))
+            // An empty set with unequal strings means the same lines appear in
+            // a different order or multiplicity; report the first divergent
+            // position instead, or the failure is unactionable.
+            let firstMismatch = zip(legacyLines, modernLines).enumerated()
+                .first { $1.0 != $1.1 }
+                .map { index, pair in
+                    """
+                    First sequential mismatch at masked line \(index):
+                      legacy: \(pair.0)
+                      modern: \(pair.1)
+                    context (legacy \(max(0, index - 3))..\(index)):
+                    \(legacyLines[max(0, index - 3) ... index].joined(separator: "\n"))
+                    """
+                } ?? "Line counts: legacy \(legacyLines.count), modern \(modernLines.count)"
+            XCTFail(
+                """
+                \(fixture): \(differing.count) distinct line(s) differ after \
+                masking the declared losses. Each is either a parity bug in \
+                the modern reader, or an undeclared format loss that needs an \
+                allow-list entry with a written justification. First 20:
+                \(differing.sorted().prefix(20).joined(separator: "\n"))
+                \(firstMismatch)
+                """
+            )
+        }
+    }
+
+    /// Every allow-list entry must still be *necessary* somewhere: for each
+    /// fixture, each rule is left out in turn, and a rule fires when its
+    /// absence leaves the two renders unequal. An entry that fires on no
+    /// fixture is masking a divergence that no longer exists — Apple filled
+    /// the gap, or the fixture stopped exercising it — and must be deleted,
+    /// not left to rot as a place where a real regression could hide.
+    func testEveryAllowListEntryStillMasksARealDivergence() throws {
+        try requireBothBackends()
+        let rules = try allowList().knownLosses.map(\.rule)
+
+        var firedAnywhere: Set<String> = []
+        for fixture in Self.fixtures {
+            let fired = try KnownLossMasker.firedRules(
+                legacy: normalizedRender(fixture, .legacy),
+                modern: normalizedRender(fixture, .modern),
+                rules: rules
+            )
+            print("Differential allow-list rules fired on \(fixture): \(fired.sorted())")
+            firedAnywhere.formUnion(fired)
+        }
+
+        for rule in rules where !firedAnywhere.contains(rule) {
+            XCTFail(
+                "Allow-list rule '\(rule)' masked nothing on any fixture. The "
+                    + "divergence it declares no longer exists; delete the "
+                    + "entry (and its masker rule) rather than letting it rot."
+            )
+        }
+    }
+
+    /// Restores the coverage the `durations` mask gives up.
+    ///
+    /// That rule normalises every `(1.23s)` in the report, because the
+    /// divergent ones cannot be scoped by line. This asserts directly on the
+    /// model that the durations which *should* agree do — XCTest test cases,
+    /// as against groups and Swift Testing cases, which the format leaves null
+    /// on modern.
+    func testXCTestCaseDurationsAgreeAcrossBackends() throws {
+        try requireBothBackends()
+        for fixture in Self.fixtures {
+            let legacy = try summary(fixture, .legacy)
+            let modern = try summary(fixture, .modern)
+
+            func durations(_ summary: Summary) -> [String: TimeInterval] {
+                Dictionary(
+                    summary.runs.flatMap(\.allTests)
+                        // Swift Testing cases report no duration on modern.
+                        .filter { !$0.identifier.hasPrefix("SwiftTestingSuite/") }
+                        .map { ($0.identifier, $0.duration) },
+                    uniquingKeysWith: { first, _ in first }
+                )
+            }
+            let legacyDurations = durations(legacy)
+            XCTAssertFalse(
+                legacyDurations.isEmpty,
+                "\(fixture): no XCTest cases to compare — assertion would be vacuous"
+            )
+            for (identifier, legacyValue) in legacyDurations {
+                let modernValue = try XCTUnwrap(durations(modern)[identifier])
+                XCTAssertEqual(
+                    legacyValue, modernValue, accuracy: 0.0005,
+                    "\(fixture): \(identifier) duration differs between backends"
+                )
+            }
+        }
+    }
+
+    func testAttachmentPayloadsAreByteIdenticalAcrossBackends() throws {
+        try requireBothBackends()
+
+        /// Keyed by filename and counted, not collected into a Set: a Set
+        /// collapses duplicates, so a backend that dropped one of two identical
+        /// screen recordings would still compare equal.
+        func payloads(_ summary: Summary) -> [String: [Data]] {
+            var byName: [String: [Data]] = [:]
+            for attachment in summary.allAttachments {
+                guard case let .data(data) = attachment.content else {
+                    continue
+                }
+                byName[attachment.filename, default: []].append(data)
+            }
+            return byName.mapValues { $0.sorted { $0.count < $1.count } }
+        }
+
+        for fixture in Self.fixtures {
+            // Rendered inline so the bytes are in hand rather than on disk.
+            let legacy = try summaryInline(fixture, .legacy)
+            let modern = try summaryInline(fixture, .modern)
+            let legacyPayloads = payloads(legacy)
+            XCTAssertFalse(
+                legacyPayloads.isEmpty,
+                "\(fixture): no attachment bytes to compare — the assertion "
+                    + "below would pass vacuously"
+            )
+            XCTAssertEqual(
+                legacyPayloads.mapValues(\.count),
+                payloads(modern).mapValues(\.count),
+                "\(fixture): attachment counts differ between backends"
+            )
+            XCTAssertEqual(
+                legacyPayloads, payloads(modern),
+                "\(fixture): attachment bytes differ between backends"
+            )
+        }
+    }
+
+    private func summaryInline(_ resource: String, _ backend: ResultBackend) throws -> Summary {
+        let url = try XCTUnwrap(
+            Bundle.testBundle.url(forResource: resource, withExtension: "xcresult")
+        )
+        return Summary(
+            resultPaths: [url.path],
+            renderingMode: .inline,
+            downsizeImagesEnabled: false,
+            downsizeScaleFactor: 0.5,
+            backend: backend
+        )
+    }
+}

--- a/Tests/XCTestHTMLReportTests/FaultReportingTests.swift
+++ b/Tests/XCTestHTMLReportTests/FaultReportingTests.swift
@@ -89,7 +89,7 @@ final class FaultReportingTests: XCTestCase {
             [.posixPermissions: 0o555], ofItemAtPath: bundle.path
         )
 
-        XCTAssertNil(file.exportLogs(reference: logReference))
+        XCTAssertNil(file.exportLogs(reference: logReference, fileName: "test.log"))
         XCTAssertTrue(
             collector.faults.contains { $0.kind == .logExportFailed },
             "A log that reads but cannot be written must be recorded as degradation"

--- a/Tests/XCTestHTMLReportTests/KnownLossMasker.swift
+++ b/Tests/XCTestHTMLReportTests/KnownLossMasker.swift
@@ -1,0 +1,170 @@
+//
+//  KnownLossMasker.swift
+//
+//  Removes exactly the differences declared in differential-allowlist.json
+//  from a rendered report, so the differential test can assert that what
+//  remains is identical across backends.
+//
+//  Each rule here corresponds 1:1 to an allow-list entry, by name. Adding a
+//  rule without adding the entry (or vice versa) fails
+//  testEveryAllowListRuleIsImplemented.
+//
+
+import Foundation
+import SwiftSoup
+
+enum KnownLossMasker {
+    /// Four, not five. `activityTypeClasses` was removed by decision 2: with no
+    /// `activityType` in the port, both backends render the same thing and there
+    /// is nothing to mask.
+    ///
+    /// `durations` stays. An earlier revision deleted it too, on the premise
+    /// that removing `ParsedActivity.finish` removed all duration divergence.
+    /// That was wrong — the surviving divergence is in group durations, which
+    /// `finish` never fed.
+    static let implementedRules: Set<String> = [
+        "durations",
+        "attachmentDisplayNames",
+        "failureTitlePrefix",
+        "wrapperGroups",
+    ]
+
+    static func mask(_ html: String, rules: [String]) -> String {
+        var masked = html
+        for rule in rules {
+            masked = apply(rule, to: masked)
+        }
+        // Canonicalize line shape before comparing. Template concatenation
+        // joins adjacent sibling blocks onto one line (`</div>  <div …>`), and
+        // *which* boundaries join depends on nesting depth — so the same DOM
+        // can line-break differently across backends once the wrapper levels
+        // are unwrapped. Splitting adjacent tags onto their own lines removes
+        // the artifact symmetrically without touching content; the earlier
+        // rules have already masked every unescaped text line this could
+        // otherwise bite (attachment names). Then collapse the whitespace-only
+        // lines the removals leave behind.
+        masked = replace(masked, #">[ \t]+<"#, with: ">\n<")
+        return masked
+            .split(separator: "\n")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+            .joined(separator: "\n")
+    }
+
+    /// Which rules actually mask a real divergence between these two renders.
+    ///
+    /// A rule "fires" when leaving it out (with every other rule still
+    /// applied) leaves the two renders unequal — i.e. the rule is necessary,
+    /// not merely matching. This is the anti-rot probe: once Apple fills a
+    /// gap, the divergence disappears, the rule stops being necessary, and
+    /// `testEveryAllowListEntryStillMasksARealDivergence` fails until the
+    /// entry is deleted. Only meaningful once the fully-masked renders are
+    /// equal — while they differ, omitting any rule trivially leaves them
+    /// unequal and every rule reports as firing.
+    static func firedRules(legacy: String, modern: String, rules: [String]) -> Set<String> {
+        var fired: Set<String> = []
+        for rule in rules {
+            let others = rules.filter { $0 != rule }
+            if mask(legacy, rules: others) != mask(modern, rules: others) {
+                fired.insert(rule)
+            }
+        }
+        return fired
+    }
+
+    private static func apply(_ rule: String, to html: String) -> String {
+        switch rule {
+        case "durations":
+            // Bare `(1.23s)` / `(0.00s)` suffixes from `[[TITLE]] ([[DURATION]])`.
+            //
+            // Deliberately over-broad, and that costs coverage. The divergence
+            // is in group headings and Swift Testing cases, but the rendered
+            // form is identical for every row and the duration sits on a
+            // different line from the `test-summary-group` class, so it cannot
+            // be scoped by line. Normalising all of them therefore also hides
+            // any regression in *XCTest* case durations, which do agree.
+            //
+            // `testXCTestCaseDurationsAgreeAcrossBackends` restores exactly
+            // that coverage. Do not delete one without the other.
+            return replace(html, #"\(\d+\.\d+s\)"#, with: "(DURATION)")
+        case "attachmentDisplayNames":
+            // The `[[NAME]]` line inside `<p class="attachment list-item">`.
+            // It is the third template line — the type-icon `<span>` sits
+            // between the `<p>` and the name — so the anchor spans both
+            // preceding lines. Anchoring on the icon span also keeps the rule
+            // from ever touching a non-attachment `<p>`.
+            return replace(
+                html,
+                #"(<p class="attachment[^"]*">\n\s*<span class="icon left [a-z-]*icon"[^\n]*></span>\n)[^\n]*\n"#,
+                with: "$1ATTACHMENT_NAME\n"
+            )
+        case "failureTitlePrefix":
+            // Two shapes, not one. Verified on `TestResults`:
+            //   legacy  "Assertion Failure at FirstSuite.swift:86:XCTAssertTrue failed - Test
+            //   failed"
+            //   modern  "FirstSuite.swift:86: XCTAssertTrue failed - Test failed"
+            // An earlier revision stripped only the legacy form, so modern's
+            // own `<file>:<line>: ` prefix survived and every failing test
+            // still differed after masking — the entry's justification claimed
+            // a convergence the rule did not deliver.
+            let legacyStripped = replace(
+                html, #"[A-Za-z ]+ at [^\s:]+:\d+:\s*"#, with: ""
+            )
+            return replace(legacyStripped, #"[\w.+-]+\.swift:\d+:\s*"#, with: "")
+        case "wrapperGroups":
+            // Legacy-only wrapper levels: `Selected tests` / `All tests` and
+            // `<target>.xctest`. Dropping only the heading *line* leaves the
+            // wrapper's div skeleton and its closing tag behind (measured:
+            // 12 residual lines per fixture), so the rule is structural — it
+            // removes the wrapper element's own heading and hoists its
+            // children, which also removes the matching close. Serialization
+            // preserves the original whitespace (`prettyPrint(false)`), so
+            // the other rules' line anchors survive; both renders pass
+            // through the same parse-serialize path, so any parser
+            // normalisation applies symmetrically.
+            do {
+                let document = try SwiftSoup.parse(html)
+                document.outputSettings().prettyPrint(pretty: false)
+                for group in try document.select("div.test-summary-group").array() {
+                    guard let heading = group.children().first(where: { $0.tagName() == "p" })
+                    else {
+                        continue
+                    }
+                    let title = try heading.text()
+                    let isWrapper = title.hasPrefix("All tests (")
+                        || title.hasPrefix("Selected tests (")
+                        || title.contains(".xctest (")
+                    guard isWrapper else {
+                        continue
+                    }
+                    for child in group.children()
+                        where child.tagName() == "span" || child.tagName() == "p"
+                    {
+                        try child.remove()
+                    }
+                    try group.unwrap()
+                }
+                return try document.outerHtml()
+            } catch {
+                // An unparseable report would mask nothing and fail the
+                // differential loudly, which is the right failure mode.
+                return html
+            }
+        default:
+            return html
+        }
+    }
+
+    private static func replace(
+        _ text: String, _ pattern: String, with template: String
+    ) -> String {
+        guard let regex = try? NSRegularExpression(pattern: pattern) else {
+            return text
+        }
+        return regex.stringByReplacingMatches(
+            in: text,
+            range: NSRange(text.startIndex..., in: text),
+            withTemplate: template
+        )
+    }
+}

--- a/Tests/XCTestHTMLReportTests/ModernPayloadStoreTests.swift
+++ b/Tests/XCTestHTMLReportTests/ModernPayloadStoreTests.swift
@@ -6,7 +6,10 @@ import XCTest
 @testable import XCTestHTMLReportCore
 
 final class ModernPayloadStoreTests: XCTestCase {
-    private func store(for resource: String) throws -> (ModernPayloadStore, URL) {
+    private func store(
+        for resource: String,
+        collector: FaultCollector = FaultCollector()
+    ) throws -> (ModernPayloadStore, URL) {
         let source = try XCTUnwrap(
             Bundle.testBundle.url(forResource: resource, withExtension: "xcresult")
         )
@@ -22,7 +25,7 @@ final class ModernPayloadStoreTests: XCTestCase {
             ModernPayloadStore(
                 client: XCResultToolClient(bundleURL: copy),
                 bundleURL: copy,
-                faultCollector: FaultCollector()
+                faultCollector: collector
             ),
             copy
         )
@@ -60,7 +63,8 @@ final class ModernPayloadStoreTests: XCTestCase {
         let data = try Data(contentsOf: written)
         XCTAssertFalse(data.isEmpty)
         XCTAssertTrue(
-            String(decoding: data, as: UTF8.self).contains("Sample attachment body")
+            try XCTUnwrap(String(bytes: data, encoding: .utf8))
+                .contains("Sample attachment body")
         )
     }
 
@@ -69,7 +73,8 @@ final class ModernPayloadStoreTests: XCTestCase {
         let uuid = try firstAttachmentUUID(in: bundle)
         let data = try XCTUnwrap(store.exportPayloadData(reference: uuid))
         XCTAssertTrue(
-            String(decoding: data, as: UTF8.self).contains("Sample attachment body")
+            try XCTUnwrap(String(bytes: data, encoding: .utf8))
+                .contains("Sample attachment body")
         )
     }
 
@@ -78,11 +83,42 @@ final class ModernPayloadStoreTests: XCTestCase {
         XCTAssertNil(store.exportPayload(reference: "not-a-uuid", fileName: nil))
     }
 
+    /// Destinations are content-addressed, so exporting the same payload to
+    /// the same name twice — sequentially or from concurrent attachment
+    /// builds — must be one file, no rewrite, and above all no fault. The
+    /// predecessor removed-then-copied, which raced concurrent exports of
+    /// payloads sharing a destination and intermittently recorded a spurious
+    /// `.payloadExportFailed` (#449).
+    func testExportPayloadIsIdempotentForTheSameDestination() throws {
+        let collector = FaultCollector()
+        let (store, bundle) = try store(for: "TestResults", collector: collector)
+        let uuid = try firstAttachmentUUID(in: bundle)
+
+        let first = try XCTUnwrap(
+            store.exportPayload(reference: uuid, fileName: "0~abc=.html")
+        )
+        let written = bundle.appendingPathComponent(first.lastPathComponent)
+        let bytes = try Data(contentsOf: written)
+
+        let second = try XCTUnwrap(
+            store.exportPayload(reference: uuid, fileName: "0~abc=.html")
+        )
+        XCTAssertEqual(first, second)
+        XCTAssertEqual(
+            try Data(contentsOf: written), bytes,
+            "The second export must not rewrite the destination"
+        )
+        XCTAssertTrue(
+            collector.faults.isEmpty,
+            "Re-exporting an already-exported payload is success, not degradation"
+        )
+    }
+
     func testActionLogExportsNextToTheBundle() throws {
         let (store, bundle) = try store(for: "SanityResults")
         // "action" is the fixed log reference the modern reader emits; the
         // store forwards it to `xcresulttool get log --type action`.
-        let relative = try XCTUnwrap(store.exportLogs(reference: "action"))
+        let relative = try XCTUnwrap(store.exportLogs(reference: "action", fileName: "action.log"))
         let written = bundle.appendingPathComponent(relative.lastPathComponent)
         let text = try String(contentsOf: written, encoding: .utf8)
         XCTAssertFalse(text.isEmpty)

--- a/Tests/XCTestHTMLReportTests/ModernReaderRuleTests.swift
+++ b/Tests/XCTestHTMLReportTests/ModernReaderRuleTests.swift
@@ -1,0 +1,238 @@
+//
+//  ModernReaderRuleTests.swift
+//
+//  Pins the bookkeeping-row rules the first differential run forced into the
+//  modern reader — tip-of-chain failure mapping, symbol-annotation and
+//  attachment-shadow drops, expected-failure removal, and content-addressed
+//  link resolution — on crafted documents where fixtures have no such shape,
+//  and on the fixture cases that motivated each rule.
+//
+
+import XCTest
+@testable import XCTestHTMLReportCore
+
+final class ModernReaderRuleTests: XCTestCase {
+    // MARK: - Helpers (mirrors ModernResultReaderTests)
+
+    private func read(_ resource: String) throws -> ParsedResult {
+        let url = try XCTUnwrap(
+            Bundle.testBundle.url(forResource: resource, withExtension: "xcresult")
+        )
+        let reader = ModernResultReader(
+            client: XCResultToolClient(bundleURL: url),
+            payloadStore: nil,
+            faultCollector: FaultCollector()
+        )
+        return try XCTUnwrap(reader.read())
+    }
+
+    private func testCases(in result: ParsedResult) -> [ParsedTestCase] {
+        func walk(_ node: ParsedNode) -> [ParsedTestCase] {
+            switch node {
+            case let .group(group): return group.children.flatMap(walk)
+            case let .testCase(testCase): return [testCase]
+            }
+        }
+        return result.runs
+            .flatMap(\.testables)
+            .flatMap(\.groups)
+            .flatMap { $0.children.flatMap(walk) }
+    }
+
+    private func flattened(_ activities: [ParsedActivity]) -> [ParsedActivity] {
+        activities.flatMap { [$0] + flattened($0.subActivities) }
+    }
+
+    // MARK: - Bookkeeping-row rules on crafted documents
+
+    /// Serves crafted `tests` and `activities` documents so the translation
+    /// rules can be pinned on shapes no fixture happens to produce.
+    private struct CraftedClient: XCResultToolInvoking {
+        let testsJSON: String
+        let activitiesJSON: String
+
+        var bundleDescription: String {
+            "Crafted.xcresult"
+        }
+
+        func run(_: [String]) throws -> Data {
+            Data()
+        }
+
+        func json<T: Decodable>(_ arguments: [String], as type: T.Type) throws -> T {
+            let payload = arguments.contains("activities") ? activitiesJSON : testsJSON
+            return try JSONDecoder().decode(type, from: Data(payload.utf8))
+        }
+    }
+
+    private func craftedCase(
+        testsJSON: String, activitiesJSON: String
+    ) throws -> ParsedTestCase {
+        let reader = ModernResultReader(
+            client: CraftedClient(testsJSON: testsJSON, activitiesJSON: activitiesJSON),
+            payloadStore: nil,
+            faultCollector: FaultCollector()
+        )
+        return try XCTUnwrap(try testCases(in: XCTUnwrap(reader.read())).first)
+    }
+
+    private static func testsDocument(
+        result: String, failureMessages: [String]
+    ) -> String {
+        let messages = failureMessages
+            .map { #"{"nodeType":"Failure Message","name":"\#($0)"}"# }
+            .joined(separator: ",")
+        return #"""
+        {"devices":[{"deviceId":"D","deviceName":"iPhone","modelName":"iPhone","osVersion":"1.0"}],
+         "testNodes":[{"nodeType":"Test Plan","name":"P","children":[
+           {"nodeType":"Unit test bundle","name":"B","children":[
+             {"nodeType":"Test Suite","name":"S","children":[
+               {"nodeType":"Test Case","name":"t()","nodeIdentifier":"S/t()",
+                "result":"\#(result)","children":[\#(messages)]}]}]}]}]}
+        """#
+    }
+
+    /// One flagged chain, two assertion rows: each flagged node with no
+    /// flagged children is a tip, independently — the container stays a plain
+    /// activity, and both tips hoist to the top level in start order.
+    func testEveryTipOfAFlaggedChainHoistsIndependently() throws {
+        let testCase = try craftedCase(
+            testsJSON: Self.testsDocument(
+                result: "Failed",
+                failureMessages: ["F.swift:1: boom one", "F.swift:2: boom two"]
+            ),
+            activitiesJSON: #"""
+            {"testIdentifier":"S/t()","testRuns":[{"activities":[
+              {"title":"container","isAssociatedWithFailure":true,"startTime":1,
+               "childActivities":[
+                 {"title":"boom one","isAssociatedWithFailure":true,"startTime":2},
+                 {"title":"boom two","isAssociatedWithFailure":true,"startTime":3}]}]}]}
+            """#
+        )
+        let rows = testCase.iterations[0].activities
+        XCTAssertEqual(
+            rows.map(\.title),
+            ["container", "F.swift:1: boom one", "F.swift:2: boom two"]
+        )
+        XCTAssertEqual(rows.map(\.isFailure), [false, true, true])
+        XCTAssertTrue(
+            rows[0].subActivities.isEmpty,
+            "Both tips must hoist out of the container"
+        )
+    }
+
+    /// A flagged activity with no flagged descendants is itself the tip: it
+    /// keeps its failure flag, gets retitled by the join, and stays where the
+    /// interleave puts it.
+    func testFlaggedLeafIsItsOwnTip() throws {
+        let testCase = try craftedCase(
+            testsJSON: Self.testsDocument(
+                result: "Failed", failureMessages: ["F.swift:9: solo boom"]
+            ),
+            activitiesJSON: #"""
+            {"testIdentifier":"S/t()","testRuns":[{"activities":[
+              {"title":"solo boom","isAssociatedWithFailure":true,"startTime":1}]}]}
+            """#
+        )
+        let rows = testCase.iterations[0].activities
+        XCTAssertEqual(rows.map(\.title), ["F.swift:9: solo boom"])
+        XCTAssertEqual(rows.map(\.isFailure), [true])
+    }
+
+    // MARK: - Fixture pins for the bookkeeping-row rules
+
+    /// The attachment-shadow join's guards are load-bearing: on
+    /// `testWithSpecialChars()` the genuine assertion row shares the
+    /// attachment's millisecond, and only `leaf`+`non-failure` keep it out of
+    /// the shadow rule's mouth. The shadow row itself — titled with the
+    /// attachment's user name — must be gone.
+    func testSameMillisecondFailureSurvivesTheShadowJoin() throws {
+        let specialChars = try XCTUnwrap(
+            try testCases(in: read("TestResults"))
+                .first { $0.identifier == "FirstSuite/testWithSpecialChars()" }
+        )
+        let rows = flattened(specialChars.iterations[0].activities)
+        XCTAssertFalse(
+            rows.contains { $0.title.hasPrefix("FileName with DoubleQuote") },
+            "The attachment's shadow row must be dropped"
+        )
+        XCTAssertTrue(
+            rows.contains { $0.isFailure && $0.title.contains("failed on purpose") },
+            "The genuine failure row sharing the shadow's millisecond must survive"
+        )
+        let container = try XCTUnwrap(
+            rows.first { $0.title.hasPrefix("Activity with DoubleQuote") }
+        )
+        XCTAssertFalse(container.attachments.isEmpty, "The attachment itself stays")
+    }
+
+    /// Expected failures are non-events in the report, exactly as legacy has
+    /// always rendered them: the `XCTExpectFailure` message claims and removes
+    /// its matching activity row (exact title match), and nothing is appended.
+    func testExpectedFailureRowsAreClaimedAndRemoved() throws {
+        let expected = try XCTUnwrap(
+            try testCases(in: read("RetryResults"))
+                .first { $0.identifier == "RetryTests/testInUnknownState()" }
+        )
+        let rows = flattened(expected.iterations[0].activities)
+        XCTAssertFalse(
+            rows.contains { $0.title.contains("Expecting a failure here") },
+            "The expected-failure activity row must be claimed and removed"
+        )
+        XCTAssertFalse(
+            rows.contains(where: \.isFailure),
+            "No failure row may be appended for an expected failure"
+        )
+        XCTAssertTrue(
+            rows.contains { $0.title == "Tear Down" },
+            "Only the expected-failure rows disappear, not the timeline"
+        )
+    }
+
+    /// Content-addressed export names carry `~` and `=`; the rendered `src`
+    /// and `data` attributes must point at files that actually exist next to
+    /// the report, or every attachment link in a linking-mode report is dead.
+    func testLinkingModeSourcesResolveToExportedFiles() throws {
+        let source = try XCTUnwrap(
+            Bundle.testBundle.url(forResource: "TestResults", withExtension: "xcresult")
+        )
+        let copy = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathComponent(source.lastPathComponent)
+        try FileManager.default.createDirectory(
+            at: copy.deletingLastPathComponent(), withIntermediateDirectories: true
+        )
+        try FileManager.default.copyItem(at: source, to: copy)
+
+        let summary = Summary(
+            resultPaths: [copy.path],
+            renderingMode: .linking,
+            downsizeImagesEnabled: false,
+            downsizeScaleFactor: 1,
+            backend: .modern
+        )
+        let html = summary.generatedHtmlReport()
+
+        let pattern = try NSRegularExpression(
+            pattern: #"(?:src|data)="(TestResults\.xcresult/[^"]+)""#
+        )
+        let range = NSRange(html.startIndex..., in: html)
+        let sources = pattern.matches(in: html, range: range).compactMap { match in
+            Range(match.range(at: 1), in: html).map { String(html[$0]) }
+        }
+        XCTAssertFalse(sources.isEmpty, "No attachment sources rendered — vacuous")
+        XCTAssertTrue(
+            sources.contains { $0.contains("~") && $0.contains("=") },
+            "Content-addressed names must exercise the URL-hostile characters"
+        )
+        let outputRoot = copy.deletingLastPathComponent()
+        for relative in Set(sources) {
+            XCTAssertTrue(
+                FileManager.default.fileExists(
+                    atPath: outputRoot.appendingPathComponent(relative).path
+                ),
+                "Rendered source '\(relative)' resolves to no exported file"
+            )
+        }
+    }
+}

--- a/Tests/XCTestHTMLReportTests/ModernResultReaderTests.swift
+++ b/Tests/XCTestHTMLReportTests/ModernResultReaderTests.swift
@@ -149,9 +149,12 @@ final class ModernResultReaderTests: XCTestCase {
     }
 
     /// The retried test's assertion fires inside the user's own activity, so
-    /// the activities document nests the failure row. The join must retitle it
-    /// in place — nested, positioned, timestamped — not append a duplicate.
-    func testNestedRetryFailureIsRetitledInPlace() throws {
+    /// the activities document nests the failure row. The join retitles it,
+    /// and the hoist then moves it to the top level — positioned by its own
+    /// timestamp through the shared interleave — because the legacy format
+    /// cannot nest failure rows and re-nesting legacy's by time window was
+    /// tested and rejected (windows collide at millisecond granularity).
+    func testNestedRetryFailureIsRetitledAndHoisted() throws {
         let retried = try XCTUnwrap(
             try testCases(in: read("RetryResults"))
                 .first { $0.identifier == "RetryTests/testRetryOnFailure()" }
@@ -161,15 +164,39 @@ final class ModernResultReaderTests: XCTestCase {
             firstAttempt.activities.first { $0.title == "Retryable Activity" },
             "The user-created activity must survive translation"
         )
-        let nested = try XCTUnwrap(
-            flattened(wrapper.subActivities).first { $0.isFailure },
-            "The failure row stays nested under the activity it fired in"
+        XCTAssertFalse(
+            wrapper.isFailure,
+            "The container is not the assertion row; only the tip of the flagged chain is"
         )
         XCTAssertTrue(
-            nested.title.hasPrefix("RetryTests.swift:"),
-            "Nested failure rows are retitled from the Failure Message node too — got '\(nested.title)'"
+            flattened(wrapper.subActivities).isEmpty,
+            "The failure row must be hoisted out of the activity it fired in"
         )
-        // And nothing appended a second copy at the top level.
+
+        let hoisted = try XCTUnwrap(
+            firstAttempt.activities.first(where: \.isFailure),
+            "The hoisted failure row surfaces at the top level"
+        )
+        XCTAssertTrue(
+            hoisted.title.hasPrefix("RetryTests.swift:"),
+            "Hoisted failure rows are retitled from the Failure Message node too — got '\(hoisted.title)'"
+        )
+        XCTAssertNotNil(
+            hoisted.start,
+            "The hoisted row keeps its own timestamp; the shared interleave positions it"
+        )
+        // Positioned where it occurred: the assertion fired during the
+        // user-created activity, so start-keyed interleaving puts the row
+        // right after it, not at the end of the test.
+        let titles = firstAttempt.activities.map(\.title)
+        let wrapperIndex = try XCTUnwrap(titles.firstIndex(of: "Retryable Activity"))
+        let failureIndex = try XCTUnwrap(titles
+            .firstIndex(where: { $0.hasPrefix("RetryTests.swift:") }))
+        XCTAssertEqual(
+            failureIndex, wrapperIndex + 1,
+            "Start-keyed interleave places the failure beside the activity it fired in"
+        )
+        // And nothing appended a second copy anywhere.
         XCTAssertEqual(
             flattened(firstAttempt.activities).filter { $0.title.hasSuffix(": failed") }.count,
             1

--- a/Tests/XCTestHTMLReportTests/PortRuleTests.swift
+++ b/Tests/XCTestHTMLReportTests/PortRuleTests.swift
@@ -1,0 +1,148 @@
+//
+//  PortRuleTests.swift
+//
+//  Direct unit tests for the port-level rules both readers share. These are
+//  the rules the differential relies on to make the backends agree by
+//  construction, so each is pinned in isolation with crafted inputs rather
+//  than only through fixture renders.
+//
+
+import Foundation
+import XCTest
+@testable import XCTestHTMLReportCore
+
+final class PortRuleTests: XCTestCase {
+    // MARK: - ParsedActivity.interleavingFailureRows
+
+    private func activity(
+        _ title: String, start: Date?, isFailure: Bool = false
+    ) -> ParsedActivity {
+        ParsedActivity(
+            title: title, isFailure: isFailure, start: start, attachments: [],
+            subActivities: []
+        )
+    }
+
+    private let epoch = Date(timeIntervalSince1970: 1786584757)
+
+    func testInterleaveOrdersByStart() {
+        let merged = ParsedActivity.interleavingFailureRows(
+            activities: [
+                activity("first", start: epoch),
+                activity("third", start: epoch.addingTimeInterval(2)),
+            ],
+            failureRows: [activity("second", start: epoch.addingTimeInterval(1), isFailure: true)]
+        )
+        XCTAssertEqual(merged.map(\.title), ["first", "second", "third"])
+    }
+
+    /// The tie this exists for is hit in practice, not hypothetically: at the
+    /// format's millisecond granularity an assertion's timestamp routinely
+    /// equals its enclosing activity's start — measured on
+    /// `testWithSpecialChars()` (activity and failure both at …37.696) and on
+    /// `ThirdSuite/testOne()` (failure at …37.873 tying two activities).
+    func testInterleaveBreaksEqualStartsActivityFirst() {
+        let merged = ParsedActivity.interleavingFailureRows(
+            activities: [activity("the activity", start: epoch)],
+            failureRows: [activity("the failure", start: epoch, isFailure: true)]
+        )
+        XCTAssertEqual(merged.map(\.title), ["the activity", "the failure"])
+    }
+
+    /// A row with no timestamp is an unpositioned annotation (appended failure
+    /// message, skip notice) and sorts after the whole timeline — not before
+    /// it, which is where a naive `nil -> .distantPast` would put it.
+    func testInterleaveOrdersNilStartsLast() {
+        let merged = ParsedActivity.interleavingFailureRows(
+            activities: [activity("timed", start: epoch)],
+            failureRows: [
+                activity("skip notice", start: nil, isFailure: true),
+                activity("timed failure", start: epoch, isFailure: true),
+            ]
+        )
+        XCTAssertEqual(
+            merged.map(\.title), ["timed", "timed failure", "skip notice"]
+        )
+    }
+
+    /// The order must be *total*: identical rows fall back to source index,
+    /// so the result is one deterministic sequence, not whatever the sort
+    /// algorithm happens to do with incomparable elements. The comparator
+    /// this helper replaced was non-total once before (#443).
+    func testInterleaveIsTotalOnIdenticalRows() {
+        let rows = (0 ..< 8).map { index in
+            activity("failure \(index)", start: epoch, isFailure: true)
+        }
+        let merged = ParsedActivity.interleavingFailureRows(
+            activities: [], failureRows: rows
+        )
+        XCTAssertEqual(merged.map(\.title), rows.map(\.title))
+    }
+
+    // MARK: - LegacyResultReader.mergingArgumentExecutions
+
+    private func iteration(
+        number: Int?, status: ParsedStatus, duration: TimeInterval = 1
+    ) -> ParsedIteration {
+        ParsedIteration(
+            iterationNumber: number, status: status, duration: duration,
+            activities: [activity("a", start: epoch)]
+        )
+    }
+
+    func testArgumentExecutionsMergeIntoOneIteration() {
+        let merged = LegacyResultReader.mergingArgumentExecutions([
+            iteration(number: nil, status: .passed, duration: 0.25),
+            iteration(number: nil, status: .passed, duration: 0.5),
+            iteration(number: nil, status: .passed, duration: 0.25),
+        ])
+        XCTAssertEqual(merged.count, 1)
+        XCTAssertEqual(merged[0].status, .passed)
+        XCTAssertEqual(merged[0].duration, 1.0, accuracy: 0.0001)
+        XCTAssertEqual(
+            merged[0].activities.count, 3,
+            "Activities concatenate in source order"
+        )
+    }
+
+    func testArgumentExecutionMergeReportsFailureWhenAnyArgumentFails() {
+        let merged = LegacyResultReader.mergingArgumentExecutions([
+            iteration(number: nil, status: .passed),
+            iteration(number: nil, status: .failed),
+        ])
+        XCTAssertEqual(merged.map(\.status), [.failed])
+    }
+
+    /// True retries carry `repetitionPolicySummary` numbers, and must keep
+    /// their iteration structure — this is the boundary that protects
+    /// `RetryResults`' mixed-status rendering.
+    func testNumberedRepetitionsAreNeverMerged() {
+        let retries = [
+            iteration(number: 1, status: .failed),
+            iteration(number: 2, status: .passed),
+        ]
+        XCTAssertEqual(
+            LegacyResultReader.mergingArgumentExecutions(retries).count, 2
+        )
+    }
+
+    // MARK: - ParsedAttachment.exportFileName
+
+    func testExportFileNameIsPayloadIdPlusExtension() {
+        XCTAssertEqual(
+            ParsedAttachment.exportFileName(
+                payloadId: "0~qL1-DW_x8=", filenameExtension: "mp4"
+            ),
+            "0~qL1-DW_x8=.mp4"
+        )
+        XCTAssertEqual(
+            ParsedAttachment.exportFileName(payloadId: "0~abc", filenameExtension: nil),
+            "0~abc"
+        )
+        XCTAssertEqual(
+            ParsedAttachment.exportFileName(payloadId: "a/b", filenameExtension: "txt"),
+            "a_b.txt",
+            "A path separator in a future id shape must not escape the bundle directory"
+        )
+    }
+}

--- a/Tests/XCTestHTMLReportTests/Resources/differential-allowlist.json
+++ b/Tests/XCTestHTMLReportTests/Resources/differential-allowlist.json
@@ -1,0 +1,25 @@
+{
+  "comment": "Each entry names one field the modern xcresulttool format does not provide, and the masking rule that removes its effect from a rendered report. The differential test masks BOTH renders with every rule here and then requires them to be byte-identical: after the declared losses are removed, nothing else may differ. Adding an entry means accepting a permanent difference between the backends — a design decision, not a way to quiet a failing test. Task 2.5 voided an earlier entry (activityTypeClasses) by removing the field from the port instead of masking the divergence; prefer that route to adding an entry here. Entries cannot rot either: a rule that no longer masks any real divergence fails testEveryAllowListEntryStillMasksARealDivergence, so the list shrinks the moment Apple fills a gap.",
+  "knownLosses": [
+    {
+      "rule": "durations",
+      "field": "group and suite duration",
+      "effect": "GROUP durations, not activity ones. durationInSeconds is null on every Test Suite, Test Plan, UI test bundle and Unit test bundle node in all three fixtures, so modern renders (0.00s) where legacy reports a real value -- FirstSuite 0.699s, SecondSuite 0.126s, ThirdSuite 0.132s, SampleAppUnitTests 0.213s. Swift Testing test cases are null the same way. These are real suite names, so wrapperGroups does not mask them. Unrelated to ParsedActivity.finish: an earlier revision deleted this entry believing removing that field removed all duration divergence."
+    },
+    {
+      "rule": "attachmentDisplayNames",
+      "field": "attachment user-supplied name",
+      "effect": "Attachment display names fall back to the type-derived label (Screenshot, Video, File) on the modern backend, because the new format exposes only the generated filename."
+    },
+    {
+      "rule": "failureTitlePrefix",
+      "field": "failure file and line",
+      "effect": "Failure activity titles are the pre-joined message rather than '<issueType> at <file>:<line>:<message>'."
+    },
+    {
+      "rule": "wrapperGroups",
+      "field": "test tree wrapper groups",
+      "effect": "The modern tree omits the legacy 'Selected tests' / 'All tests' and '<target>.xctest' wrapper levels."
+    }
+  ]
+}

--- a/Tests/XCTestHTMLReportTests/ResultBackendTests.swift
+++ b/Tests/XCTestHTMLReportTests/ResultBackendTests.swift
@@ -24,6 +24,30 @@ final class ResultBackendTests: XCTestCase {
         XCTAssertNotEqual(ResultBackend.legacy.resolve(), .use(.modern))
     }
 
+    /// `XCHR_RESULT_READER` is the CI override that drives the forced-modern
+    /// job leg: it defaults every `Summary` and the CLI flag, so `swift test`
+    /// under it exercises the whole suite on one backend. Unset or garbage
+    /// must fall back to `.auto` — an env var has no parser to reject it.
+    func testEnvironmentOverrideSelectsTheBackend() {
+        let original = ProcessInfo.processInfo.environment["XCHR_RESULT_READER"]
+        defer {
+            if let original {
+                setenv("XCHR_RESULT_READER", original, 1)
+            } else {
+                unsetenv("XCHR_RESULT_READER")
+            }
+        }
+
+        setenv("XCHR_RESULT_READER", "modern", 1)
+        XCTAssertEqual(ResultBackend.fromEnvironment(), .modern)
+        setenv("XCHR_RESULT_READER", "legacy", 1)
+        XCTAssertEqual(ResultBackend.fromEnvironment(), .legacy)
+        setenv("XCHR_RESULT_READER", "not-a-backend", 1)
+        XCTAssertEqual(ResultBackend.fromEnvironment(), .auto)
+        unsetenv("XCHR_RESULT_READER")
+        XCTAssertEqual(ResultBackend.fromEnvironment(), .auto)
+    }
+
     func testAutoNeverResolvesToAuto() {
         XCTAssertNotEqual(ResultBackend.auto.resolve(), .use(.auto))
         XCTAssertNotEqual(ResultBackend.auto.resolve(), .legacyUnavailable)

--- a/docs/superpowers/plans/2026-08-10-xcresulttool-legacy-migration.md
+++ b/docs/superpowers/plans/2026-08-10-xcresulttool-legacy-migration.md
@@ -3623,6 +3623,31 @@ git commit -m "feat: select the result reader at runtime with --result-reader"
 What actually proves the migration. Runs both readers over one bundle and holds
 the diff to a declared list.
 
+> **Execution note (2026-08-12).** Landed; every snippet below is intent, and
+> the shipped implementation supersedes them in four ways, each forced by
+> evidence from the first real differential run (the run also root-caused
+> #449; the rulings live in the spec's "Task 12 execution rules"):
+>
+> 1. The `wrapperGroups` rule is structural, not line-filtering: dropping the
+>    heading *line* left the wrapper's 6-line div skeleton and its closing
+>    tag behind (measured on every fixture), so the masker parses with
+>    SwiftSoup (`prettyPrint(false)` preserves the other rules' line anchors),
+>    removes the wrapper's heading, and unwraps the element — matching the
+>    div *and its close*, as Step 3's own escape hatch prescribes.
+> 2. The `attachmentDisplayNames` regex below never matched: the `[[NAME]]`
+>    line is the *third* template line — a type-icon `<span>` sits between
+>    the `<p>` and the name — so the shipped anchor spans both preceding
+>    lines.
+> 3. `mask()` canonicalizes line joins (`>\s+<` → one tag per line) before
+>    comparing: template concatenation joins sibling blocks onto one line,
+>    and *which* boundaries join shifts once wrapper levels are unwrapped —
+>    same DOM, different line breaks.
+> 4. Anti-rot is enforced by a necessity probe, not by matching: a rule
+>    "fires" only if leaving it out (others still applied) leaves the two
+>    renders unequal. `testEveryAllowListEntryStillMasksARealDivergence`
+>    fails on any entry that fires on no fixture. The four entries all fire;
+>    the allow-list gained nothing.
+
 **Files:**
 - Create: `Tests/XCTestHTMLReportTests/DifferentialTests.swift`
 - Create: `Tests/XCTestHTMLReportTests/Resources/differential-allowlist.json`
@@ -4374,6 +4399,25 @@ Add a section covering `--result-reader auto|legacy|modern`, that `auto`
 prefers legacy while the toolchain offers it, the `--json` schema change with a
 before/after snippet, and the known differences between backends (drawn from
 the allow-list, not re-derived).
+
+**Release-notes checklist (added during Task 12 — every item is a 4.0
+output change accepted by ruling; see the spec's "Task 12 execution rules"):**
+
+- [ ] On-disk attachment names are content-addressed
+      (`<payloadId>.<ext>`) on **both** backends; display names in the
+      report are unchanged. Byte-identical payloads deduplicate to one file.
+      This also fixes intermittent `payloadExportFailed` degradation on
+      Xcode 26.2 screen recordings (#449).
+- [ ] The exported run log is named `<run-identifier-digest>.log` instead of
+      the backend-internal reference name (`<CAS id>.log` today).
+- [ ] Parameterized Swift Testing `@Test(arguments:)` cases render as one
+      test case instead of N pseudo-repetitions ("3 succeeded" /
+      `Iteration 0` rows).
+- [ ] Skipped tests now show their skip reason as a row; it was always in
+      the bundle, the legacy reader never read it.
+- [ ] Assertion-failure rows render where the assertion fired (interleaved
+      by start on both backends); expected failures render nothing, as
+      before, on both backends.
 
 - [ ] **Step 2: Mark the spec's phases 1-5 done**
 

--- a/docs/superpowers/specs/2026-08-10-xcresulttool-legacy-migration-design.md
+++ b/docs/superpowers/specs/2026-08-10-xcresulttool-legacy-migration-design.md
@@ -65,7 +65,7 @@ asymmetries the differential still has to mask.
 | group / suite `duration` | `durationInSeconds` is `null` on every suite, plan and bundle node | **lost** — unrelated to `finish`; masked by the `durations` allow-list entry |
 | activity `uuid` | absent | synthesized locally (already how the HTML uses it) |
 | attachment `name` (user-supplied, e.g. `"HTML"`) | `name` holds the legacy *filename* | **lost** — present only in a sibling child-activity title |
-| attachment `filename` | `name` | maps, renamed |
+| attachment `filename` | `name` | ~~maps, renamed~~ **superseded (2026-08-12)** — true for user attachments, false for auto screen recordings, so both backends now derive export names from the shared payload id; see "Content-addressed attachment exports" |
 | attachment `uniformTypeIdentifier` | absent | **dropped** (answer 4) — both backends type from the file extension |
 | attachment `payloadRef.id` | `payloadId` | present, but payload-by-id export is itself a legacy command |
 | `ActionTestFailureSummary.fileName` / `.lineNumber` / `.issueType` | one string on the `Failure Message` node: `"RetryTests.swift:31: XCTAssertTrue failed"` | **lost as structure**, text preserved |
@@ -96,9 +96,14 @@ which the new format does not expose, so one of the two labels would always be
 fabricated. The modern tree is also the more consistent one — legacy places
 Swift Testing suites at a different depth than XCTest suites.
 
-Swift Testing display names also differ: legacy reports
-`taggedMultiplication()`, modern reports the `@Test` display name
-`Tagged multiplication check`.
+Swift Testing display names are a **model rule, not a rendering
+observation** *(amended during Task 12)*: the legacy format carries only the
+function-form name (`taggedMultiplication()`), the modern format's `name`
+holds the `@Test` display name (`Tagged multiplication check`), and a name
+only one backend can fill does not belong in the port — the same rule that
+removed `activityType`. Both readers therefore carry the function-form name
+from the test identifier's last component, and the display name is
+deliberately unused until the redesign models it.
 
 ### Attachments
 
@@ -313,7 +318,7 @@ that field.
 
 | Rule | What still differs | Exercised by |
 | --- | --- | --- |
-| `attachmentDisplayNames` | Modern exposes only the generated filename, so display names fall back to the type-derived label (`Screenshot`, `Video`, `File`). No modern source for the user-supplied name. | `TestResults` — `FirstSuite/testWithSpecialChars()` and `testAttachHtmlData()` both set `XCTAttachment.name` |
+| `attachmentDisplayNames` | Modern exposes only the generated filename, so display names fall back to the type-derived label (`Screenshot`, `Video`, `File`). No modern source for the user-supplied name. | `TestResults` — `FirstSuite/testWithSpecialChars()` and `testAttachHtmlData()` both set `XCTAttachment.name`; `RetryResults` — screen recordings show the raw `kXCTAttachmentScreenRecording` constant on legacy, the `Video` fallback on modern *(added during Task 12, measured)* |
 | `failureTitlePrefix` | Legacy renders `<issueType> at <file>:<line>:<message>`; modern's `Failure Message` node gives `<file>:<line>: <message>` pre-joined, with no `issueType`. | `TestResults` — every failing case; `RetryResults` — `testJustFail()` |
 | `wrapperGroups` | Modern omits the legacy `Selected tests` / `All tests` and `<target>.xctest` levels. A deliberate render difference, not a format loss. | `TestResults` — both bundles; `SanityResults` |
 | `durations` | **Group** durations, not activity ones. `durationInSeconds` is `null` on every `Test Suite`, `Test Plan` and `*test bundle` node in all three fixtures, so modern renders `(0.00s)` where legacy reports a real value — `FirstSuite` 0.699s, `SecondSuite` 0.126s, `ThirdSuite` 0.132s, `SampleAppUnitTests` 0.213s. Swift Testing test *cases* are `null` the same way. These are real suite names, so `wrapperGroups` does not mask them. | all three fixtures |
@@ -434,6 +439,110 @@ regexing them back out, since that would build visible UI on an inferred parse
 of a format Apple can reformat without notice. The residual difference — legacy
 renders `Assertion Failure at FirstSuite.swift:66:...`, modern renders
 `FirstSuite.swift:66: ...` — is a declared entry in the diff allow-list.
+
+### Task 12 execution rules (2026-08-12)
+
+Running the differential for the first time surfaced divergences the tables
+above did not anticipate. Each was resolved by a rule, recorded here with its
+reasoning; **none added an allow-list entry** — the list stands at the four
+above, and every rule below follows the settled doctrine: agree by
+construction over mask, and never model what only one backend can fill.
+
+**Content-addressed attachment exports (fixes #449).** Xcode 26.2 gives every
+auto screen recording in a session one shared display name
+(`Screen Recording <timestamp>.mp4` — in the activities document *and* the
+manifest's `suggestedHumanReadableName`), and the legacy pretty filename
+embeds a legacy-only uuid the modern format cannot see. Naming exports after
+either backend's pretty name therefore broke both ways at once: distinct
+payloads collapsed onto one path (every video row played the same recording),
+concurrent copies raced on it and intermittently recorded a spurious
+`.payloadExportFailed` — root-caused as #449 with a live `EEXIST` trace whose
+`fileExists` recovery check lost to a third thread's `removeItem`. The one
+attachment identifier both formats share is the content-addressed payload id
+(legacy `payloadRef.id` == modern `payloadId`, the same CAS id), so both
+backends name every exported payload
+`ParsedAttachment.exportFileName(payloadId:filenameExtension:)`. Names agree
+by construction, the export is idempotent (a file already at the destination
+*is* the payload — never removed, never rewritten), and byte-identical
+payloads deduplicate to one file. 4.0 release note: on-disk attachment names
+change for every user; display names in the report do not.
+
+**Symbol-annotation rows are dropped.** The 26.2 activities document nests
+backtrace-frame rows under failures (`RetryTests.testJustFail()`,
+`closure #1 in …`) — exactly the rows with no `startTime`. The timeline model
+orders on `start` (answer 1); a row without one is an annotation, not an
+event. A no-start row carrying attachments, a failure flag, or surviving
+children is kept, not dropped — rendering it unordered beats silently gutting
+real content if a future format variant stops stamping times.
+
+**Attachment-shadow rows are dropped by a timestamp join.** For every
+attachment the document also emits one childless, non-failure child row whose
+`startTime` equals the attachment's `timestamp` (title: the attachment's
+user-supplied name — which stays unmined, per "Reconstructing lost fields by
+heuristic"). The row is the attachment's shadow and is claimed by the join,
+mirroring the failure-message join. The leaf and non-failure guards are
+load-bearing, not decorative: on `testWithSpecialChars()` a genuine failure
+row shares the attachment's millisecond and must survive — pinned by
+`testSameMillisecondFailureSurvivesTheShadowJoin`.
+
+**Parameterized executions merge on legacy.** A Swift Testing
+`@Test(arguments:)` reaches the legacy format as duplicate sibling metadata
+entries sharing one identifier — the retry encoding, minus the
+`repetitionPolicySummary`. Rendering them as repetitions invents retry
+semantics ("3 succeeded", three `Iteration 0` rows) for what are argument
+variations, and the modern format renders one case. The legacy reader merges
+same-identifier siblings that all lack repetition metadata into one iteration
+(durations summed per answer 8; failed > skipped > passed precedence,
+mirroring the modern parent node's own summary). True retries always carry
+the policy summary and are untouched — `RetryResults` pins `[1, 2]` and
+`.mixed`. 4.0 release note: legacy rendering of parameterized tests changes.
+
+**Expected failures are non-events, enforced by an inverted join.** Legacy
+has always rendered nothing for `XCTExpectFailure` (status flattens to
+`.unknown`); the modern documents carry both the message and a matching
+activity row. For a test whose result is `Expected Failure`, each `Failure
+Message` claims and *removes* the first activity whose title equals the
+message **exactly — never fuzzily**, subtree included, and unmatched messages
+are suppressed rather than appended.
+
+**Skip notices were a legacy reader gap, now read.** The modern reader has
+always surfaced the skip reason (an unmatched `Failure Message`, appended);
+the legacy format carries the identical string on
+`ActionTestSummary.skipNoticeSummary`, which the reader simply never read.
+It now appends the same row — title as given, no timestamp — so both
+backends surface the reason identically. Today's report gains a row it never
+had; that is a fix, not a regression: the reason was in the bundle all along.
+
+**Failure-row placement goes through one shared function.** The modern
+format nests an assertion row inside the activity it fired in and flags every
+ancestor (`isAssociatedWithFailure`); the legacy format structurally cannot
+nest (post-3.39 failure summaries are separate objects). Re-nesting legacy's
+rows by `[start, finish]` window was tested and rejected on evidence: at the
+format's millisecond granularity the windows collide (`SecondSuite`'s failure
+timestamp sits inside `Set Up`'s window; `ThirdSuite`'s deliberately bare
+top-level assertion sits inside a *sibling* activity's window), so the join
+misplaces rows — exactly the heuristic reconstruction this spec bans. The
+resolution inverts it: `ParsedActivity.isFailure` means "this row IS the
+assertion row" (modern maps the tip of the flagged chain — flagged with no
+flagged children; each such node is a tip independently), and the modern
+reader hoists failure tips out of the tree, feeding
+`ParsedActivity.interleavingFailureRows` — the same function the legacy
+reader feeds its failure-summary list. One function is the strongest form of
+agree-by-construction: the order is total — `(start, activities before
+failure rows on tie, source index)`, `nil` starts last — and neither reader
+may sort these rows independently. **The hoist is a scaffold constraint, not
+a design preference**: it exists so the differential can hold both backends
+to one placement while both exist. Once the legacy backend is removed, the
+modern reader may stop hoisting and the redesign may restore the native
+nesting.
+
+**Run-log exports are named from the run's identifier path.** Legacy named
+the exported log after its CAS id, modern after the literal `action` — both
+backend-internal, so the names could never agree. Both now write
+`<run-identifier-path-digest>.log` (the same #430 scheme every element id
+uses): identical across backends by construction, and unique per run, so a
+multi-action bundle gets one log per action instead of last-writer-wins. 4.0
+release note: the log file's on-disk name changes.
 
 ## `--json` becomes our own schema
 


### PR DESCRIPTION
THE DIFFERENTIAL — the test this migration exists to pass, landed while both backends still exist to compare. Renders every fixture through **both** readers, asserts structural equality exactly, and holds the HTML diff to the four declared allow-list entries — nothing more, nothing less, enforced in both directions. Plus the forced-`modern` CI leg so both paths run on every PR (Tasks 12–13 of the [migration plan](docs/superpowers/plans/2026-08-10-xcresulttool-legacy-migration.md)).

Fixes #449. Refs #391. Milestone 4.0.

## Differential results (Xcode 26.2 17C52, xcresulttool 24514, fresh fixture generation)

**`swift test --filter DifferentialTests` — all 6 tests pass:**

| Assertion | TestResults | SanityResults | RetryResults |
| --- | --- | --- | --- |
| Per-run counts (all/passed/skipped/failed/mixed) | equal | equal | equal |
| identifier → status map | equal | equal | equal |
| Run counts | equal | equal | equal |
| XCTest case durations (±0.5 ms) | equal | equal | equal |
| Exported attachment **filenames** | **exactly equal** | exactly equal | **exactly equal** |
| Exported attachment **bytes** | **exactly equal** | exactly equal | **exactly equal** |
| Masked HTML diff (identifiers normalized, `[0-9a-f]{32}` per #430) | **0 lines** | **0 lines** | **0 lines** |

**Allow-list anti-rot (necessity probe: a rule "fires" only if omitting it leaves the renders unequal):**

| Entry | TestResults | SanityResults | RetryResults | Spec "Exercised by" |
| --- | --- | --- | --- | --- |
| `durations` | fires | fires | fires | all three ✓ |
| `attachmentDisplayNames` | fires | — | fires | TestResults ✓ (+ RetryResults, spec cell amended: recordings show `kXCTAttachmentScreenRecording` vs `Video`) |
| `failureTitlePrefix` | fires | — | fires | TestResults + RetryResults ✓ |
| `wrapperGroups` | fires | fires | fires | TestResults + SanityResults ✓ |

All four entries fire; a diff outside the list fails the build; an entry that fires nowhere also fails (`testEveryAllowListEntryStillMasksARealDivergence`), so entries cannot rot once Apple fills a gap. The list stands at **exactly the spec's four entries — the first differential run added none.**

## #449: reproduced, root-caused, fixed

- **Reproduced**: 1-in-12 flake of `testModernRenderOfEveryFixtureRecordsNoFaults` on a fresh RetryResults generation; two of five CLI renders degraded (exit 3).
- **Root cause**: Xcode 26.2 gives *every* auto screen recording in a session one shared display name (`Screen Recording <timestamp>.mp4` — verified in both the activities document and the manifest's `suggestedHumanReadableName`). `ModernPayloadStore` used that name as its copy destination, so distinct payloads collapsed onto one path and concurrent test-case builds raced remove/copy on it. Live trace captured: `copyItem` threw `EEXIST`, and by the time the `fileExists` recovery check ran, a third thread's `removeItem` had deleted the file again → spurious `.payloadExportFailed` + `unresolvedAttachment` → exit 3. Generation-variant because the collision needs same-second recording names; CI's Xcode 26.6 names differ.
- **Fix**: content-addressed exports (below). The export is idempotent — an existing destination *is* the payload; nothing is ever removed. Pinned by `testExportPayloadIsIdempotentForTheSameDestination`; the no-faults test now passes consistently.

## The rulings (all coordinator-approved; spec's new "Task 12 execution rules" section)

The first real differential run surfaced divergences the spec's tables didn't anticipate. Every resolution follows the settled doctrine — agree by construction over mask; never model what only one backend can fill:

1. **R1 — content-addressed attachment exports.** Legacy filenames embed a legacy-only uuid; modern's names collide (above). The payload id is the same CAS id in both formats (verified value-for-value), so both backends export `<payloadId>.<ext>` via one shared helper. Filenames agree by construction; byte-identical payloads deduplicate. Rendered `src`/`data` links resolve on disk with `~`/`=` in names (`testLinkingModeSourcesResolveToExportedFiles`).
2. **R2 — symbol-annotation rows dropped.** 26.2 nests backtrace rows (`closure #1 in …`) under failures; they are exactly the rows with no `startTime`. Kept if they ever carry attachments/failure flags/children.
3. **R3 — attachment-shadow rows dropped by timestamp join** (leaf + non-failure + startTime == sibling attachment's timestamp; verified on all 15 shadow rows across fixtures). The guards are load-bearing: a genuine failure row shares the attachment's millisecond on `testWithSpecialChars()` — pinned by test.
4. **R4 — Swift Testing names from the identifier's function form** on both backends; the `@Test` display name is a field only one backend can fill (spec's Tree-shape paragraph amended to a model rule).
5. **R5 — legacy merges parameterized argument executions** (duplicate siblings *without* `repetitionPolicySummary`) into one iteration, durations summed. True retries keep numbers — `RetryResults` pins `[1, 2]` + `.mixed`.
6. **R6 — expected failures are non-events on both backends**: messages claim-and-remove their matching activity rows by **exact** title match; unmatched messages are suppressed, never appended. Pinned on `testInUnknownState()`.
7. **R7 — run logs export as `<run-identifier-digest>.log`** on both backends (the #430 id scheme) instead of backend-internal names (`<CAS id>.log` vs `action.log`); unique per action, so multi-action bundles can't last-writer-win (asserted by comment — no fixture has two actions).
8. **R8 — failure-row placement through one shared function.** Modern nests assertion rows and flags whole ancestor chains; legacy structurally cannot nest. Re-nesting legacy rows by `[start, finish]` window was **tested and rejected on evidence**: at millisecond granularity `SecondSuite`'s failure timestamp sits inside `Set Up`'s window and `ThirdSuite`'s bare top-level assertion sits inside a *sibling*'s window — the heuristic reconstruction the spec bans. Instead: `ParsedActivity.isFailure` now means "this row IS the assertion row" (tip of the flagged chain), and the modern reader hoists tips into `ParsedActivity.interleavingFailureRows` — the same total-ordered function the legacy reader feeds (`(start, activities-before-failures-on-tie, source index)`; nil-start rows sort last; totality unit-pinned after #443's non-total-comparator history). The hoist is documented as a **reversible scaffold constraint**: when legacy dies, native nesting may return.
   - Plus one reader-gap fix found by the differential: **skip reasons**. The legacy format always carried the reason on `skipNoticeSummary`; the reader never read it. Both backends now render the identical appended row.

## Task 13: forced-modern CI leg

- `test.yml` runs a `result_reader: [auto, modern]` matrix (`fail-fast: false`), threading `XCHR_RESULT_READER` through the env; reuses the #436 fixture cache unchanged. No new action steps (nothing new to SHA-pin); **zizmor: no findings; actionlint: clean**.
- `ResultBackend.fromEnvironment()` defaults both `Summary.init` and the CLI's `--result-reader`, so `swift test` and CLI-driven tests both honor the leg; flag still wins when passed. Unset/garbage → `.auto` (unit-pinned).

## Suite results (local, this generation)

- `swift test` (auto): **92 tests, 2 skipped, 0 failures**
- `XCHR_RESULT_READER=modern swift test`: **92 tests, 2 skipped, 0 failures**
- `XCHR_RESULT_READER=auto swift test`: **92 tests, 2 skipped, 0 failures**
- swiftformat + swiftlint clean on changed files (pre-commit hook enforced; `ModernResultReader` split to stay under type-body limits)

## Docs amended in this PR (rules with reasoning, not changelog notes)

- Spec: new **"Task 12 execution rules (2026-08-12)"** section (all rulings above); attachment-`filename` table row superseded; Tree-shape display-name paragraph promoted to a model rule; `attachmentDisplayNames` Exercised-by cell gains RetryResults.
- Plan: Task 12 execution note (four ways the shipped harness supersedes the snippets: structural wrapper unwrap, corrected display-name anchor, line-join canonicalization, necessity-probe anti-rot); Task 15 gains a **release-notes checklist** (on-disk attachment names, log file name, parameterized rendering, skip-reason rows, failure-row placement) so PR G cannot miss the 4.0 output changes.

## New tests

`DifferentialTests` (6), `PortRuleTests` (8: interleave totality incl. the real ms-collision ties, argument-execution merge boundaries, export-name derivation), `ModernReaderRuleTests` (5: crafted-document tip extraction — multi-tip chains and flagged leaves — shadow-join survivor pin, expected-failure removal pin, content-addressed link resolution), store idempotency, env-var override. Existing `testNestedRetryFailureIsRetitledInPlace` updated to the hoist contract (`…RetitledAndHoisted`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic result-reader selection through the `XCHR_RESULT_READER` environment setting.
  * Improved modern and legacy report parsing, including failure handling, retries, skips, and parameterized tests.
  * Standardized attachment and run-log filenames for more reliable linked reports.
  * Improved repeated attachment exports without overwriting existing files.

* **Bug Fixes**
  * Corrected failure-row ordering, expected-failure handling, attachment links, and duplicate test execution merging.
  * Added safeguards for concurrent and repeated file exports.

* **Tests**
  * Added extensive cross-reader comparison and regression coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->