### PR TITLE
`--json` emits ParsedResult behind a documented wire contract + 4.0 release notes (#391, Tasks 14–15)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,6 +82,9 @@ jobs:
       if: failure()
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
-        name: xcresult-fixtures
+        # Suffixed per matrix leg: upload-artifact v4+ refuses duplicate
+        # artifact names, so a run where both legs fail would otherwise lose
+        # the second leg's upload.
+        name: xcresult-fixtures-${{ matrix.result_reader }}
         path: Tests/XCTestHTMLReportTests/Resources
         retention-days: 7

--- a/README.md
+++ b/README.md
@@ -121,8 +121,12 @@ JSON report successfully created at ./report.json
 ```
 
 Starting in 4.0, `report.json` is our own documented, versioned schema —
-[docs/json-schema.md](docs/json-schema.md) is the contract, and the file is
-identical whichever result reader produced it. Earlier versions dumped
+[docs/json-schema.md](docs/json-schema.md) is the contract. The *schema* is
+identical whichever result reader produced it: same keys, same nesting, same
+`schemaVersion`. A few *values* legitimately differ between readers — the
+four differences listed under "Choosing the result reader" below, plus
+`testCase.arguments`, which only the modern reader can populate — and the
+contract documents each one. Earlier versions dumped
 `xcresulttool`'s legacy object graph verbatim; that graph is Apple's
 internal shape and disappears together with the legacy commands, so 4.0
 replaces it once, deliberately. The change is visible at a glance — before:
@@ -180,6 +184,12 @@ avoid:
 - **Group durations.** The new format reports no duration for test suites
   and bundles, so the modern reader shows `(0.00s)` where legacy shows a
   real value.
+
+`--json` output additionally carries `testCase.arguments` (Swift Testing
+`@Test(arguments:)` values), which only the modern reader can populate — the
+legacy format has no counterpart, so it is always `[]` there. See the
+[schema contract](docs/json-schema.md) for how consumers should compare
+reports across readers.
 
 ## Exit codes
 

--- a/README.md
+++ b/README.md
@@ -113,12 +113,73 @@ JUnit report successfully created at report.junit
 You can generate json reports with the `--json` flag
 
 ``` bash
-$ xchtmlreport -json TestResults1
+$ xchtmlreport --json TestResults1
 
 Report successfully created at ./index.html
 
 JSON report successfully created at ./report.json
 ```
+
+Starting in 4.0, `report.json` is our own documented, versioned schema —
+[docs/json-schema.md](docs/json-schema.md) is the contract, and the file is
+identical whichever result reader produced it. Earlier versions dumped
+`xcresulttool`'s legacy object graph verbatim; that graph is Apple's
+internal shape and disappears together with the legacy commands, so 4.0
+replaces it once, deliberately. The change is visible at a glance — before:
+
+``` json
+[{"_type":{"_name":"ActionsInvocationRecord"},"actions":{"_type":{"_name":"Array"},"_values":[...
+```
+
+after:
+
+``` json
+{
+  "runs" : [ ... ],
+  "schemaVersion" : "1.0.0"
+}
+```
+
+Consumers should read `schemaVersion` first and follow the version policy in
+the contract document.
+
+### Choosing the result reader
+
+`xcresulttool`'s legacy API — the way every version before 4.0 read result
+bundles — is deprecated and will be removed from Xcode. `xchtmlreport` now
+has two readers and picks one per run:
+
+``` bash
+$ xchtmlreport --result-reader auto TestResults.xcresult    # the default
+```
+
+- `auto` prefers `legacy` while the toolchain still offers the legacy
+  commands, and falls back to `modern` once they are gone (or when the probe
+  cannot tell).
+- `modern` forces the new-format reader on any toolchain.
+- `legacy` forces the legacy reader; if the toolchain no longer provides the
+  legacy commands this is an error, never a silent substitution.
+
+The `XCHR_RESULT_READER` environment variable sets the default when the flag
+is absent — useful for forcing a whole CI job onto one reader.
+
+Reports from the two readers are held byte-identical by a differential test
+suite, up to a short declared list of differences the new format cannot
+avoid:
+
+- **Attachment display names.** The new format does not expose the
+  user-supplied `XCTAttachment` name, so the modern reader labels
+  attachments by their type (`Screenshot`, `Video`, `File`).
+- **Failure title prefixes.** Legacy renders
+  `Assertion Failure at File.swift:12: message`; modern renders
+  `File.swift:12: message` — the new format pre-joins the string and drops
+  the issue type.
+- **Wrapper groups.** Legacy nests two extra levels
+  (`All tests` / `Selected tests`, then `<target>.xctest`) that the new
+  format does not have; the modern reader renders the natural flat tree.
+- **Group durations.** The new format reports no duration for test suites
+  and bundles, so the modern reader shows `(0.00s)` where legacy shows a
+  real value.
 
 ## Exit codes
 

--- a/Sources/XCTestHTMLReportCore/Classes/Models/JsonReport.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Models/JsonReport.swift
@@ -1,0 +1,278 @@
+//
+//  JsonReport.swift
+//  XCTestHTMLReportCore
+//
+//  The `--json` wire contract, implemented. docs/json-schema.md is the
+//  contract document; this file makes the output match it.
+//
+//  This is a deliberate encoding layer, not a synthesized `Encodable` on the
+//  `Parsed*` model: every key on the wire is an explicit string below, so
+//  renaming a model property breaks this file's compilation instead of
+//  silently renaming a public output key. The model is internal and free to
+//  change; this file is the contract and changes only with a `schemaVersion`
+//  bump per the documented policy.
+//
+//  Two model fields are deliberately not on the wire: `ParsedRun
+//  .logReference` and `ParsedAttachment.payloadReference` are opaque
+//  backend-internal handles (a legacy CAS id, a modern attachment uuid) that
+//  are meaningless outside this process and could never agree across
+//  backends.
+//
+
+import Foundation
+
+// MARK: - JsonReport
+
+/// Encodes parsed runs as the documented `--json` schema.
+struct JsonReport {
+    /// The wire contract's version. Bumped by the policy in
+    /// docs/json-schema.md — never as a side effect of a model change.
+    static let schemaVersion = "1.0.0"
+
+    let runs: [ParsedRun]
+
+    func encoded() -> String {
+        let encoder = JSONEncoder()
+        // Sorted keys make two reports over the same bundle byte-comparable,
+        // which the contract's ordering guarantees promise. Slashes stay
+        // unescaped so test identifiers read as written
+        // ("FirstSuite/testOne()", not "FirstSuite\/testOne()").
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        guard
+            let data = try? encoder.encode(JsonDocument(runs: runs)),
+            let text = String(data: data, encoding: .utf8)
+        else {
+            return "{}"
+        }
+        return text
+    }
+
+    /// The five documented status strings. A switch rather than a raw value
+    /// so that renaming a `ParsedStatus` case cannot silently rename a wire
+    /// value — the compiler forces this list back into review instead.
+    fileprivate static func status(_ status: ParsedStatus) -> String {
+        switch status {
+        case .passed: return "passed"
+        case .failed: return "failed"
+        case .skipped: return "skipped"
+        case .expectedFailure: return "expectedFailure"
+        case .unknown: return "unknown"
+        }
+    }
+
+    /// ISO-8601 UTC with exactly millisecond precision, e.g.
+    /// `2026-08-12T21:22:33.123Z`.
+    ///
+    /// The milliseconds are computed as an integer and appended by hand
+    /// rather than via `.withFractionalSeconds`: both backends store the
+    /// instant as a `Double`, and a value like 0.123 sits just below its
+    /// decimal spelling in binary, so a formatter that truncates can print
+    /// `.122` from one backend's double and `.123` from the other's.
+    /// Rounding to an integer first makes the two spellings agree whenever
+    /// the instants do.
+    fileprivate static func timestamp(_ date: Date) -> String {
+        let totalMilliseconds = Int((date.timeIntervalSince1970 * 1000).rounded())
+        let seconds = totalMilliseconds.quotientAndRemainder(dividingBy: 1000)
+        let base = secondsFormatter.string(
+            from: Date(timeIntervalSince1970: TimeInterval(seconds.quotient))
+        )
+        // "…33Z" → "…33.123Z"
+        return base.dropLast() + String(format: ".%03dZ", seconds.remainder)
+    }
+
+    private static let secondsFormatter: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        formatter.timeZone = TimeZone(identifier: "UTC")
+        return formatter
+    }()
+}
+
+// MARK: - Wire structures
+
+//
+// Each type below hand-writes `encode(to:)` so that the contract's null rule
+// holds mechanically: every documented key is written on every emission, and
+// an absent value is an explicit `null` — `encode` on an `Optional` writes
+// null where the synthesized conformance's `encodeIfPresent` would drop the
+// key entirely.
+//
+
+private struct JsonDocument: Encodable {
+    let runs: [ParsedRun]
+
+    enum CodingKeys: String, CodingKey {
+        case schemaVersion
+        case runs
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(JsonReport.schemaVersion, forKey: .schemaVersion)
+        try container.encode(runs.map(JsonRun.init), forKey: .runs)
+    }
+}
+
+private struct JsonRun: Encodable {
+    let run: ParsedRun
+
+    enum CodingKeys: String, CodingKey {
+        case destination
+        case testables
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(
+            JsonDestination(destination: run.destination), forKey: .destination
+        )
+        try container.encode(run.testables.map(JsonTestable.init), forKey: .testables)
+    }
+}
+
+private struct JsonDestination: Encodable {
+    let destination: ParsedDestination
+
+    enum CodingKeys: String, CodingKey {
+        case displayName
+        case deviceIdentifier
+        case modelName
+        case operatingSystemVersion
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(destination.displayName, forKey: .displayName)
+        try container.encode(destination.deviceIdentifier, forKey: .deviceIdentifier)
+        try container.encode(destination.modelName, forKey: .modelName)
+        try container.encode(
+            destination.operatingSystemVersion, forKey: .operatingSystemVersion
+        )
+    }
+}
+
+private struct JsonTestable: Encodable {
+    let testable: ParsedTestable
+
+    enum CodingKeys: String, CodingKey {
+        case targetName
+        case groups
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(testable.targetName, forKey: .targetName)
+        try container.encode(
+            testable.groups.map { JsonNode.group($0) }, forKey: .groups
+        )
+    }
+}
+
+/// The recursive tree node, discriminated by `kind` — consumers switch on
+/// it rather than sniffing for keys.
+private enum JsonNode: Encodable {
+    case group(ParsedGroup)
+    case testCase(ParsedTestCase)
+
+    enum CodingKeys: String, CodingKey {
+        case kind
+        case name
+        case identifier
+        case duration
+        case children
+        case arguments
+        case iterations
+    }
+
+    init(node: ParsedNode) {
+        switch node {
+        case let .group(group):
+            self = .group(group)
+        case let .testCase(testCase):
+            self = .testCase(testCase)
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case let .group(group):
+            try container.encode("group", forKey: .kind)
+            try container.encode(group.name, forKey: .name)
+            try container.encode(group.identifier, forKey: .identifier)
+            try container.encode(group.duration, forKey: .duration)
+            try container.encode(group.children.map(JsonNode.init), forKey: .children)
+        case let .testCase(testCase):
+            try container.encode("testCase", forKey: .kind)
+            try container.encode(testCase.name, forKey: .name)
+            try container.encode(testCase.identifier, forKey: .identifier)
+            try container.encode(testCase.arguments, forKey: .arguments)
+            try container.encode(
+                testCase.iterations.map(JsonIteration.init), forKey: .iterations
+            )
+        }
+    }
+}
+
+private struct JsonIteration: Encodable {
+    let iteration: ParsedIteration
+
+    enum CodingKeys: String, CodingKey {
+        case iterationNumber
+        case status
+        case duration
+        case activities
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(iteration.iterationNumber, forKey: .iterationNumber)
+        try container.encode(JsonReport.status(iteration.status), forKey: .status)
+        try container.encode(iteration.duration, forKey: .duration)
+        try container.encode(
+            iteration.activities.map(JsonActivity.init), forKey: .activities
+        )
+    }
+}
+
+private struct JsonActivity: Encodable {
+    let activity: ParsedActivity
+
+    enum CodingKeys: String, CodingKey {
+        case title
+        case isFailure
+        case start
+        case attachments
+        case subActivities
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(activity.title, forKey: .title)
+        try container.encode(activity.isFailure, forKey: .isFailure)
+        try container.encode(activity.start.map(JsonReport.timestamp), forKey: .start)
+        try container.encode(
+            activity.attachments.map(JsonAttachment.init), forKey: .attachments
+        )
+        try container.encode(
+            activity.subActivities.map(JsonActivity.init), forKey: .subActivities
+        )
+    }
+}
+
+private struct JsonAttachment: Encodable {
+    let attachment: ParsedAttachment
+
+    enum CodingKeys: String, CodingKey {
+        case name
+        case filename
+        case filenameExtension
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(attachment.name, forKey: .name)
+        try container.encode(attachment.filename, forKey: .filename)
+        try container.encode(attachment.filenameExtension, forKey: .filenameExtension)
+    }
+}

--- a/Sources/XCTestHTMLReportCore/Classes/Models/Summary.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Models/Summary.swift
@@ -10,7 +10,9 @@ import Foundation
 
 public struct Summary {
     let runs: [Run]
-    let resultFiles: [ResultFile]
+    /// The backend-neutral model the runs were built from, retained so
+    /// `generatedJsonReport()` can emit it without a second parse.
+    private let parsedRuns: [ParsedRun]
     private let faultCollector: FaultCollector
 
     public enum RenderingMode {
@@ -32,7 +34,7 @@ public struct Summary {
         backend: ResultBackend = .fromEnvironment()
     ) {
         var runs: [Run] = []
-        var resultFiles: [ResultFile] = []
+        var parsedRuns: [ParsedRun] = []
         self.faultCollector = faultCollector
 
         // The CLI already rejects an explicit `legacy` the toolchain cannot
@@ -57,7 +59,6 @@ public struct Summary {
             Logger.step("Parsing \(resultPath)")
             let url = URL(fileURLWithPath: resultPath)
             let resultFile = ResultFile(url: url, faultCollector: faultCollector)
-            resultFiles.append(resultFile)
 
             let (reader, payloads) = Self.makeReader(
                 resolved: resolved,
@@ -72,6 +73,7 @@ public struct Summary {
                 // bundle when multiple were passed.
                 continue
             }
+            parsedRuns.append(contentsOf: parsed.runs)
             // Identifiers are derived from the bundle's position in the
             // argument list rather than from its path, so moving a bundle
             // between directories still renders the same report. See
@@ -92,7 +94,7 @@ public struct Summary {
             runs.append(contentsOf: resultRuns)
         }
         self.runs = runs
-        self.resultFiles = resultFiles
+        self.parsedRuns = parsedRuns
     }
 
     /// Reader and payload provider for one bundle on the resolved backend.
@@ -139,16 +141,15 @@ public struct Summary {
         Logger.substep("Deleted \(deletedFilesCount) unattached files")
     }
 
+    /// Emits the parsed model as JSON, per the contract in
+    /// docs/json-schema.md.
+    ///
+    /// Before 4.0 this dumped `xcresulttool`'s legacy object graph verbatim.
+    /// That graph is Apple's internal shape and disappears with the legacy
+    /// commands, so the output is now our own documented, versioned schema —
+    /// identical on both backends.
     public func generatedJsonReport() -> String {
-        let jsonStrings: [String] = resultFiles.compactMap { resultFile in
-            guard let jsonData = resultFile.exportJson() else {
-                return nil
-            }
-            return String(data: jsonData, encoding: .utf8)
-        }
-
-        // TODO: The result files may be encoded directly as an array instead of concatenating raw output
-        return "[\(jsonStrings.joined(separator: ","))]"
+        JsonReport(runs: parsedRuns).encoded()
     }
 
     /// Check post-conditions on the assembled model and record any degradation.

--- a/Sources/XCTestHTMLReportCore/Classes/ResultReading/Legacy/LegacyResultReader.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/ResultReading/Legacy/LegacyResultReader.swift
@@ -87,7 +87,9 @@ struct LegacyResultReader: ResultReader {
                 identifier: identifier,
                 // Legacy has no counterpart to Swift Testing's Arguments nodes.
                 arguments: [],
-                iterations: Self.mergingArgumentExecutions(iterations)
+                iterations: Self.strippingLoneIterationNumber(
+                    Self.mergingArgumentExecutions(iterations)
+                )
             ))
         }
 
@@ -198,6 +200,35 @@ struct LegacyResultReader: ResultReader {
             status: merged,
             duration: iterations.reduce(0) { $0 + $1.duration },
             activities: iterations.flatMap(\.activities)
+        )]
+    }
+
+    /// A single execution carries no repetition information, on either
+    /// backend.
+    ///
+    /// Under a retry-enabled test plan, legacy stamps *every* test's summary
+    /// with a `repetitionPolicySummary` — a test that ran once is "iteration
+    /// 1" of a policy that never fired — while the modern format only emits
+    /// `Repetition` children when there was more than one run. Nothing
+    /// renders a lone iteration number (the HTML differential is green
+    /// across this asymmetry), but `--json` emits the model, so the
+    /// difference surfaced there: legacy `1` against modern `null` on every
+    /// single-run test in `RetryResults`. Dropping the number from the lone
+    /// iteration makes the backends agree by construction; true repetitions
+    /// always come in twos or more and keep theirs.
+    static func strippingLoneIterationNumber(
+        _ iterations: [ParsedIteration]
+    ) -> [ParsedIteration] {
+        guard iterations.count == 1, let only = iterations.first,
+              only.iterationNumber != nil
+        else {
+            return iterations
+        }
+        return [ParsedIteration(
+            iterationNumber: nil,
+            status: only.status,
+            duration: only.duration,
+            activities: only.activities
         )]
     }
 

--- a/Sources/XCTestHTMLReportCore/Classes/ResultReading/Legacy/ResultFile.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/ResultReading/Legacy/ResultFile.swift
@@ -44,10 +44,6 @@ class ResultFile {
         file.getActionTestSummary(id: id)
     }
 
-    func exportJson() -> Data? {
-        file.exportRecursiveJson()
-    }
-
     // MARK: - Private
 
     /// Lock guarding every export of `id`, created on first use.

--- a/Sources/XCTestHTMLReportCore/Classes/ResultReading/Modern/ModernPayloadStore.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/ResultReading/Modern/ModernPayloadStore.swift
@@ -24,7 +24,7 @@ final class ModernPayloadStore: PayloadProviding {
         }
     }
 
-    init(client: XCResultToolClient, bundleURL: URL, faultCollector: FaultCollector) {
+    init(client: XCResultToolInvoking, bundleURL: URL, faultCollector: FaultCollector) {
         self.client = client
         self.faultCollector = faultCollector
         url = bundleURL
@@ -120,7 +120,10 @@ final class ModernPayloadStore: PayloadProviding {
 
     // MARK: Private
 
-    private let client: XCResultToolClient
+    /// The protocol, not the concrete client, so tests can fail the one-shot
+    /// export on demand and prove the degradation is recorded — the same seam
+    /// `ModernResultReader` already uses.
+    private let client: XCResultToolInvoking
     private let relativeURL: URL
     private let faultCollector: FaultCollector
 
@@ -190,6 +193,10 @@ final class ModernPayloadStore: PayloadProviding {
         } catch {
             Logger.warning("Can't export attachments: \(error)")
             faultCollector.record(.payloadExportFailed, "attachment export")
+            // `exportDirectory` was never set, so `deinit` will not clean the
+            // directory the failed export leaves behind — remove it here or
+            // every failed run leaks it into NSTemporaryDirectory().
+            try? FileManager.default.removeItem(at: directory)
         }
     }
 

--- a/Sources/XCTestHTMLReportCore/Classes/ResultReading/Modern/ModernResultReader.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/ResultReading/Modern/ModernResultReader.swift
@@ -227,9 +227,26 @@ struct ModernResultReader: ResultReader {
                 as: TestActivities.self
             )
             let runs = document.testRuns ?? []
-            let run: TestActivities.TestRun? = iteration
-                .flatMap { index in runs.indices.contains(index) ? runs[index] : nil }
-                ?? runs.first
+            let run: TestActivities.TestRun?
+            if let index = iteration {
+                // The document carries one testRun per repetition, in order.
+                // An index the document cannot satisfy is a document anomaly,
+                // not a format limitation: falling back to `runs.first` here
+                // would silently render repetition 1's activities under
+                // repetition N, which is worse than rendering none and
+                // saying so.
+                guard runs.indices.contains(index) else {
+                    Logger.warning(
+                        "Activities document for \(identifier) has \(runs.count) "
+                            + "testRun(s); repetition index \(index) is out of range"
+                    )
+                    faultCollector.record(.missingActivities, identifier)
+                    return []
+                }
+                run = runs[index]
+            } else {
+                run = runs.first
+            }
             return (run?.activities ?? []).map { parseActivity(pruning: $0) }
         } catch {
             // A failed activities query is a genuine read failure, not a

--- a/Tests/XCTestHTMLReportTests/JsonClassMask.swift
+++ b/Tests/XCTestHTMLReportTests/JsonClassMask.swift
@@ -1,0 +1,122 @@
+//
+//  JsonClassMask.swift
+//
+//  The `--json` cross-backend comparison's masking layer — the JSON
+//  counterpart of `KnownLossMasker`, which does the same job for rendered
+//  HTML. Applies exactly the declared value-difference classes and nothing
+//  else:
+//
+//  - `wrapperGroups` (class 1): legacy-only, wrapper levels splice out.
+//  - `durations` (class 1): every `duration` becomes 0 on both sides.
+//  - `attachmentDisplayNames` (class 1): `attachment.name` blanks on legacy;
+//    on modern it must already be null and is counted, not blanked.
+//  - `failureTitlePrefix` (class 1): the `title` of rows whose `isFailure`
+//    is true blanks on both sides.
+//  - `arguments` (class 2): blanks on both sides; the values themselves are
+//    asserted separately, never by cross-backend equality.
+//
+//  `Stats` is how the caller keeps the masks honest: a mask that had nothing
+//  to remove is masking a divergence that no longer exists.
+//
+
+import Foundation
+
+enum JsonClassMask {
+    // MARK: Internal
+
+    struct Stats {
+        var unwrappedWrapperGroups = 0
+        var modernAttachmentNames = 0
+    }
+
+    static func masked(_ any: Any, legacy: Bool, stats: inout Stats) -> Any {
+        switch any {
+        case let dict as [String: Any]:
+            return masked(dictionary: dict, legacy: legacy, stats: &stats)
+        case let array as [Any]:
+            return array.map { masked($0, legacy: legacy, stats: &stats) }
+        default:
+            return any
+        }
+    }
+
+    /// Deterministic text for deep comparison with a readable diff.
+    static func canonical(_ object: Any) -> String {
+        guard
+            let data = try? JSONSerialization.data(
+                withJSONObject: object, options: [.prettyPrinted, .sortedKeys]
+            )
+        else {
+            return ""
+        }
+        return String(data: data, encoding: .utf8) ?? ""
+    }
+
+    // MARK: Private
+
+    private static let wrapperNames: Set<String> = ["All tests", "Selected tests"]
+
+    private static func masked(
+        dictionary: [String: Any], legacy: Bool, stats: inout Stats
+    ) -> [String: Any] {
+        var dict = dictionary
+        for (key, value) in dict {
+            dict[key] = masked(value, legacy: legacy, stats: &stats)
+        }
+        maskScalars(&dict)
+        maskAttachmentName(&dict, legacy: legacy, stats: &stats)
+        unwrapWrapperGroups(&dict, legacy: legacy, stats: &stats)
+        return dict
+    }
+
+    private static func maskScalars(_ dict: inout [String: Any]) {
+        if dict["duration"] != nil {
+            dict["duration"] = 0
+        }
+        if dict["arguments"] != nil {
+            dict["arguments"] = [String]()
+        }
+        if dict["isFailure"] as? Bool == true {
+            dict["title"] = ""
+        }
+    }
+
+    /// An attachment is the only object carrying `filenameExtension`.
+    private static func maskAttachmentName(
+        _ dict: inout [String: Any], legacy: Bool, stats: inout Stats
+    ) {
+        guard dict.keys.contains("filenameExtension") else {
+            return
+        }
+        if legacy {
+            dict["name"] = NSNull()
+        } else if !(dict["name"] is NSNull) {
+            stats.modernAttachmentNames += 1
+        }
+    }
+
+    private static func isWrapperGroup(_ dict: [String: Any]) -> Bool {
+        guard dict["kind"] as? String == "group", let name = dict["name"] as? String
+        else {
+            return false
+        }
+        return wrapperNames.contains(name) || name.hasSuffix(".xctest")
+    }
+
+    private static func unwrapWrapperGroups(
+        _ dict: inout [String: Any], legacy: Bool, stats: inout Stats
+    ) {
+        for key in ["groups", "children"] {
+            guard let nodes = dict[key] as? [[String: Any]] else {
+                continue
+            }
+            dict[key] = nodes.flatMap { node -> [[String: Any]] in
+                guard legacy, isWrapperGroup(node) else {
+                    return [node]
+                }
+                stats.unwrappedWrapperGroups += 1
+                return node["children"] as? [[String: Any]] ?? []
+            }
+        }
+    }
+}

--- a/Tests/XCTestHTMLReportTests/JsonReportTests.swift
+++ b/Tests/XCTestHTMLReportTests/JsonReportTests.swift
@@ -1,0 +1,319 @@
+//
+//  JsonReportTests.swift
+//
+//  Holds `--json` to its wire contract (docs/json-schema.md): our own schema,
+//  not the legacy object graph, and identical across backends up to exactly
+//  the two permitted value-difference classes — the four declared
+//  render-level losses (class 1) and the modern-only `arguments` capability
+//  (class 2). Every mask applied here carries a non-vacuity guard, so a
+//  divergence that stops existing fails the test rather than rotting as dead
+//  masking.
+//
+
+import XCTest
+@testable import XCTestHTMLReportCore
+
+final class JsonReportTests: XCTestCase {
+    // MARK: - Shared documents
+
+    private static let fixtures = ["TestResults", "SanityResults", "RetryResults"]
+
+    /// One parse per fixture-and-backend. Building a `Summary` spawns
+    /// `xcresulttool` subprocesses, so tests share documents the same way
+    /// `DifferentialTests` shares renders.
+    private static var documents: [String: [String: Any]] = [:]
+
+    private func document(
+        _ resource: String, _ backend: ResultBackend
+    ) throws -> [String: Any] {
+        let key = "\(resource)|\(backend.rawValue)"
+        if let cached = Self.documents[key] {
+            return cached
+        }
+        let url = try XCTUnwrap(
+            Bundle.testBundle.url(forResource: resource, withExtension: "xcresult")
+        )
+        let text = Summary(
+            resultPaths: [url.path],
+            renderingMode: .linking,
+            downsizeImagesEnabled: false,
+            downsizeScaleFactor: 0.5,
+            backend: backend
+        ).generatedJsonReport()
+        let object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(text.utf8)) as? [String: Any],
+            "--json output is not a single JSON object"
+        )
+        Self.documents[key] = object
+        return object
+    }
+
+    /// Mirrors `DifferentialTests.requireBothBackends`: skip when the
+    /// toolchain has no legacy commands, and refuse a silently substituted
+    /// backend, which would compare modern against itself.
+    private func requireBothBackends() throws {
+        switch ResultBackend.legacy.resolve() {
+        case .legacyUnavailable:
+            throw XCTSkip(
+                "Toolchain has no legacy commands; the cross-backend "
+                    + "comparison cannot run."
+            )
+        case let .use(backend):
+            XCTAssertEqual(backend, .legacy)
+        }
+    }
+
+    // MARK: - The schema is ours
+
+    func testEmitsOurSchemaNotTheLegacyObjectGraph() throws {
+        let object = try document("SanityResults", .fromEnvironment())
+        XCTAssertNotNil(object["runs"])
+        XCTAssertEqual(object["schemaVersion"] as? String, "1.0.0")
+        XCTAssertEqual(
+            Set(object.keys), ["schemaVersion", "runs"],
+            "The top level carries exactly the two documented keys"
+        )
+        // The legacy dump wrapped every scalar in {"_value": ...}. Ours does not.
+        XCTAssertFalse(
+            String(describing: object).contains("_value"),
+            "Output still looks like the legacy object graph"
+        )
+    }
+
+    /// Contract pins that need no second backend: enum spellings are the five
+    /// documented lowercase strings, timestamps are ISO-8601 UTC with
+    /// millisecond precision, and both are asserted against real data rather
+    /// than against the encoder's own constants.
+    func testStatusAndTimestampEncodingsMatchTheContract() throws {
+        let object = try document("TestResults", .fromEnvironment())
+
+        let statuses = Set(
+            testCases(in: object)
+                .flatMap { $0["iterations"] as? [[String: Any]] ?? [] }
+                .compactMap { $0["status"] as? String }
+        )
+        XCTAssertFalse(statuses.isEmpty, "No statuses found — vacuous")
+        XCTAssertTrue(
+            statuses.isSubset(of: ["passed", "failed", "skipped", "expectedFailure", "unknown"]),
+            "Undocumented status spelling: \(statuses)"
+        )
+        XCTAssertTrue(
+            statuses.isSuperset(of: ["passed", "failed", "skipped"]),
+            "TestResults exercises at least these three: \(statuses)"
+        )
+
+        let timestampShape = try NSRegularExpression(
+            pattern: #"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$"#
+        )
+        let starts = activityRows(in: object).compactMap { $0["start"] as? String }
+        XCTAssertFalse(starts.isEmpty, "No timestamps found — vacuous")
+        for start in starts {
+            XCTAssertNotNil(
+                timestampShape.firstMatch(
+                    in: start, range: NSRange(start.startIndex..., in: start)
+                ),
+                "Timestamp '\(start)' is not ISO-8601 UTC with milliseconds"
+            )
+        }
+    }
+
+    // MARK: - Schema identity across backends
+
+    /// Schema identity, not value identity — the spec permits four value
+    /// differences and forbids the rest. The schema is recursive (a node is
+    /// a group or a test case, at any depth), and the `wrapperGroups` loss
+    /// means legacy alone places group nodes at nested positions — so raw
+    /// key-path sets differ on every fixture for that permitted reason.
+    /// Collapsing the tree's recursion edges (`groups`/`children` become one
+    /// segment, consecutive `subActivities` collapse) compares the keys each
+    /// *node type* carries instead of the positions nodes happen to occupy:
+    /// a key that exists on one backend's groups or test cases and not the
+    /// other's still fails, wherever it sits.
+    func testSchemaIsIdenticalAcrossBackends() throws {
+        try requireBothBackends()
+
+        func keyPaths(_ any: Any, prefix: String = "") -> Set<String> {
+            switch any {
+            case let dict as [String: Any]:
+                return dict.reduce(into: Set<String>()) { acc, pair in
+                    acc.insert(collapsed(prefix + pair.key))
+                    acc.formUnion(keyPaths(pair.value, prefix: prefix + pair.key + "."))
+                }
+            case let array as [Any]:
+                return array.reduce(into: Set<String>()) { acc, element in
+                    acc.formUnion(keyPaths(element, prefix: prefix))
+                }
+            default:
+                return []
+            }
+        }
+
+        for fixture in Self.fixtures {
+            let legacy = try document(fixture, .legacy)
+            let modern = try document(fixture, .modern)
+            XCTAssertEqual(
+                keyPaths(legacy), keyPaths(modern),
+                "\(fixture): a key exists on one backend and not the other"
+            )
+            XCTAssertEqual(
+                legacy["schemaVersion"] as? String,
+                modern["schemaVersion"] as? String,
+                "\(fixture): backends disagree on schemaVersion"
+            )
+        }
+    }
+
+    /// `groups` and `children` unify into one `nodes` segment and repeats
+    /// collapse (segment-wise, so a path *ending* in a repeat collapses
+    /// too); likewise consecutive `subActivities`. Recursion depth and node
+    /// position stop registering; key differences never do.
+    private func collapsed(_ path: String) -> String {
+        var segments: [String] = []
+        for raw in path.split(separator: ".").map(String.init) {
+            let segment = raw == "groups" || raw == "children" ? "nodes" : raw
+            if segment == segments.last,
+               segment == "nodes" || segment == "subActivities"
+            {
+                continue
+            }
+            segments.append(segment)
+        }
+        return segments.joined(separator: ".")
+    }
+
+    // MARK: - Class 2: arguments compare by capability, never blind equality
+
+    /// The parameterized fixture exists precisely so this cannot pass
+    /// vacuously: legacy must be `[]` because its format has no counterpart,
+    /// and modern must be non-empty for the parameterized case because the
+    /// bundle really carries the Arguments nodes.
+    func testArgumentsAreEmptyOnLegacyAndPopulatedOnModern() throws {
+        try requireBothBackends()
+
+        let legacyCases = try testCases(in: document("TestResults", .legacy))
+        XCTAssertFalse(legacyCases.isEmpty, "No test cases parsed — vacuous")
+        for testCase in legacyCases {
+            XCTAssertEqual(
+                testCase["arguments"] as? [String], [],
+                "Legacy has no Arguments source; \(testCase["identifier"] ?? "?") "
+                    + "must be []"
+            )
+        }
+
+        let modernCases = try testCases(in: document("TestResults", .modern))
+        let parameterized = try XCTUnwrap(
+            modernCases.first {
+                $0["identifier"] as? String
+                    == "SwiftTestingSuite/parameterizedAddition(value:)"
+            },
+            "The parameterized fixture case is missing from the modern document"
+        )
+        XCTAssertEqual(
+            (parameterized["arguments"] as? [String])?.sorted(), ["1", "2", "3"],
+            "Modern must surface the @Test(arguments:) values"
+        )
+        for testCase in modernCases
+            where testCase["identifier"] as? String
+            != "SwiftTestingSuite/parameterizedAddition(value:)"
+        {
+            XCTAssertEqual(
+                testCase["arguments"] as? [String], [],
+                "Non-parameterized case \(testCase["identifier"] ?? "?") "
+                    + "must have no arguments"
+            )
+        }
+    }
+
+    // MARK: - The differential: values equal outside the two classes
+
+    /// Mask exactly the declared losses out of both documents, then require
+    /// deep equality. Any value difference outside the two permitted classes
+    /// is a reader bug, not a permitted variance (the spec's words), and this
+    /// is the assertion that catches it.
+    func testValueDifferencesAreConfinedToTheTwoPermittedClasses() throws {
+        try requireBothBackends()
+
+        for fixture in Self.fixtures {
+            var stats = JsonClassMask.Stats()
+            let legacy = try JsonClassMask.masked(
+                document(fixture, .legacy), legacy: true, stats: &stats
+            )
+            let modern = try JsonClassMask.masked(
+                document(fixture, .modern), legacy: false, stats: &stats
+            )
+
+            // Non-vacuity: each class-1 mask must have had something to mask
+            // on the fixtures that exercise it, and the class-2 blanking is
+            // pinned by testArgumentsAreEmptyOnLegacyAndPopulatedOnModern.
+            XCTAssertGreaterThan(
+                stats.unwrappedWrapperGroups, 0,
+                "\(fixture): no wrapper group unwrapped — the wrapperGroups "
+                    + "divergence no longer exists; delete the mask"
+            )
+            XCTAssertEqual(
+                stats.modernAttachmentNames, 0,
+                "\(fixture): a modern attachment carried a user-supplied name — "
+                    + "the attachmentDisplayNames loss no longer exists"
+            )
+
+            let legacyText = JsonClassMask.canonical(legacy)
+            let modernText = JsonClassMask.canonical(modern)
+            guard legacyText != modernText else {
+                continue
+            }
+            let legacyLines = legacyText.split(separator: "\n").map(String.init)
+            let modernLines = modernText.split(separator: "\n").map(String.init)
+            let index = zip(legacyLines, modernLines).prefix { $0 == $1 }.count
+            let firstMismatch: String
+            if index < min(legacyLines.count, modernLines.count) {
+                firstMismatch = """
+                First mismatch at canonical line \(index):
+                  legacy: \(legacyLines[index])
+                  modern: \(modernLines[index])
+                context (legacy \(max(0, index - 5))..\(index)):
+                \(legacyLines[max(0, index - 5) ... index].joined(separator: "\n"))
+                """
+            } else {
+                firstMismatch =
+                    "Line counts: legacy \(legacyLines.count), modern \(modernLines.count)"
+            }
+            XCTFail(
+                """
+                \(fixture): --json values differ outside the two permitted \
+                classes.
+                \(firstMismatch)
+                """
+            )
+        }
+    }
+
+    // MARK: - JSON walking helpers
+
+    /// Every `kind == "testCase"` object, recursively.
+    private func testCases(in any: Any) -> [[String: Any]] {
+        switch any {
+        case let dict as [String: Any]:
+            if dict["kind"] as? String == "testCase" {
+                return [dict]
+            }
+            return dict.values.flatMap(testCases(in:))
+        case let array as [Any]:
+            return array.flatMap(testCases(in:))
+        default:
+            return []
+        }
+    }
+
+    /// Every activity row, recursively — any object carrying `isFailure`.
+    private func activityRows(in any: Any) -> [[String: Any]] {
+        switch any {
+        case let dict as [String: Any]:
+            let selfRow: [[String: Any]] = dict["isFailure"] != nil ? [dict] : []
+            return selfRow + dict.values.flatMap(activityRows(in:))
+        case let array as [Any]:
+            return array.flatMap(activityRows(in:))
+        default:
+            return []
+        }
+    }
+}

--- a/Tests/XCTestHTMLReportTests/LegacyResultReaderTests.swift
+++ b/Tests/XCTestHTMLReportTests/LegacyResultReaderTests.swift
@@ -39,11 +39,20 @@ final class LegacyResultReaderTests: XCTestCase {
         XCTAssertEqual(retried.iterations.map(\.iterationNumber), [1, 2])
         XCTAssertEqual(retried.iterations.map(\.status), [.failed, .passed])
 
-        // And a non-repeated test still has exactly one iteration.
+        // And a non-repeated test still has exactly one iteration — with no
+        // iteration number. Under a retry-enabled plan legacy stamps every
+        // summary "iteration 1" even when the policy never fired; the modern
+        // format reports nothing for a single run, and a lone number renders
+        // nowhere, so the reader drops it and the backends agree by
+        // construction. `--json` is where the asymmetry would surface.
         let passed = try XCTUnwrap(
             cases.first { $0.identifier == "RetryTests/testJustPass()" }
         )
         XCTAssertEqual(passed.iterations.count, 1)
+        XCTAssertNil(
+            passed.iterations[0].iterationNumber,
+            "A single execution carries no repetition information"
+        )
     }
 
     func testAttachmentFieldsSurviveTranslation() throws {

--- a/Tests/XCTestHTMLReportTests/ModernPayloadStoreTests.swift
+++ b/Tests/XCTestHTMLReportTests/ModernPayloadStoreTests.swift
@@ -114,6 +114,55 @@ final class ModernPayloadStoreTests: XCTestCase {
         )
     }
 
+    /// Serves nothing: every subcommand fails. The store degrades through
+    /// `FaultCollector` rather than aborting, and this is the only way to
+    /// prove the degradation is recorded — a real bundle cannot be made to
+    /// fail on demand. The protocol seam exists for exactly this test.
+    private struct FailingClient: XCResultToolInvoking {
+        var bundleDescription: String {
+            "Failing.xcresult"
+        }
+
+        func run(_ arguments: [String]) throws -> Data {
+            throw XCResultToolError.executionFailed(
+                arguments: arguments, status: 1, stderr: "injected failure"
+            )
+        }
+
+        func json<T: Decodable>(_ arguments: [String], as type: T.Type) throws -> T {
+            try JSONDecoder().decode(type, from: run(arguments))
+        }
+    }
+
+    func testFailedExportRecordsAFaultAndLeaksNoTempDirectory() throws {
+        /// The export directory's name is internal, so hold the whole family
+        /// of names still across the call: any new survivor is the leak.
+        func exportDirectories() throws -> Set<String> {
+            try Set(
+                FileManager.default
+                    .contentsOfDirectory(atPath: NSTemporaryDirectory())
+                    .filter { $0.hasPrefix("xchtmlreport-attachments-") }
+            )
+        }
+        let before = try exportDirectories()
+
+        let collector = FaultCollector()
+        let store = ModernPayloadStore(
+            client: FailingClient(),
+            bundleURL: URL(fileURLWithPath: NSTemporaryDirectory()),
+            faultCollector: collector
+        )
+        XCTAssertNil(store.exportPayload(reference: "any-uuid", fileName: nil))
+        XCTAssertTrue(
+            collector.faults.contains { $0.kind == .payloadExportFailed },
+            "A failed one-shot export must reach the degradation path"
+        )
+        XCTAssertEqual(
+            try exportDirectories(), before,
+            "The failed export left its temp directory behind"
+        )
+    }
+
     func testActionLogExportsNextToTheBundle() throws {
         let (store, bundle) = try store(for: "SanityResults")
         // "action" is the fixed log reference the modern reader emits; the

--- a/Tests/XCTestHTMLReportTests/ModernReaderRuleTests.swift
+++ b/Tests/XCTestHTMLReportTests/ModernReaderRuleTests.swift
@@ -121,6 +121,94 @@ final class ModernReaderRuleTests: XCTestCase {
         )
     }
 
+    /// The symbol-annotation drop's keep-guard, exercised on all three kinds
+    /// of content it protects: a no-`startTime` row carrying an attachment, a
+    /// failure flag, or surviving children is **kept**, while the genuinely
+    /// empty no-start row is dropped. The guard exists so a future format
+    /// variant that stops stamping times degrades to unordered rows instead
+    /// of silently gutting real content — no fixture produces such rows, so
+    /// this is pinned on a crafted document.
+    func testNoStartRowsWithContentSurviveTheAnnotationDrop() throws {
+        let testCase = try craftedCase(
+            testsJSON: Self.testsDocument(result: "Passed", failureMessages: []),
+            activitiesJSON: #"""
+            {"testIdentifier":"S/t()","testRuns":[{"activities":[
+              {"title":"container","startTime":1,"childActivities":[
+                {"title":"annotation"},
+                {"title":"keeps its attachment","attachments":[
+                  {"uuid":"A1","payloadId":"P1","name":"shot.png","timestamp":9}]},
+                {"title":"keeps its child","childActivities":[
+                  {"title":"inner","startTime":2}]},
+                {"title":"keeps its failure flag","isAssociatedWithFailure":true}]}]}]}
+            """#
+        )
+        let rows = testCase.iterations[0].activities
+        let all = flattened(rows)
+        XCTAssertFalse(
+            all.contains { $0.title == "annotation" },
+            "The contentless no-start row is an annotation and must drop"
+        )
+        let container = try XCTUnwrap(rows.first { $0.title == "container" })
+        XCTAssertEqual(
+            container.subActivities.map(\.title),
+            ["keeps its attachment", "keeps its child"],
+            "No-start rows with content must survive in source order"
+        )
+        XCTAssertFalse(
+            try XCTUnwrap(all.first { $0.title == "keeps its attachment" })
+                .attachments.isEmpty
+        )
+        // The flagged no-start row survives as a failure tip; the hoist moves
+        // it to the top level and the interleave orders its nil start last.
+        let flagged = try XCTUnwrap(all.first { $0.title == "keeps its failure flag" })
+        XCTAssertTrue(flagged.isFailure)
+        XCTAssertEqual(rows.last?.title, "keeps its failure flag")
+    }
+
+    /// A repetition index the activities document cannot satisfy renders no
+    /// activities and records the degradation — never repetition 1's rows
+    /// under repetition N, which is what a silent `runs.first` fallback did.
+    func testOutOfRangeRepetitionIndexDegradesLoudly() throws {
+        let collector = FaultCollector()
+        let reader = ModernResultReader(
+            client: CraftedClient(
+                testsJSON: #"""
+                {"devices":[{"deviceId":"D","deviceName":"iPhone","modelName":"iPhone","osVersion":"1.0"}],
+                 "testNodes":[{"nodeType":"Test Plan","name":"P","children":[
+                   {"nodeType":"Unit test bundle","name":"B","children":[
+                     {"nodeType":"Test Suite","name":"S","children":[
+                       {"nodeType":"Test Case","name":"t()","nodeIdentifier":"S/t()",
+                        "result":"Passed","children":[
+                          {"nodeType":"Repetition","nodeIdentifier":"1","result":"Passed"},
+                          {"nodeType":"Repetition","nodeIdentifier":"2","result":"Passed"}]}]}]}]}]}
+                """#,
+                activitiesJSON: #"""
+                {"testIdentifier":"S/t()","testRuns":[{"activities":[
+                  {"title":"only recorded run","startTime":1}]}]}
+                """#
+            ),
+            payloadStore: nil,
+            faultCollector: collector
+        )
+        let testCase = try XCTUnwrap(
+            try testCases(in: XCTUnwrap(reader.read())).first
+        )
+        XCTAssertEqual(
+            testCase.iterations[0].activities.map(\.title), ["only recorded run"]
+        )
+        XCTAssertTrue(
+            testCase.iterations[1].activities.isEmpty,
+            "The missing testRun must not borrow repetition 1's activities"
+        )
+        XCTAssertTrue(
+            collector.faults.contains {
+                $0.kind == .missingActivities && $0.detail == "S/t()"
+            },
+            "Rendering a repetition without its activities is a degradation "
+                + "and must say so"
+        )
+    }
+
     /// A flagged activity with no flagged descendants is itself the tip: it
     /// keeps its failure flag, gets retitled by the join, and stays where the
     /// interleave puts it.

--- a/docs/json-schema.md
+++ b/docs/json-schema.md
@@ -1,0 +1,313 @@
+# The `--json` report schema
+
+This document is the wire contract for the file `xchtmlreport --json` writes
+(`report.json`). It is versioned by the top-level `schemaVersion` field and
+changes only by the policy at the end of this document. The Swift types that
+produce it (`JsonReport.swift`) implement this contract; the internal
+`ParsedResult` model is **not** the contract, and renaming a Swift property
+must never change this output — that is why the encoder names every key
+explicitly instead of synthesizing them from the model.
+
+Introduced in 4.0. Before 4.0, `--json` dumped the legacy `xcresulttool`
+object graph verbatim (every scalar wrapped in `{"_value": ...}`, keys named
+by Apple's internal types). That graph is Apple's internal shape and
+disappears with the legacy commands, so the output is now our own schema,
+emitted identically by both result readers. See the 4.0 release notes for the
+migration rationale.
+
+## Document shape
+
+One invocation writes one JSON document, whatever the number of `.xcresult`
+bundles passed. The document is a single object:
+
+| Key | Type | Meaning |
+| --- | --- | --- |
+| `schemaVersion` | string | The version of this contract, semver. `"1.0.0"` as of this document. |
+| `runs` | array of Run | Every run from every bundle, in bundle-argument order, then in the bundle's own action/device order. |
+
+The document is pretty-printed with lexicographically sorted keys, so two
+reports over the same bundle with the same reader are byte-comparable.
+
+### The null rule — one rule, uniform
+
+**Every key named in this document is present in every emission.** A value
+the reader cannot supply is `null`, never omitted. Arrays are never `null`:
+a collection with no elements is `[]`. There are no optional keys, so
+consumers never need existence checks — only null checks, and only on the
+fields whose type below says "or null".
+
+### Run
+
+| Key | Type | Meaning |
+| --- | --- | --- |
+| `destination` | Destination | The device the run executed on. |
+| `testables` | array of Testable | One entry per test target, in document order. |
+
+### Destination
+
+| Key | Type | Meaning |
+| --- | --- | --- |
+| `displayName` | string | E.g. `"iPhone 16 Pro"`. |
+| `deviceIdentifier` | string | The device UDID. |
+| `modelName` | string | E.g. `"iPhone 16 Pro"`. |
+| `operatingSystemVersion` | string | E.g. `"26.2"`. |
+
+### Testable
+
+| Key | Type | Meaning |
+| --- | --- | --- |
+| `targetName` | string | The test target, e.g. `"SampleAppUnitTests"`. |
+| `groups` | array of Node | The target's top-level nodes, in document order. |
+
+### Node — group or test case
+
+The test tree is recursive: a group's `children` holds further groups and
+test cases, discriminated by `kind`. Consumers must switch on `kind`, not on
+the presence of other keys.
+
+`kind: "group"` — a suite, plan, or (legacy only) wrapper level:
+
+| Key | Type | Meaning |
+| --- | --- | --- |
+| `kind` | string | `"group"`. |
+| `name` | string | Display name, e.g. `"FirstSuite"`. |
+| `identifier` | string | The backend's identifier for the group. |
+| `duration` | number | Seconds. `0` where the format carries none (see the cross-backend table). |
+| `children` | array of Node | Sub-groups and test cases, in document order. |
+
+`kind: "testCase"` — a test method:
+
+| Key | Type | Meaning |
+| --- | --- | --- |
+| `kind` | string | `"testCase"`. |
+| `name` | string | The function-form name, e.g. `"testTwo()"`. |
+| `identifier` | string | Suite-qualified, e.g. `"FirstSuite/testTwo()"`. Stable across backends; use this as the diff key. |
+| `arguments` | array of string | Swift Testing `@Test(arguments:)` values, one per argument set, in document order. `[]` for non-parameterized tests and always `[]` on the legacy reader (see class 2 below). |
+| `iterations` | array of Iteration | One per repetition; a non-repeated test has exactly one. Ascending iteration number. |
+
+### Iteration
+
+| Key | Type | Meaning |
+| --- | --- | --- |
+| `iterationNumber` | integer or null | 1-based repetition number. `null` when the backend reports no repetition information (every non-repeated test). |
+| `status` | string | See "Status encoding". |
+| `duration` | number | Seconds. |
+| `activities` | array of Activity | The iteration's timeline, top level only here; nesting is inside each activity. See "Ordering". |
+
+### Activity
+
+| Key | Type | Meaning |
+| --- | --- | --- |
+| `title` | string | The row's text, e.g. `"Start Activity"` or the failure message. |
+| `isFailure` | boolean | `true` when this row *is* an assertion failure, appended failure message, or skip notice — not when it merely contains one. |
+| `start` | string or null | ISO-8601 UTC with milliseconds, e.g. `"2026-08-12T21:22:33.123Z"`. `null` for unpositioned annotation rows (appended failure messages, skip notices). |
+| `attachments` | array of Attachment | In document order. |
+| `subActivities` | array of Activity | Nested rows, in document order. |
+
+### Attachment
+
+| Key | Type | Meaning |
+| --- | --- | --- |
+| `name` | string or null | The user-supplied `XCTAttachment` name. `null` on the modern reader, which has no source for it (class 1 below). |
+| `filename` | string or null | The content-addressed exported file name, `<payloadId>.<ext>` — identical across backends, unique per payload. `null` for an attachment with no payload. |
+| `filenameExtension` | string or null | Lowercased, no leading dot, e.g. `"png"`. `null` when neither the filename nor the type carries one. |
+
+## Status encoding
+
+`status` is one of exactly five strings — our neutral vocabulary, in neither
+backend's spelling, never ordinals:
+
+| Value | Meaning |
+| --- | --- |
+| `"passed"` | Legacy `Success`, modern `Passed`. |
+| `"failed"` | Legacy `Failure`, modern `Failed`. |
+| `"skipped"` | Both spell it `Skipped`. |
+| `"expectedFailure"` | An `XCTExpectFailure` that failed as expected. |
+| `"unknown"` | Anything the reader did not recognise. |
+
+A test with several iterations carries one status per iteration; the
+"mixed" state the HTML report shows is a rendering of those, not a wire
+value — derive it by folding `iterations[].status`.
+
+## Units and formats
+
+- **Durations** are seconds, as a JSON number. `0` where the format carries
+  no value (never `null`, because "no duration" and "took no time" render
+  identically everywhere this value is consumed — see the cross-backend
+  table for where that happens).
+- **Timestamps** are ISO-8601 in UTC with exactly millisecond precision and
+  a trailing `Z`: `2026-08-12T21:22:33.123Z`. Both underlying formats stamp
+  at millisecond granularity, so no precision is invented or lost.
+
+## Ordering guarantees
+
+Consumers may diff two reports line by line; every array order is
+deterministic:
+
+- `runs`: bundle argument order, then the bundle's own action/device order.
+- `testables`, `groups`, `children`, `attachments`, `subActivities`,
+  `arguments`: the backend's document order, which is stable for a given
+  bundle and reader.
+- `iterations`: ascending `iterationNumber`, source order on ties.
+- `activities`: total order — ascending `start` with `null` last, activities
+  before failure rows on equal `start`, source order last. Both readers place
+  failure rows through one shared function, so this order is identical
+  across backends.
+- Object keys are lexicographically sorted.
+
+## Identical across backends — and the two permitted exceptions
+
+Both readers emit the same keys, nesting, enum vocabulary, and
+`schemaVersion`: a group carries the same keys on both backends, a test case
+carries the same keys on both backends, at whatever depth a node sits. (The
+wrapper levels below mean legacy alone places group nodes at nested
+positions — deeper documents, never different keys.) Value differences fall
+into exactly two classes;
+anything outside them is a reader bug, not a permitted variance.
+
+**Class 1 — the four declared render-level losses** (the same allow-list the
+HTML differential holds both backends to):
+
+| Rule | Where it shows in this schema |
+| --- | --- |
+| `attachmentDisplayNames` | `attachment.name` is a string on legacy, `null` on modern. |
+| `failureTitlePrefix` | Failure-row `title` is `<issueType> at <file>:<line>:<message>` on legacy, the pre-joined `<file>:<line>: <message>` on modern. |
+| `wrapperGroups` | Legacy nests two extra group levels (`"All tests"` / `"Selected tests"`, then `"<target>.xctest"`) that modern omits. Same keys, more depth. |
+| `durations` | `duration` is a real number on legacy but `0` on modern for every group and every Swift Testing test case — the modern format reports `null` there. XCTest iteration durations agree to within a millisecond but are **not** byte-identical: the two formats report them from different documents. Treat every `duration` as a per-backend measurement, not a comparison key. |
+
+**Class 2 — a model-level capability difference:** `testCase.arguments` is
+populated on the modern reader for parameterized Swift Testing cases and
+always `[]` on legacy, which has no counterpart in its format. This is not
+an allow-list rule — nothing in the HTML renders it — and consumers
+comparing backends must compare it separately rather than expecting
+equality.
+
+## What is deliberately not in the schema
+
+- **Backend-internal handles.** The readers carry opaque references (log
+  CAS ids, attachment payload uuids) that are meaningless outside the
+  process and could never agree across backends. They are not emitted.
+- **The `@Test` display name.** Only the modern format carries it; a field
+  one backend can never fill does not enter the port, so it cannot enter
+  this schema. `name` is the function-form name on both.
+- **Anything the HTML report derives.** Mixed status, per-status counts,
+  CSS classes: all foldable from the wire values above.
+
+## Worked example
+
+The complete, unedited document for `SanityResults.xcresult` (one passing
+test with one attachment), modern reader:
+
+```json
+{
+  "runs" : [
+    {
+      "destination" : {
+        "deviceIdentifier" : "E9620177-E008-4401-BF1B-930A418C0E4C",
+        "displayName" : "iPhone 17 Pro Max",
+        "modelName" : "iPhone 17 Pro Max",
+        "operatingSystemVersion" : "26.2"
+      },
+      "testables" : [
+        {
+          "groups" : [
+            {
+              "children" : [
+                {
+                  "arguments" : [
+
+                  ],
+                  "identifier" : "FirstSuite/testOne()",
+                  "iterations" : [
+                    {
+                      "activities" : [
+                        {
+                          "attachments" : [
+
+                          ],
+                          "isFailure" : false,
+                          "start" : "2026-08-13T04:32:50.670Z",
+                          "subActivities" : [
+
+                          ],
+                          "title" : "Start Test at 2026-08-12 21:32:50.670"
+                        },
+                        {
+                          "attachments" : [
+
+                          ],
+                          "isFailure" : false,
+                          "start" : "2026-08-13T04:32:50.688Z",
+                          "subActivities" : [
+
+                          ],
+                          "title" : "Set Up"
+                        },
+                        {
+                          "attachments" : [
+                            {
+                              "filename" : "0~Y_cC85cDZmf7QR61P4GJIWMU5YMbJQjJCzkyt-5XQzFmHVAST7N8yUdK30t5orGbr_vNDCMf3uVTLaODuu7Gpw==.txt",
+                              "filenameExtension" : "txt",
+                              "name" : null
+                            }
+                          ],
+                          "isFailure" : false,
+                          "start" : "2026-08-13T04:32:50.688Z",
+                          "subActivities" : [
+
+                          ],
+                          "title" : "Text Attachment"
+                        },
+                        {
+                          "attachments" : [
+
+                          ],
+                          "isFailure" : false,
+                          "start" : "2026-08-13T04:32:50.688Z",
+                          "subActivities" : [
+
+                          ],
+                          "title" : "Tear Down"
+                        }
+                      ],
+                      "duration" : 0.06264996528625488,
+                      "iterationNumber" : null,
+                      "status" : "passed"
+                    }
+                  ],
+                  "kind" : "testCase",
+                  "name" : "testOne()"
+                }
+              ],
+              "duration" : 0,
+              "identifier" : "FirstSuite",
+              "kind" : "group",
+              "name" : "FirstSuite"
+            }
+          ],
+          "targetName" : "SampleAppUITests"
+        }
+      ]
+    }
+  ],
+  "schemaVersion" : "1.0.0"
+}
+```
+
+## Version policy
+
+`schemaVersion` is semver, and this document is versioned with it:
+
+- **Major** — anything that can break a consumer: a key removed or renamed,
+  a type or the null rule changed, an enum value removed or renamed, an
+  ordering guarantee weakened, meaning changed.
+- **Minor** — additive only: a new key, a new enum value. Consumers must
+  ignore keys they do not recognise, so minor bumps are safe to take
+  blindly.
+- **Patch** — clarifications to this document; the bytes consumers see do
+  not change shape.
+
+**Consumer guidance:** read `schemaVersion` first. Accept any `1.x.y`,
+ignoring unknown keys; refuse anything with a different major and say which
+version you expected. Do not sniff for individual keys as a version probe —
+the field exists so you never have to.

--- a/docs/release-notes/4.0.0.md
+++ b/docs/release-notes/4.0.0.md
@@ -1,0 +1,161 @@
+# 4.0.0
+
+<!--
+Draft for the 4.0.0 GitHub release body. Written alongside #391 (the
+xcresulttool legacy migration); the report-redesign workstream adds its own
+sections before the release ships.
+-->
+
+## Why a major release
+
+Every earlier version of `xchtmlreport` read result bundles through
+`xcresulttool`'s legacy API. Apple has deprecated that API and will remove
+it; when that happens, every earlier version stops working entirely.
+
+4.0 reads the current `xcresulttool` format directly. The new format is not
+a superset of the old one — a handful of things the report used to show have
+no source anymore — so this migration is unavoidably a breaking release. We
+chose to take every consequence of that break **once, deliberately, in one
+version**, rather than shipping a release that breaks again each time Apple
+removes another piece: where the new format cannot supply something, the old
+reader stops showing it too, and the two produce the same report by
+construction. A differential test suite renders every fixture through both
+readers on every CI run and holds the difference to a short, reviewed
+allow-list — parity is enforced, not assumed.
+
+Nothing changes in how you invoke the tool. Everything below is about what
+comes out.
+
+## ⚠️ Breaking change: `--json` is now our own documented schema
+
+`--json` used to dump `xcresulttool`'s legacy object graph verbatim — every
+scalar wrapped in `{"_value": ...}`, keys named by Apple's internal types.
+That graph is Apple's internal shape and disappears with the legacy
+commands, so there is no version of the future in which it survives.
+
+`report.json` is now our own schema: documented, versioned, and identical
+whichever reader produced it.
+
+``` json
+{
+  "runs" : [ ... ],
+  "schemaVersion" : "1.0.0"
+}
+```
+
+**[docs/json-schema.md](https://github.com/XCTestHTMLReport/XCTestHTMLReport/blob/main/docs/json-schema.md)
+is the contract**: field names and nesting with a complete worked example,
+enum encodings, the null rule, duration and timestamp formats, array
+ordering guarantees, and the version policy. Consumers should read
+`schemaVersion` first; the top-level field exists so nobody ever has to
+sniff keys to guess a version again.
+
+If you parsed the old dump: there is no compatibility mode. The old output
+could not be kept — the command producing it is being removed. Port your
+consumer against the contract document once, and the `schemaVersion` policy
+tells you exactly what may change afterwards and how it will be signalled.
+
+## New: `--result-reader auto|legacy|modern`
+
+`xchtmlreport` now carries both readers and picks one per run:
+
+- `auto` (the default) prefers the legacy reader while the toolchain still
+  offers the legacy commands, and falls back to the modern reader once they
+  are gone.
+- `modern` forces the new-format reader — this is what CI uses to prove the
+  future-proof path works end to end today.
+- `legacy` forces the old reader; on a toolchain without the legacy
+  commands this is an error, never a silent substitution.
+
+The `XCHR_RESULT_READER` environment variable sets the default when the
+flag is absent.
+
+## Report changes, on both readers
+
+These are the once-only consequences of holding the two readers to one
+output. Each was accepted by an explicit ruling during the migration, and
+each applies identically to both readers.
+
+### Attachment files on disk are named by content, not by title
+
+Exported attachment files are now named `<payloadId>.<ext>` — the payload's
+content-addressed store id — instead of a prettified attachment title.
+**Display names in the report are unchanged**; only the file names on disk
+change. If your pipeline reaches into the report directory for attachment
+files by name, it needs updating.
+
+This is not cosmetic: Xcode 26.2 gives every automatic screen recording in
+a session the same display name, so name-derived exports collapsed distinct
+recordings onto one path — every video row played the same file — and
+concurrent exports raced on it, intermittently degrading the report (#449).
+Content-addressed names are unique per payload by construction, identical
+byte-for-byte payloads deduplicate to one file, and the export is
+idempotent.
+
+### The run log is named by run, not by internal reference
+
+The exported run log is now `<run-identifier-digest>.log` (the same
+path-digest scheme every element id in the report uses, #430) instead of a
+backend-internal reference name. One log per run, identical on both
+readers — a multi-action bundle no longer overwrites one `action.log`-style
+file per action.
+
+### Parameterized Swift Testing cases render as one test
+
+A Swift Testing `@Test(arguments:)` case used to render as N
+pseudo-repetitions ("3 succeeded", rows titled `Iteration 0`) — retry
+semantics invented for what are argument variations. It now renders as one
+test case on both readers. True retries (`-retry-tests-on-failure`) are
+unaffected and keep their per-iteration rows.
+
+### Skipped tests now show their reason
+
+The skip reason (`XCTSkip`'s message) was always in the result bundle; the
+old reader simply never read it. Both readers now append it as a row on the
+skipped test. Your reports gain a row they never had — that is a fix, not a
+regression.
+
+### Failure rows render where the assertion fired
+
+Assertion-failure rows are now interleaved into the activity timeline by
+their timestamp on both readers, so a failure appears at the point in the
+test where it happened rather than after everything else. **JUnit reports
+inherit this reposition**: failure entries can appear at a different place
+in a test case's output than in 3.x. Expected failures
+(`XCTExpectFailure`) render nothing, exactly as before — on both readers.
+
+### Activity types and per-activity durations leave the report
+
+The new format carries neither the legacy activity taxonomy (the five
+`activityType` constants that drove row styling, including the
+user-created-activity highlight) nor per-activity finish times. A field
+only one reader could fill would poison the parity guarantee, so both
+readers drop them: activity rows lose their type-specific styling and their
+`(1.23s)` duration suffix. Suite and bundle rows show `(0.00s)` on the
+modern reader for the same reason — the new format reports no duration for
+groups.
+
+## What still differs between the two readers
+
+Four differences could not be removed and are declared instead of hidden —
+the differential suite fails if any other difference ever appears, and also
+if one of these four quietly disappears:
+
+| Difference | Why |
+| --- | --- |
+| Attachment display names | The new format has no source for the user-supplied `XCTAttachment` name; the modern reader labels by type (`Screenshot`, `Video`, `File`). |
+| Failure title prefix | Legacy: `Assertion Failure at File.swift:12: message`. Modern: `File.swift:12: message`, pre-joined by the format. |
+| Wrapper groups | Legacy nests `All tests` / `Selected tests` and `<target>.xctest` levels; the modern reader renders the natural flat tree. |
+| Group durations | The new format reports none, so the modern reader shows `(0.00s)` where legacy shows a real value. |
+
+`--json` output additionally carries `testCase.arguments`, which only the
+modern reader can populate (the legacy format has no counterpart) — see the
+contract document.
+
+## What is *not* in 4.0
+
+XCResultKit and the legacy reader stay in the tool for as long as Apple
+ships the legacy commands: the differential suite is the continuous proof
+that the modern reader is right, and it can only run while both paths
+exist. Removing them is deliberately deferred until Apple forces the
+question.

--- a/docs/superpowers/plans/2026-08-10-xcresulttool-legacy-migration.md
+++ b/docs/superpowers/plans/2026-08-10-xcresulttool-legacy-migration.md
@@ -4224,7 +4224,7 @@ Breaking change, landing in 4.0 with release notes.
 - Modify: `Sources/XCTestHTMLReportCore/Classes/Models/ResultFile.swift`
 - Create: `Tests/XCTestHTMLReportTests/JsonReportTests.swift`
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 ```swift
 //
@@ -4296,7 +4296,7 @@ final class JsonReportTests: XCTestCase {
 }
 ```
 
-- [ ] **Step 2: Run to verify it fails**
+- [x] **Step 2: Run to verify it fails**
 
 ```bash
 swift test --filter JsonReportTests
@@ -4304,7 +4304,7 @@ swift test --filter JsonReportTests
 
 Expected: FAIL — output still contains `_value`.
 
-- [ ] **Step 3: Write the wire contract before writing the encoder**
+- [x] **Step 3: Write the wire contract before writing the encoder**
 
 `--json` is public output. A synthesized `Encodable` publishes whatever the
 Swift type looks like that day, which makes every later field rename a silent
@@ -4320,7 +4320,7 @@ Write it from the final `ParsedResult`, then make the encoder match the
 document — not the other way round. The spec's `--json` section lists these as
 required.
 
-- [ ] **Step 4: Make `ParsedResult` `Encodable` and re-point `--json`**
+- [x] **Step 4: Make `ParsedResult` `Encodable` and re-point `--json`**
 
 Add `: Encodable` to every `Parsed*` type, to `ParsedNode`, and to
 `ParsedStatus` — the last needs `String` raw values so `--json` emits
@@ -4357,7 +4357,7 @@ public func generatedJsonReport() -> String {
 Delete `ResultFile.exportJson()` and its `exportRecursiveJson()` call — the
 last XCResultKit use outside `LegacyResultReader`.
 
-- [ ] **Step 5: Run tests to verify they pass**
+- [x] **Step 5: Run tests to verify they pass**
 
 ```bash
 swift test --filter JsonReportTests && swift test 2>&1 | tail -5
@@ -4365,7 +4365,7 @@ swift test --filter JsonReportTests && swift test 2>&1 | tail -5
 
 Expected: 2 new tests PASS; full suite green.
 
-- [ ] **Step 6: Confirm XCResultKit is confined to one file**
+- [x] **Step 6: Confirm XCResultKit is confined to one file**
 
 ```bash
 grep -rln "import XCResultKit" Sources/
@@ -4374,7 +4374,7 @@ grep -rln "import XCResultKit" Sources/
 Expected: exactly
 `Sources/XCTestHTMLReportCore/Classes/ResultReading/Legacy/LegacyResultReader.swift`.
 
-- [ ] **Step 7: Commit**
+- [x] **Step 7: Commit**
 
 ```bash
 swiftformat . && git add -A
@@ -4385,6 +4385,43 @@ That graph is Apple's internal shape and disappears with the legacy commands,
 so --json now emits a documented schema, identical on both backends."
 ```
 
+**Amendments (implementation, 2026-08-12).**
+
+- **Step 4's synthesized `Encodable` is superseded by an explicit encoding
+  layer** (`Classes/Models/JsonReport.swift`), on the spec's own rationale:
+  a synthesized conformance publishes whatever the Swift type looks like on
+  the day, and every later field rename becomes a silent breaking change to
+  public output. `Parsed*` types stay plain; the wire keys are explicit
+  strings in `JsonReport`, and `ParsedStatus` keeps no raw values — the
+  encoder owns the five wire spellings in a `switch`, so renaming a case
+  breaks compilation instead of the contract. `Summary` retains the parsed
+  runs from `init` and `generatedJsonReport()` is
+  `JsonReport(runs: parsedRuns).encoded()`.
+- **Step 1's `keyPaths` comparison collapses the tree's recursion edges**
+  (`groups`/`children` unify, consecutive `subActivities` collapse) before
+  comparing. The raw path sets the snippet compared differ on every fixture
+  for a *permitted* reason — `wrapperGroups` means legacy alone places group
+  nodes at nested positions — while the collapsed sets still fail on any key
+  one backend's groups or test cases carry and the other's lack. Two more
+  tests beyond the snippet: contract pins for enum spellings and timestamp
+  shape, and a masked value-differential asserting values equal outside the
+  two permitted classes (with `arguments` asserted per class 2 — legacy
+  `== []` explicitly, modern non-empty for the parameterized fixture case —
+  never by blind equality).
+- **The value differential surfaced one reader-parity gap** the HTML
+  differential structurally cannot see: under a retry-enabled plan, legacy
+  stamps every summary with `repetitionPolicySummary` ("iteration 1" of a
+  policy that never fired) while modern emits `Repetition` children only for
+  actual repetitions. Nothing renders a lone iteration number, so
+  `LegacyResultReader` now strips it (`strippingLoneIterationNumber`): a
+  single execution carries no repetition information, on either backend.
+  Recorded in the spec's "Task 14 execution rules".
+- **Step 6's expectation is two files, not one**: `ResultFile.swift` moved
+  into `ResultReading/Legacy/` during Task 5a and legitimately still imports
+  XCResultKit for the object-graph accessors. XCResultKit is confined to
+  `Sources/XCTestHTMLReportCore/Classes/ResultReading/Legacy/` — both files
+  are deleted together in phase 6.
+
 ---
 
 ## Task 15: Documentation
@@ -4393,7 +4430,7 @@ so --json now emits a documented schema, identical on both backends."
 - Modify: `README.md`
 - Modify: `docs/superpowers/specs/2026-08-10-xcresulttool-legacy-migration-design.md`
 
-- [ ] **Step 1: Document the flag and the `--json` break in `README.md`**
+- [x] **Step 1: Document the flag and the `--json` break in `README.md`**
 
 Add a section covering `--result-reader auto|legacy|modern`, that `auto`
 prefers legacy while the toolchain offers it, the `--json` schema change with a
@@ -4403,29 +4440,29 @@ the allow-list, not re-derived).
 **Release-notes checklist (added during Task 12 — every item is a 4.0
 output change accepted by ruling; see the spec's "Task 12 execution rules"):**
 
-- [ ] On-disk attachment names are content-addressed
+- [x] On-disk attachment names are content-addressed
       (`<payloadId>.<ext>`) on **both** backends; display names in the
       report are unchanged. Byte-identical payloads deduplicate to one file.
       This also fixes intermittent `payloadExportFailed` degradation on
       Xcode 26.2 screen recordings (#449).
-- [ ] The exported run log is named `<run-identifier-digest>.log` instead of
+- [x] The exported run log is named `<run-identifier-digest>.log` instead of
       the backend-internal reference name (`<CAS id>.log` today).
-- [ ] Parameterized Swift Testing `@Test(arguments:)` cases render as one
+- [x] Parameterized Swift Testing `@Test(arguments:)` cases render as one
       test case instead of N pseudo-repetitions ("3 succeeded" /
       `Iteration 0` rows).
-- [ ] Skipped tests now show their skip reason as a row; it was always in
+- [x] Skipped tests now show their skip reason as a row; it was always in
       the bundle, the legacy reader never read it.
-- [ ] Assertion-failure rows render where the assertion fired (interleaved
+- [x] Assertion-failure rows render where the assertion fired (interleaved
       by start on both backends); expected failures render nothing, as
       before, on both backends.
 
-- [ ] **Step 2: Mark the spec's phases 1-5 done**
+- [x] **Step 2: Mark the spec's phases 1-5 done**
 
 Add a short status line at the top of the spec noting which phases landed and
 that phase 6 (removing XCResultKit) is deliberately deferred until Apple
 removes the legacy commands.
 
-- [ ] **Step 3: Full verification**
+- [x] **Step 3: Full verification**
 
 ```bash
 swiftformat --lint --reporter github-actions-log . && echo "FORMAT OK"
@@ -4438,12 +4475,24 @@ XCHR_RESULT_READER=modern swift test 2>&1 | tail -5
 
 Expected: every line reports success; both test runs green.
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 git add README.md docs/
 git commit -m "docs: document --result-reader and the --json schema change"
 ```
+
+**Amendments (implementation, 2026-08-12).** The repo keeps release notes as
+GitHub release bodies (3.0.0 set the narrative style), so the 4.0 notes are
+drafted in-repo at `docs/release-notes/4.0.0.md` for the release to source.
+The draft covers this task's checklist plus the items added by rulings
+R1/R5/R7 and the #443/#450 reviews: the `--json` break with the contract
+linked, `--result-reader`, content-addressed attachment export names
+(`<payloadId>.<ext>`, #449), digest-derived run-log names, parameterized
+legacy rendering collapsing to one case, skip reasons appearing, the
+failure-row reposition (which the JUnit report inherits — shape 4 of Task
+5b's enumerated diff), activity types/durations leaving the report, the
+four declared reader differences, and the break-once 4.0 framing.
 
 ---
 

--- a/docs/superpowers/specs/2026-08-10-xcresulttool-legacy-migration-design.md
+++ b/docs/superpowers/specs/2026-08-10-xcresulttool-legacy-migration-design.md
@@ -2,6 +2,14 @@
 
 Design spec for [#391](https://github.com/XCTestHTMLReport/XCTestHTMLReport/issues/391). Milestone 4.0.
 
+> **Status (2026-08-12): phases 1–5 have landed** — the port and legacy
+> reader (#443), the modern reader and payload store (#447), backend
+> selection (#448), the differential and forced-modern CI leg (#450), and
+> `--json` on the documented schema with the 4.0 release notes drafted
+> (this phase's PR). Phase 6 — removing XCResultKit and the legacy reader —
+> is **deliberately deferred until Apple removes the legacy commands**: the
+> differential only proves the modern reader right while both paths exist.
+
 > Originally written against milestone 3.0, inherited from #391's label. 3.0.0
 > shipped on 2026-08-07, so the breaking changes here — the `--json` schema and
 > the declared output diff — land in 4.0. The migration shares that major with a
@@ -543,6 +551,35 @@ backend-internal, so the names could never agree. Both now write
 uses): identical across backends by construction, and unique per run, so a
 multi-action bundle gets one log per action instead of last-writer-wins. 4.0
 release note: the log file's on-disk name changes.
+
+### Task 14 execution rules (2026-08-12)
+
+Deriving `--json` from the model made one asymmetry visible that the HTML
+differential structurally cannot see, because nothing renders it. Same
+doctrine as Task 12's rules: agree by construction, never model what only
+one backend can fill, and no allow-list entry was added.
+
+**A single execution carries no repetition information.** Under a
+retry-enabled test plan the legacy format stamps *every* test summary with a
+`repetitionPolicySummary` — a test that ran once reports "iteration 1" of a
+policy that never fired — while the modern format emits `Repetition`
+children only when there was more than one run. A lone iteration number
+renders nowhere (the HTML differential is green across the asymmetry), but
+`--json` emits the model, so it surfaced there: legacy `1` against modern
+`null` on every single-run test in `RetryResults`. The legacy reader strips
+the number from a lone iteration (`strippingLoneIterationNumber`); true
+repetitions always come in twos or more and keep theirs. Pinned by
+`LegacyResultReaderTests` on `testJustPass()`.
+
+**Schema identity is per node type, not per document position.** The wire
+tree is recursive, and the `wrapperGroups` loss means legacy alone places
+group nodes at nested positions — so raw key-path sets differ between
+backends on every fixture, for a permitted class-1 reason. The `--json`
+schema-identity test therefore collapses the recursion edges
+(`groups`/`children` unify, consecutive `subActivities` collapse) before
+comparing: what is asserted is that a group carries the same keys on both
+backends and a test case carries the same keys on both backends, at
+whatever depth a node sits — which is what the contract promises.
 
 ## `--json` becomes our own schema
 


### PR DESCRIPTION
Tasks 14 and 15 of the [migration plan](docs/superpowers/plans/2026-08-10-xcresulttool-legacy-migration.md) for #391 — the last phase-5 PR. `--json` stops dumping `xcresulttool`'s legacy object graph and emits the `ParsedResult` model behind a documented, versioned wire contract; the 4.0 release notes are drafted in-repo.

## Task 14 — `--json` emits our own schema

**The contract came first**: [`docs/json-schema.md`](docs/json-schema.md) documents field names and nesting with the complete worked example from a real `SanityResults` render, the five status spellings, one uniform null rule (every key always present, absent values are explicit `null`, arrays never null), duration units and the timestamp format, array ordering guarantees, the two permitted cross-backend value-difference classes, and a semver `schemaVersion` policy with consumer guidance.

**The encoder is an explicit layer, not a synthesized `Encodable`** (`Classes/Models/JsonReport.swift`): every wire key is an explicit string, so renaming a `Parsed*` property breaks compilation instead of silently renaming public output — the spec's stated reason. `ParsedStatus` keeps no raw values; the encoder owns the five wire spellings in a `switch`. The plan's Task 14 snippet (synthesized conformance + raw values) is superseded; amendment recorded in the plan. `Summary` retains the parsed runs, so `--json` needs no second parse. `ResultFile.exportJson()` — the last `exportRecursiveJson()` call, kept alive since Task 5a — is deleted; XCResultKit is now confined to `ResultReading/Legacy/` (two files, deleted together in phase 6).

**Cross-backend discipline, tested** (`JsonReportTests`, differential-style, both backends, all three fixtures):

- *Schema identity*: key-path sets compared after collapsing the tree's recursion edges — `wrapperGroups` means legacy alone places group nodes at nested positions, so raw path sets differ for a permitted class-1 reason; the collapsed comparison still fails on any key one backend's groups or test cases carry and the other's lack.
- *Value identity outside the two classes*: a JSON-level masker (`JsonClassMask`, the wire counterpart of `KnownLossMasker`) removes exactly the four declared class-1 losses, with non-vacuity stats so a mask that stops masking fails the test. What remains must be deeply equal — and is, on all three fixtures.
- *Class 2, never blind equality*: legacy `arguments` asserted `== []` explicitly; modern asserted **non-empty** (`["1","2","3"]`) for `SwiftTestingSuite/parameterizedAddition(value:)`, so the assertion cannot pass vacuously now that the parameterized fixture exists.
- Contract pins: status spellings and the `…Z` millisecond timestamp shape asserted against real output.

**One reader-parity gap surfaced and fixed** — exactly what the `--json` differential exists to catch: under a retry-enabled plan, legacy stamps *every* test summary with `repetitionPolicySummary` ("iteration 1" of a policy that never fired) while modern emits `Repetition` children only for real repetitions. Nothing renders a lone iteration number (the HTML differential is structurally blind to it), but `--json` emits the model, so it showed up as legacy `1` vs modern `null` on every single-run test in `RetryResults`. `LegacyResultReader.strippingLoneIterationNumber` makes a single execution carry no repetition information on either backend; pinned in `LegacyResultReaderTests`, recorded as a Task 14 execution rule in the spec.

## Task 15 — documentation and release notes

- **[`docs/release-notes/4.0.0.md`](docs/release-notes/4.0.0.md)** — drafted in the 3.0.0 release's narrative style for the release to source. Covers the full checklist: the `--json` break with the contract linked and the break-once framing; `--result-reader`; content-addressed attachment export names (`<payloadId>.<ext>`, fixes #449) with the on-disk-only caveat; digest-derived run-log names; parameterized legacy rendering collapsing to one case; skip reasons now appearing; failure rows rendering where the assertion fired, **including that JUnit inherits the reposition** (shape 4); activity types and per-activity durations leaving the report; the four declared reader differences; and the deliberate phase-6 deferral.
- **README** — `--result-reader` section, the `--json` break with a before/after snippet, and the known backend differences drawn from the allow-list.
- **Spec** — status header marking phases 1–5 landed (#443, #447, #448, #450, this PR), phase 6 deferred until Apple removes the legacy commands; new "Task 14 execution rules" section.

## Carried findings (all folded in, none deferred)

1. **R2 keep-guard test** (#450 review): `testNoStartRowsWithContentSurviveTheAnnotationDrop` pins all three branches of the guard at `ModernResultReader.parseActivity` on a crafted document — a no-`startTime` row with an attachment, with a failure flag, or with surviving children is kept; the contentless one drops.
2. **`test.yml` artifact collision** (#450 review): failure-artifact name is now suffixed per matrix leg (`xcresult-fixtures-${{ matrix.result_reader }}`); upload-artifact v4 refuses duplicate names, so a both-legs-fail run would have lost the second upload.
3. **#447 review items**, all three:
   - `ModernPayloadStore` now takes `XCResultToolInvoking` (the existing seam) instead of the concrete client; `testFailedExportRecordsAFaultAndLeaksNoTempDirectory` proves export-failure faulting in-suite.
   - The failed one-shot export no longer leaks its temp directory (removed in the `catch`; same test asserts no survivor).
   - An out-of-range repetition index no longer falls back silently to `runs.first`: it renders no activities for that iteration, records `.missingActivities`, and `testOutOfRangeRepetitionIndexDegradesLoudly` pins that repetition 1's rows are not borrowed.

## Verification

- `swiftformat --lint` clean, `swiftlint` non-strict clean apart from one type-length warning on a test class (matching the existing `ModernResultReaderTests` precedent), `shellcheck` clean, release build clean.
- Full suite green on **both** reader legs (`swift test` and `XCHR_RESULT_READER=modern swift test`) against freshly generated fixtures.

Refs #391. Milestone 4.0. **Do not merge without review.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a versioned, backend-neutral JSON report format with runs, tests, activities, attachments, statuses, and timestamps.
  * Added `--result-reader auto|legacy|modern` and `XCHR_RESULT_READER` configuration.
  * Modern reader output now includes test-case arguments where available.

* **Bug Fixes**
  * Improved handling of repeated tests, missing activities, failed attachments, and activity metadata.
  * Prevented collisions in parallel test artifacts.

* **Documentation**
  * Added comprehensive JSON schema documentation and updated migration and 4.0.0 release notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->