### PR TITLE
Fixture coverage for the redesign: expectedFailure + PNG-attachment cases (refs #439)

### DIFF
--- a/Tests/XCTestHTMLReportTests/CoreTests.swift
+++ b/Tests/XCTestHTMLReportTests/CoreTests.swift
@@ -78,14 +78,17 @@ final class CoreTests: XCTestCase {
             // because a run still depends on the simulator behaving, and an
             // exact split would measure that rather than this project.
             //
-            // 18 = 14 XCTest methods + 4 Swift Testing `@Test` functions in
-            // SwiftTestingSuite (SampleAppUnitTests target). The 14th XCTest
-            // method is FirstSuite.testAttachScreenshot, added by #393 to give
-            // the image rendering path a fixture; the 4th `@Test` is
-            // parameterizedAddition, added by the xcresulttool migration
+            // 21 = 16 XCTest methods + 5 Swift Testing `@Test` functions in
+            // SwiftTestingSuite (SampleAppUnitTests target). Beyond the
+            // original 13 XCTest methods: FirstSuite.testAttachScreenshot was
+            // added by #393 to give the image rendering path a fixture, and
+            // testExpectedFailure + testWithPngAttachment by #439 for the
+            // redesign's status-icon and attachment-type work. The 4th `@Test`
+            // is parameterizedAddition, added by the xcresulttool migration
             // (Task 8) to exercise `Arguments` nodes — its three argument sets
-            // merge into one row, exactly like repetitions.
-            XCTAssertEqual(all, 18, "One row per test method; fixed by the sample sources")
+            // merge into one row, exactly like repetitions — and the 5th is
+            // knownIssue (#439), Swift Testing's expected-failure counterpart.
+            XCTAssertEqual(all, 21, "One row per test method; fixed by the sample sources")
             XCTAssertEqual(
                 skipped,
                 1,
@@ -94,8 +97,11 @@ final class CoreTests: XCTestCase {
             XCTAssertEqual(mixed, 0, "TestResults excludes RetryTests, so nothing can be mixed")
             XCTAssertEqual(
                 passed + failed,
-                all - skipped,
-                "Every remaining test lands in exactly one bucket"
+                all - skipped - 2,
+                "Every remaining test lands in exactly one bucket, except the " +
+                    "two `Expected Failure` cases (testExpectedFailure and " +
+                    "knownIssue) — `Status` folds them to `.unknown`, so today " +
+                    "they are counted in no header bucket at all; see #439"
             )
             XCTAssertGreaterThanOrEqual(
                 failed, 6,

--- a/XCTestHTMLReportSampleApp/SampleAppUnitTests/SampleAppUnitTests.swift
+++ b/XCTestHTMLReportSampleApp/SampleAppUnitTests/SampleAppUnitTests.swift
@@ -6,11 +6,43 @@
 //  Copyright © 2017 Tito. All rights reserved.
 //
 
+import UIKit
 import XCTest
 
 class SampleAppUnitTests: XCTestCase {
     func testFailure() {
         XCTAssert(false, "Test failed")
+    }
+
+    /// Records with result `Expected Failure` in the xcresult — a status no
+    /// other fixture test produces. The report currently renders it as
+    /// `.unknown` (blank icon); the redesign's status-icon work needs a real
+    /// case to verify against. See #439.
+    func testExpectedFailure() {
+        XCTExpectFailure("Intentional expected failure for fixture coverage") {
+            XCTAssert(false, "This assertion fails inside XCTExpectFailure")
+        }
+    }
+
+    /// Attaches a genuine PNG. Every other data attachment in the fixtures is
+    /// txt, log, html, or mp4 — `testAttachScreenshot` goes through the
+    /// screenshot machinery, not the plain-attachment path — so the
+    /// extension-derived `.png` attachment type had no fixture exercising it.
+    /// The image is generated in code to keep binaries out of the repo; an
+    /// 8×8 solid fill is ~100 bytes of PNG. See #439.
+    func testWithPngAttachment() throws {
+        let size = CGSize(width: 8, height: 8)
+        let image = UIGraphicsImageRenderer(size: size).image { context in
+            UIColor.systemRed.setFill()
+            context.fill(CGRect(origin: .zero, size: size))
+        }
+        let attachment = try XCTAttachment(
+            data: XCTUnwrap(image.pngData()),
+            uniformTypeIdentifier: "public.png"
+        )
+        attachment.name = "TinyRedSquare"
+        attachment.lifetime = .keepAlways
+        add(attachment)
     }
 
     func testSuccess() {

--- a/XCTestHTMLReportSampleApp/SampleAppUnitTests/SwiftTestingSuite.swift
+++ b/XCTestHTMLReportSampleApp/SampleAppUnitTests/SwiftTestingSuite.swift
@@ -29,6 +29,17 @@ struct SwiftTestingSuite {
     func parameterizedAddition(value: Int) {
         #expect(value + 0 == value)
     }
+
+    /// Swift Testing's counterpart to `XCTExpectFailure`. Added alongside
+    /// SampleAppUnitTests.testExpectedFailure so the `Expected Failure`
+    /// status has coverage from both test frameworks — verify against
+    /// `xcresulttool get test-results tests` what this actually records as,
+    /// rather than assuming it matches XCTest. See #439.
+    @Test func knownIssue() {
+        withKnownIssue("Intentional known issue for fixture coverage") {
+            #expect(1 == 2, "This known-issue expectation fails on purpose")
+        }
+    }
 }
 
 extension Tag {


### PR DESCRIPTION
Fixture coverage for the redesign: expectedFailure + PNG-attachment cases (refs #439)

## What

Three new sample-app tests, so the generated fixtures finally exercise two things the redesign (#439) must render but no fixture produced:

- `SampleAppUnitTests.testExpectedFailure` — XCTest `XCTExpectFailure`; records as **`Expected Failure`** in the xcresult.
- `SwiftTestingSuite.knownIssue()` — Swift Testing `withKnownIssue`; verified against `xcresulttool get test-results tests`: it records as **`Expected Failure`** too (not assumed — checked).
- `SampleAppUnitTests.testWithPngAttachment` — attaches a genuine PNG (`public.png`) generated in code (8×8 `UIGraphicsImageRenderer` fill, ~100 bytes; no binary checked in). Every other plain data attachment across the fixtures is txt/log/html/mp4.

All three land in the `SampleAppUnitTests` target, so they flow only into `TestResults.xcresult`: `SanityResults` (only `FirstSuite/testOne`) and `RetryResults` (only `RetryTests`) are untouched, and all three bundles keep their meaning. The CI fixture cache key hashes `XCTestHTMLReportSampleApp/**`, so the cache misses and fixtures regenerate automatically — no manual bump.

Test-suite updates (`CoreTests.testResultStatusCount`): header total goes 18 → 21, and the bucket invariant becomes `passed + failed == all - skipped - 2`, because expected-failure rows are counted in **no** header bucket today (see baseline below).

## What the new cases render as TODAY (the baseline the redesign will change)

Verified identically on **both** backends (`--result-reader legacy` and `modern`):

- Both `Expected Failure` cases render `class="test-summary "` — an **empty status class, i.e. a blank icon**, because `Status` folds `ParsedStatus.expectedFailure` to `.unknown`. They count into `All (21)` but into none of Passed/Skipped/Failed/Mixed (header reads All 21 / Passed 12 / Skipped 1 / Failed 6 / Mixed 0).
- The PNG attachment exports on both backends and types as `.png` (legacy via the `public.png` UTI, modern via the exported filename's extension). It renders through the screenshot machinery (`img.screenshot-flow`, `screenshot-icon`) and its activity row reads `Added attachment named 'TinyRedSquare' ()` — with empty trailing parens, the attachment-label quirk the redesign's attachment-label work is targeting.

## Verification

- `./prepareTestResults.sh` regenerated all three bundles (Xcode 26.2, iPhone 17 Pro Max, iOS 26.2 sim).
- Full suite green on both `XCHR_RESULT_READER` legs (auto + modern), plus `DifferentialTests` explicitly — the new cases flow through both readers and parity held by construction (no allow-list change needed).
- swiftformat/swiftlint clean on the touched files.

Refs #439.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for expected failures and known issues.
  * Added coverage for tests with preserved PNG attachments.
  * Updated result-count validation to reflect the expanded test fixtures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->