### PR TITLE
Tokenization: give the stylesheet a token layer, zero visual change (refs #439)

### DIFF
--- a/Sources/XCTestHTMLReportCore/Classes/HTMLTemplates.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/HTMLTemplates.swift
@@ -16,10 +16,64 @@ struct HTMLTemplates
 
     <style type=\"text/css\">
 
+    /* Design tokens (#439). Every value matches the pre-token stylesheet
+       byte-for-byte in computed terms; retheme by editing this block only. */
+    :root {
+      /* Colour — brand */
+      --color-accent: #1780FA;
+      --color-accent-soft: #B1D3FE;
+      --color-on-accent: #FFF;
+
+      /* Colour — text */
+      --color-text-primary: #111;
+      --color-text-secondary: #333;
+      --color-text-muted: #777;
+      --color-text-subtle: #666;
+      --color-text-placeholder: #AAA;
+
+      /* Colour — status */
+      --status-failed: red;
+
+      /* Colour — surfaces */
+      --color-surface: #FFF;
+      --color-bg-sidebar: #F2F2F2;
+      --color-bg-group-header: #F6F6F6;
+
+      /* Colour — borders */
+      --color-border-strong: #BBB;
+      --color-border-medium: #CCC;
+      --color-border-light: #DDD;
+      --color-border-faint: #EEE;
+      --color-preview-border: #021a40;
+
+      /* Typography — \"SF Pro Display\" stack pinned exactly as-is;
+         the font fix is C-refresh scope, not tokenization's */
+      --font-family-base: \"SF Pro Display\", \"SF Pro Icons\", \"Helvetica Neue\", \"Helvetica\", \"Arial\";
+      --font-size-xs: 11px;
+      --font-size-sm: 12px;
+      --font-size-md: 13px;
+      --font-size-lg: 16px;
+      --font-size-xl: 17px;
+      --font-size-title: 20px;
+      --font-weight-regular: 400;
+      --font-weight-medium: 500;
+
+      /* Spacing — only the two steps the stylesheet actually repeats */
+      --space-xs: 4px;
+      --space-sm: 10px;
+
+      /* Component sizes */
+      --icon-size-sm: 10px;
+      --icon-size: 14px;
+      --icon-size-lg: 24px;
+      --preview-height: 600px;
+      --radius-sm: 3px;
+    }
+
     html, body {
       margin: 0;
       padding: 0;
-      font-family: \"SF Pro Display\", \"SF Pro Icons\", \"Helvetica Neue\", \"Helvetica\", \"Arial\";
+      font-family: var(--font-family-base);
       height: 100%;
       overflow: hidden;
     }
@@ -47,19 +101,19 @@ struct HTMLTemplates
     }
 
     header {
-      color: #111;
-      background-color: #FFF;
+      color: var(--color-text-primary);
+      background-color: var(--color-surface);
       width: 100%;
       height: 70px;
     }
 
     #info-sections ul {
-      padding-left: 4px;
+      padding-left: var(--space-xs);
     }
 
     #info-sections ul li {
-      font-size: 12px;
-      color: #333;
+      font-size: var(--font-size-sm);
+      color: var(--color-text-secondary);
       line-height: 18px;
       white-space: nowrap;
       overflow: hidden;
@@ -67,26 +121,26 @@ struct HTMLTemplates
     }
 
     #info-sections ul.selected li {
-      color: #FFFFFF;
+      color: var(--color-on-accent);
     }
 
     #info-sections ul li h3 {
-      font-size: 16px;
+      font-size: var(--font-size-lg);
       margin: 0;
     }
 
     .device-info {
       margin: 0;
-      padding: 10px 0;
+      padding: var(--space-sm) 0;
       cursor: pointer;
     }
 
     .device-info.selected {
-      background-color: #1780FA;
+      background-color: var(--color-accent);
     }
 
     .device-info li:nth-child(2) {
-      margin-bottom: 10px;
+      margin-bottom: var(--space-sm);
     }
 
     .device-os,
@@ -101,28 +155,28 @@ struct HTMLTemplates
     }
 
     #title {
-      border-bottom: 1px solid #BBB;
+      border-bottom: 1px solid var(--color-border-strong);
       padding: 6px;
     }
 
     .toolbar {
-      background-color: white;
+      background-color: var(--color-surface);
       height: 24px;
-      border-bottom: 1px solid #DDD;
-      padding: 4px 10px;
+      border-bottom: 1px solid var(--color-border-light);
+      padding: var(--space-xs) var(--space-sm);
     }
 
     #test-log-toolbar {
       text-align: center;
-      border-bottom: 1px solid #BBB;
+      border-bottom: 1px solid var(--color-border-strong);
     }
 
     #title h1 {
-      padding-left: 10px;
-      font-size: 20px;
+      padding-left: var(--space-sm);
+      font-size: var(--font-size-title);
       float: left;
       margin: 0;
-      font-weight: 400;
+      font-weight: var(--font-weight-regular);
     }
 
     #title span {
@@ -136,37 +190,37 @@ struct HTMLTemplates
     ul.toggle-toolbar li {
       display: inline;
       margin: 0px 2px;
-      padding: 3px 10px;
-      border-radius: 3px;
-      color: #777;
-      font-size: 11px;
+      padding: 3px var(--space-sm);
+      border-radius: var(--radius-sm);
+      color: var(--color-text-muted);
+      font-size: var(--font-size-xs);
       cursor: default;
     }
 
     ul.toggle-toolbar li:hover {
-      background-color: #B1D3FE;
-      color: white;
+      background-color: var(--color-accent-soft);
+      color: var(--color-on-accent);
     }
 
     ul.toggle-toolbar li.selected {
-      background-color: #1780FA;
-      color: white;
+      background-color: var(--color-accent);
+      color: var(--color-on-accent);
     }
 
     ul.toggle-toolbar.centered-toolbar li {
-      color: #777;
-      font-size: 11px;
+      color: var(--color-text-muted);
+      font-size: var(--font-size-xs);
       cursor: default;
     }
 
     ul.toggle-toolbar.centered-toolbar li.selected {
-      background-color: white;
-      color: #1780FA !important;
+      background-color: var(--color-surface);
+      color: var(--color-accent) !important;
     }
 
     ul.toggle-toolbar.centered-toolbar li:hover {
-      background-color: white;
-      color: #777;
+      background-color: var(--color-surface);
+      color: var(--color-text-muted);
     }
 
     .table-header {
@@ -176,13 +230,13 @@ struct HTMLTemplates
     }
 
     .table-header li {
-      font-size: 11px;
-      color: #777;
+      font-size: var(--font-size-xs);
+      color: var(--color-text-muted);
     }
 
     .table-header li+li {
-      border-left: 1px solid #CCC;
-      padding-left: 4px;
+      border-left: 1px solid var(--color-border-medium);
+      padding-left: var(--space-xs);
     }
 
     #logs {
@@ -197,16 +251,16 @@ struct HTMLTemplates
     }
 
     .icon {
-      background-size: 14px 14px;
-      height: 14px;
-      width: 14px;
-      margin: 0 4px;
+      background-size: var(--icon-size) var(--icon-size);
+      height: var(--icon-size);
+      width: var(--icon-size);
+      margin: 0 var(--space-xs);
     }
 
     .icon.big {
-      background-size: 24px;
-      height: 24px;
-      width:24px;
+      background-size: var(--icon-size-lg);
+      height: var(--icon-size-lg);
+      width: var(--icon-size-lg);
       margin: 0;
     }
 
@@ -231,9 +285,9 @@ struct HTMLTemplates
     }
 
     .paperclip-icon {
-      width: 10px;
-      height: 10px;
-      background-size: 10px 10px;
+      width: var(--icon-size-sm);
+      height: var(--icon-size-sm);
+      background-size: var(--icon-size-sm) var(--icon-size-sm);
       background-image: url(data:image/svg+xml;utf8;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0ZWQgYnkgSWNvTW9vbi5pbyAtLT4KPCFET0NUWVBFIHN2ZyBQVUJMSUMgIi0vL1czQy8vRFREIFNWRyAxLjEvL0VOIiAiaHR0cDovL3d3dy53My5vcmcvR3JhcGhpY3MvU1ZHLzEuMS9EVEQvc3ZnMTEuZHRkIj4KPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB2ZXJzaW9uPSIxLjEiIHdpZHRoPSI2NHB4IiBoZWlnaHQ9IjY0cHgiIHZpZXdCb3g9IjAgMCAxNiAxNiI+CjxwYXRoIGZpbGw9IiM4ZjhmOGYiIGQ9Ik0yLjcgMTUuM2MtMC43IDAtMS40LTAuMy0xLjktMC44LTAuOS0wLjktMS4yLTIuNSAwLTMuN2w4LjktOC45YzEuNC0xLjQgMy44LTEuNCA1LjIgMHMxLjQgMy44IDAgNS4ybC03LjQgNy40Yy0wLjIgMC4yLTAuNSAwLjItMC43IDBzLTAuMi0wLjUgMC0wLjdsNy40LTcuNGMxLTEgMS0yLjcgMC0zLjdzLTIuNy0xLTMuNyAwbC04LjkgOC45Yy0wLjggMC44LTAuNiAxLjcgMCAyLjIgMC42IDAuNiAxLjUgMC44IDIuMiAwbDguOS04LjljMC4yLTAuMiAwLjItMC41IDAtMC43cy0wLjUtMC4yLTAuNyAwbC03LjQgNy40Yy0wLjIgMC4yLTAuNSAwLjItMC43IDBzLTAuMi0wLjUgMC0wLjdsNy40LTcuNGMwLjYtMC42IDEuNi0wLjYgMi4yIDBzMC42IDEuNiAwIDIuMmwtOC45IDguOWMtMC42IDAuNC0xLjMgMC43LTEuOSAwLjd6Ii8+Cjwvc3ZnPgo=)
     }
 
@@ -261,7 +315,7 @@ struct HTMLTemplates
     .test-result-icon {
       float: left;
       display: none;
-      margin: 4px;
+      margin: var(--space-xs);
     }
 
     .test-summary.succeeded .test-result-icon,
@@ -295,9 +349,9 @@ struct HTMLTemplates
 
     .drop-down-icon {
       cursor: pointer;
-      background-size: 10px 10px;
-      height: 10px;
-      width: 10px;
+      background-size: var(--icon-size-sm) var(--icon-size-sm);
+      height: var(--icon-size-sm);
+      width: var(--icon-size-sm);
       margin-top: 2px;
       background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAUgAAAF3CAYAAADHONJLAAAABGdBTUEAALGPC/xhBQAAJfJJREFUeAHtnQl0VdW5xyEDBoQqaOmEdFDxdbAt+jq99/q6qJ1e59WBjqstfW0pCOFmQAURRUStgARIQFREcSy1ztbZiCAOSEBRGWsttFZBAYVCCBHef/NuShKS3OkMe+/zu2vtlXvPsPf3/b7Ln29/95yzu02fPv2eGTNmfLAbLwhAAAIQaEOg6MCBA1956623nr300ktr1Pq12csHCEAAAgkmUJT2vWT//v1jJJYblFGeXl9fX5JgJrgOAQhA4CCBFoE8+EEC2U+ttqGhwWSUX4IRBCAAgSQTaCOQLSAkkh9URnmfssm7a2pqTmrZzl8IQAACSSLQoUC2AJBQflX1ydXTpk27dM6cOX1btvMXAhCAQBIIdCmQBoBEslR/Knbv3m3qkyMWLVpUnAQw+AgBCEAgo0C2QnSMxHLO5s2bn6E+2YoKbyEAAW8JdNf0+UCe3t3ZvXv36qqqqvV5ns9pEIAABKwmkEsG2d6Rb2jDcxLYabrQ/Oj2O/kMAQhAwHUChQhkS32ySr94m/rkcOqTrn8dsB8CEGhNoCCBbOlItclj1S7btGnTKmWTX2jZzl8IQAACLhMIRCBbAfiILgt6QNnkbTNnzjyx1XbeQgACEHCOQNACeRCAsslv7du3z9QnL5k3b95RzlHBYAhAAAIiEIpApsn20N+xu3btMvXJX1Of5PsGAQi4RiBMgTzIQtnk29UuV32yQfXJz7sGCHshAIHkEghdIFuh/ajqkw8pm7xl1qxZx7fazlsIQAACVhIo5ELxQhxq0kXmNaWlpVPKy8vfLKQjzoUABCAQFoEoM8jWPvTQtPuMpqamDbpt8X/1Pi47WtvEewhAAAJtCMSVQbY1onv3Z4qKilIVFRWPtNnBBwhAAAIxErAic1MG+THVJ+tVn7xZP+R8IEYeDA0BCEDgXwSsEMgWaySU39Vtiy9o2n3R/Pnz+7Rs5y8EIACBOAhYJZAGgETyCInkWTt27DD1yWHUJ+P4WjAmBCBgCFhRg+wqFPq1e2VxcXFKr0e7Oo59EIAABIImYF0G2d5BZZCDm5ubF6s+uWj27Nnvb7+fzxCAAATCImC9QLY4LqH8vi4LWqNp95S6urreLdv5CwEIQCAsAs4IpAGQrk+O37Nnj7m/+xf63D0sMPQLAQhAwPoaZIYQrdD+VHV19dIMx7EbAhCAQM4EnMogO/DuVG1bomzyptra2vd2sJ9NEIAABPIm4LpAHnRcU+0fNDY2rtXzJycvXLjwyLxpcCIEIACBVgS8EMi0P2X6O2Hr1q2mPvkz6pOtosxbCEAgLwKu1yA7dVrXTz6dvr/7sU4PYgcEIACBLgj4lEG2cVMZ5L/r/u6lyiZv0Po4A9vs5AMEIACBLAh4K5Atvksof6QLzU19chL1yRYq/IUABLIh4L1AGggSyZ76M1H1yXXKKH9KfTKbrwbHQAAC3tYguwqt6pNPpeuTj3d1HPsgAIFkE0hEBtk+xMogP6n65DJlk9epHdd+P58hAAEIGAKJFMiW0Esof6L3Ztp9rtbv7tWynb8QgAAEDIFEC6QBYOqTauft3LlznR6E8WO95/5uA4YXBCCAQLb6DgzQg3qvl0guq6mp+VSr7byFAAQSSiDxGWT7uCuD/LTqk4/rsqCFEsv3tN/PZwhAIDkEEvkrdrbh1a/du3Xsxfo7rbKyck+253EcBCDgBwEyyC7iqGyyl9r5aqY++cMuDmUXBCDgIQEyyNyC+nhJSckYrY+zPLfTOBoCEHCRABlkblH7jOqTT6o+ebXWx3l3bqdyNAQg4BoBBDLHiGm6bS4D+vnevXvX6/rJsxcsWGAes8YLAhDwkAACmX9Qj5RYXrBt2zZTnxyafzecCQEI2EqAGmRAkdEv3Y+ppfRr99MBdUk3EIBAzATIIAMKgLLJ/1R7SvXJq2bMmPGugLqlGwhAIEYCCGSA8NP1yWG6I8fUJ8dRnwwQLl1BIAYCCGQI0CWUvdUuVH1yjbLJ74UwBF1CAAIREKAGGQXk7t2XpJ8/2RDBcAwBAQgERIAMMiCQXXWjbPKzun5yuabdV9bV1b2zq2PZBwEI2EOADDL6WOzUr91TSktLa8rLy/dGPzwjQgAC2RIgg8yWVHDH9VFGeXFTU5OpT34nuG7pCQIQCJoAGWTQRHPsT9nk4nR9clWOp3I4BCAQMgEyyJABZ+pe2eTnVJ9cofrk5XpQ7zsyHc9+CEAgOgIIZHSsuxqpSEL5a63fvUG3LY6dNWvWEV0dzD4IQCAaAghkNJyzHaWPLjK/ZN++fS/ojpxvZ3sSx0EAAuEQQCDD4VpQr8omP6AObtW0+2G1jxXUGSdDAAJ5E0Ag80YX/okSyiFqDRLJy+bOnds//BEZAQIQaE0AgWxNw873pj45fPfu3aY+WbVo0aIedpqJVRDwjwAC6UhMJZJvU31y2ubNm59XRvlNR8zGTAg4TQCBdCx8EsoT1G6XSD6ojPJkx8zHXAg4RQCBdCpch4yVSJ6mtlJCOUeXBb390B7eQQACQRFAIIMiGUM/EshitRG6bdHUJyvmzZtXGoMZDAkBbwkgkH6E9ijVJy/duXOnqU9+3Q+X8AIC8RNAIOOPQZAWnKiM8k5dZP7AzJkzPxJkx/QFgSQSQCD9jPoXdNviKmWTtRLLY/10Ea8gED4BBDJ8xrGMkK5Pnq6nBW2QSI6hPhlLGBjUcQIIpOMBzGS+hPJoHVOj+uRqZZRfzXQ8+yEAgUMEEMhDLHx/d5LE8m6J5H26LOhDvjuLfxAIggACGQRFh/qQSH5JlwU9I6GcXVtbe4xDpmMqBCIngEBGjtyKAUsklKMaGxtNfXJ0fX19iRVWYQQELCOAQFoWkIjN6avxZjU0NKzWheZfiXhshoOA9QQQSOtDFL6Byib/TRea36Np9z1aSOyD4Y/ICBBwgwAC6UacIrFSQvkVrY/zrIRypjLKfpEMyiAQsJgAAmlxcGIyzdQny9U2SChPpz4ZUxQY1goCCKQVYbDPCAlkP7Va1Sef1Q85X7bPQiyCQPgEEMjwGTs9gkTS1CTvlUjepWVpT3LaGYyHQI4EEMgcgSX48K+pPmnuxpkxZ84c8+s3Lwh4TwCB9D7EwTmobLJULZVeH2ek1scpDq53eoKAfQQQSPti4oJFx+iyoDqtj/OMpt5fdMFgbIRAPgQQyHyocc5BAsomP6w390sk79DUexBYIOAbAQTSt4jG4883NOxzEsnputDcPD2IFwS8IIBAehHG+J1I1ycrNfU26+P8lvpk/DHBgsIJIJCFM6SHVgQklMdKJOeqPmlWXDyt1S7eQsA5AgikcyFzw2AJ5clqD0okb1NGeYIbVmMlBNoSQCDb8uBTwAQkkt9SRmlWW5yqZR+OCrh7uoNAqAQQyFDx0nmaQA8JZfWuXbvM8yd/Q32S74UrBBBIVyLlgZ0SybfLjXmbNm1q0K/dn/fAJVzwnAAC6XmALXXvo7pt8SFNu2/R+jjHW2ojZkGgW3dNeQ7AAQIxEmjS0rQ1paWlU8rLy9+M0Q6GhsBhBMggD0PChogJmPrkGVpIzNQnf6X3fCcjDgDDdU6ADLJzNuyJh8Cq4uLiCr0eiWd4RoXAIQL8b32IBe/sIPBx1SfrVZ+8WT/kfMAOk7AiqQQQyKRG3nK/NdX+rq6ffEEXmV80f/78Ppabi3meEkAgPQ2sD25JJI+QSJ61Y8cOsz7OL6lP+hBVt3ygBulWvBJtrX7tXqn6ZEqvRxMNAucjI0AGGRlqBiqUgDLIwc3NzYuVTS5SffJ9hfbH+RDIRACBzESI/dYRkFB+Xz/krFF9ckpdXV1v6wzEIG8IIJDehDJxjpSpPjm+sbFxvTLKX0g0uyeOAA6HToAaZOiIGSAiAis0Tqq6unppROMxTAIIkEEmIMgJcfFU+blE2eRNtbW1702Iz7gZMgEEMmTAdB8tAU21f6Bp91rdtjh54cKFR0Y7OqP5RgCB9C2i+GMIlKlN2LJli6lP/oz6JF+KfAlQg8yXHOe5RGC5rqFMVVVVLXPJaGyNnwAZZPwxwILwCXxCWeRjyiZvmDlz5sDwh2MEXwggkL5EEj8yEpBI/kgXmpv65CTqkxlxcYAIIJB8DRJFQCLZUw5P3Lp16zpllD+lPpmo8OfsLDXInJFxgk8EVJt8qqioKKXnTz7uk1/4EgwBMshgONKLowSUQX5Sd+SY+uR1Wh9ngKNuYHZIBBDIkMDSrTsEzDRb7Sf79u0z0+5ztX53L3esx9IwCSCQYdKlb6cISCR7qZ23c+fOdXoQxo+NcDrlAMYGTgCBDBwpHXpAYICm3ddLJJfV1NR8ygN/cCFPAghknuA4zX8CyiA/rceqPa7LghZKLN/jv8d42J4Av2K3J8JnCHRAQL9279bmi/V3WmVl5Z4ODmGThwTIID0MKi4FTyBdnzxff0198ofBj0CPNhIgg7QxKthkPQFlksvS6+Mst95YDMybABlk3ug4MckElEn+h+qTT6o+efXs2bPfnWQWPvuOQPocXXwLlYBE0lwG9PO9e/eax6qdvWDBAvOYNV4eEUAgPQomrsRG4EiJ5QWvv/76WtUnh8ZmBQMHToAaZOBI6TDpBFSfXCrBNOvjmHVyeDlMgAzS4eBhup0EJI7/JZFcrvrkVVq/+112WolV2RBAILOhxDEQyJFAuj45THfkmPrkOOqTOQK05HAE0pJAYIafBCSUvdUu3LZt2xplk9/z00t/vaIG6W9s8cxCApp6L0k/f7LBQvMwqR0BMsh2QPgIgTAJKJv8rK6fXK5p9/y6urp3hjkWfRdOgAyycIb0AIF8CexURjmltLS0pry8fG++nXBeeATIIMNjS88QyESgjzLKi5uamkx98juZDmZ/9ATIIKNnzogQ6JCAssnF6frkqg4PYGPkBMggI0fOgBDomICyyc+pPrlC9ckr9KDed3R8FFujJIBARkmbsSCQmUCRhPJXEsr1um1x7KJFi3pkPoUjwiKAQIZFln4hUAABieTbdJH5JZs2bXpBd+R8u4CuOLUAAghkAfA4FQIREDheY9yqaffDah+LYDyGaEUAgWwFg7cQsJWAMsohag3KJufNnTu3v612+mYXAulbRPHHZwLm3+tvdu/evUHZZDX1yfBDjUCGz5gRIBAoAVOfVJu6efPm5yWU3wy0czprQwCBbIODDxBwh4BE8gS12yWSD+oX75PdsdwdSxFId2KFpRDokIBE8jS1lapPzlU7tsOD2JgXAQQyL2ycBAG7CEggi2XRb9U2KqOsnDdvXqldFrppDQLpZtywGgKdEThKYjl9586dpj759c4OYnt2BBDI7DhxFARcI3CihPJOieT9qk9+2DXjbbEXgbQlEtgBgRAISCS/qPaMapN1tbW1x4QwhNddIpBehxfnINCtmwTS1CdHav1uU59MUZ/M/luBQGbPiiMh4DQBCeXRajNUn1yt509+zWlnIjIegYwINMNAwCICJ+lpQXcpm7x31qxZH7LILutM4YG51oUEgyAQKYFmPaj3MrVzKysrt0U6sgODkUE6ECRMhECIBEo07R6lR6uZ+mR5fX19SYhjOdc1AulcyDAYAqEQ6CuhnNnQ0GDqk/8TyggOdsoU28GgYTIEIiBwj8aorK6uXhvBWNYOQQZpbWgwDAKxEjBZ5GpNu2fOmTOnb6yWxDg4AhkjfIaGgOUETH2yfM+ePRt1N86oJNYnEUjLv6GYB4G4CUgk++lHnNkrVqwwd+R8OW57ohwfgYySNmNBwG0C5prJeyWSd2lZ2pPcdiU76xHI7DhxFAQgcIjA13ShualP6gfvGUcf2uzfOwTSv5jiEQRCJ6Bpd6laSkJp6pMjtT6Oud/buxcC6V1IcQgCkRI4RvXJOq2PY+qTX4x05AgGQyAjgMwQEPCdgLJJ88zJ+yWSd2jqPcgXfxFIXyKJHxCwg8A3ZMZzEklToHS+PolA2vGlwgoIeEMgXZ+s1NR7g+qTv3W5PolAevO1xBEI2EVAQnmsRHKu6pMrlVCeZpd12VmDQGbHiaMgAIE8CUgoT1Z7UCJ5mzLKE/LsJpbTEMhYsDMoBJJHQCL5LWWUZrXFqVr24SgXCCCQLkQJGyHgD4EeEsrqXbt2bdAv3r/Re6s1iMed+fPFwxMIuEjgWT3NPFVVVVVvo/FWq7eNwLAJAhAIlMBHlUU+rGn3LVof5/hAew6gMzLIACDSBQQgEAiBJmWTNaWlpVPKy8vfDKTHAjshgywQIKdDAAKBETD1yTOamppMffJXNtQnySADiy0dQQACARNYVVRUlNJqi4sD7jfr7sggs0bFgRCAQMQEPq7Lgh5RffLm2bNnvz/isQ8Oh0DGQZ0xIQCBrAloqv1dTbvX6CLzi+bPn98n6xMDOBCBDAAiXUAAAuESkEgeoWzyrO3bt69XRvnLqOqTCGS4caV3CEAgWALvlDjOVza5XMs+/HewXR/eGwJ5OBO2QAAClhOQSJ7S3Ny8WNnkIj1W7X1hmYtAhkWWfiEAgdAJSCi/r2UfTH1ySl1dXe+gB0QggyZKfxCAQNQEylSfHN/Y2Gjqk7+QaHYPygCugwyKJP1AAAK2EFghQ1LV1dVLCzWIDLJQgpwPAQjYRuBUGbRE2eRNtbW17y3EOASyEHqcCwEIWEtAU+0faNq9VrctTl64cOGR+RiKQOZDjXMgAAFXCJTJ0Albtmwx9cmf5VqfpAbpSpixEwIQCILA8vTzJ5dl0xkZZDaUOAYCEPCFwCeURT6mafeNM2fOHJjJKQQyEyH2QwACPhL4oS40N/XJSVofp1dnDiKQnZFhOwQg4DUBZZI95eBErY9j6pM/7ag+SQ3S668AzkEAAjkQeDJdn3yi5RwyyBYS/IUABJJO4FMCsEzZ5PVaH2eAgUEGmfSvBP5DAAKHEVAm+ZraZ8ggD0PDBghAIKkEJIoH1G7QwmGDtdTDxpKkgsBvCEAAAu0IPKnPZo3uf9UgEch2hPgIAQgkjsDfiouLx6dSqetMBtnae6bYrWnwHgIQSAwBieEetcl9+vQ5qaKi4tr24mhAkEEm5uuAoxCAQCsCN+n9GZpOb2617bC3CORhSNgAAQh4TGC5ptNjlDE+no2PCGQ2lDgGAhBwncDLRUVF4yWMCzuaSnfmHDXIzsiwHQIQcJ5Aus44pX///oN02c41uYijcZ4M0vmvAA5AAAKdEFhUUlIydsyYMZs62Z9xMwKZEREHQAACLhFQlvi0ptMpTacfK9RuBLJQgpwPAQhYQUDC+A+1syWMV+c6le7MAWqQnZFhOwQg4AqBRgniRWVlZabOuCAocTTOk0G68hXATghAoCMCN+uynbHKGl/qaGeh2xDIQglyPgQgEDkBZYkNailljEvCHByBDJMufUMAAkETeEU/wExQxmim0vuD7rx9f9Qg2xPhMwQgYB0BieFetd/17dvX1BnnRyGOBgIZpHVfBQyCAATaEbilR48e1aNHj/5Lu+2hf0QgQ0fMABCAQD4ElCWuVKtQxrg4n/ODOAeBDIIifUAAAoERkCi+qs7OiXIq3Znx1CA7I8N2CEAgUgISxr0acOrRRx99oh5DdoU+h/4jTCYHySAzEWI/BCAQOgGJ4W36dbpKv06/GPpgOQyAQOYAi0MhAIFgCUgYn1GPFcoY64PtOZjeEMhgONILBCCQG4EtEseJqjNaMZXuzHRqkJ2RYTsEIBAGgSZ1Ol2X7Zg64zwb6oxdOUkG2RUd9kEAAoERkBjeoValrHFjYJ2G3BECGTJguodA0glIFFenn8/4sGssEEjXIoa9EHCEgIRxq0w997jjjrt86NChbzlidhszEcg2OPgAAQgUSkDCuO/AgQO1vXv3njR8+PA3Cu0vzvMRyDjpMzYEPCMgcbxL68BUah2YDT64hkD6EEV8gED8BJ7Tg2t1nXfFg/GbEpwFCGRwLOkJAokjoIzxNTl9nuqMl7laZ+wqaAhkV3TYBwEIdEjA1BnV5qidp6xxR4cHebARgfQgiLgAgSgJSBT/pPHMY8jWRzluHGMhkHFQZ0wIuEngBV3PaITxfjfNz91qBDJ3ZpwBgaQReF0OTzr11FPnDhkypDlJziOQSYo2vkIgNwLNmk7P7dmz57kjR47cntupfhyNQPoRR7yAQKAEJIz36mJv8xiytYF27FhnCKRjAcNcCIRJQMK4Rk1lxsp7wxzHlb4RSFcihZ0QCJGARHGbMsbzTznllLqk1Rm7wopAdkWHfRDwn4CpM5rnMk7UdHqb/+7m5iECmRsvjoaANwQkiveZy3b0WuONUwE7gkAGDJTuIOAAgXW6b9oskHW3A7bGaiICGSt+BodApAS2K2s8X48hq9NjyPZFOrKjgyGQjgYOsyGQLQGJonlY7eVHHHHEOaNGjTIXffPKkgACmSUoDoOAiwQkjg+omdsDn3fR/rhtRiDjjgDjQyAEAhLF9WrVEsY7Q+g+MV0ikIkJNY4mgYBE0Tx6bLLqjLOpMxYecQSycIb0AIHYCUgYTZ3xSl3sPaG6uto8xJZXAAQQyAAg0gUEYibwoNaBqdA6MM/FbId3wyOQ3oUUh5JCQFnjxnSd8fak+By1nwhk1MQZDwKFE3hDwniB1oGZpXVgmgrvjh46I4BAdkaG7RCwjICpM6rGOL9Hjx4TysvLt1pmnpfmIJBehhWnPCTwsFlWNZVKPeuhb9a6hEBaGxoMg8BBAn/WAyXG6nrGW+ERPQEEMnrmjAiBjAQ0nX5T0+kpAwcOrKHOmBFXaAcgkKGhpWMI5EVgv8Txql69ep09YsSILXn1wEmBEUAgA0NJRxAomMAjps6o16qCe6KDQAggkIFgpBMI5E9AGeOLOvsMPdH7j/n3wplhEEAgw6BKnxDIjsBOHXZhaWnpDF22sze7UzgqSgIIZJS0GQsC/0/A1Bmv1nR6vC7beRUo9hJAIO2NDZb5SeBRiWNK0+mVfrrnl1cIpF/xxBtLCUgUX5Jpps74B0tNxKwOCCCQHUBhEwSCIiBh3KXrGS9SnXE6dcagqEbXDwIZHWtGShABCeMBuXtNWVnZuNNPP/2VBLnulasIpFfhxBkbCEgclyprTOnBtStssAcb8ieAQObPjjMh0J7AXyWOZ6rO+Pv2O/jsJgEE0s24YbVdBP6pB0pc3Ldv32nDhg1rtMs0rCmEAAJZCD3OTTSBdJ3xWj2fcdzo0aNfTjQMT51HID0NLG6FS0DiuExtjB5D9nS4I9F7nAQQyDjpM7ZzBCSKm/QDzFmqM97onPEYnDMBBDJnZJyQUAKmzniJfJ8qcdyTUAaJcxuBTFzIcTgXAuk64/X6e5am03/P5VyOdZ8AAul+DPEgPAKPSxhTEsanwhuCnm0mgEDaHB1si4WARHGz6ozjdKH39bEYwKDWEEAgrQkFhsRNQMK4WzZM7d279yXDhw8373klnAACmfAvAO536yZhNPdN36gHSpypB0r8DSYQaCGAQLaQ4G9SCTwpx83zGZ9IKgD87pwAAtk5G/Z4TEBZ49912c44PdH7unQG6bG3uJYvgaJ8T+Q8CLhIQGK4R22y6oyDtHrgtYiji1GMzmYyyOhYM1L8BG6SCeap3pvjNwULXCCAQLoQJWwslMByZYqmzris0I44P1kEEMhkxTtp3r6sOuN4TaUXMpVOWuiD8ZcaZDAc6cUuAo0SxCn9+/cfpLtgrkEc7QqOS9aQQboULWzNhsAiXc84dsyYMZuyOZhjINAVAQSyKzrsc4aAssSnNZ1OaTr9mDNGY6j1BBBI60OEgV0RkDD+Q+1sCePVTKW7IsW+fAhQg8yHGufYQMDUGS/SsqqmzrgAcbQhJP7ZQAbpX0yT4NHNxcXFY5U1vpQEZ/ExPgIIZHzsGTlHAsoSG9TM8xmX5Hgqh0MgLwIIZF7YOCliAq/oB5gJyhjNVHp/xGMzXIIJUINMcPBtd11iuFftd1pv2tQZ5yOOtkfMP/vIIP2LqS8e3aL1pqu13vRffHEIP9wjgEC6FzPfLV5lrmdUxrjYd0fxz34CCKT9MUqEhZo+vypHz2EqnYhwO+MkNUhnQuWnoabOKM+m6vbAQXrazhXUGf2Ms6tekUG6GjkP7JYY3qbpdJV+nX7RA3dwwUMCCKSHQbXdJQnjM7KxQhljve22Yl+yCSCQyY5/1N5v0YCmznglU+mo0TNePgSoQeZDjXNyJdCkE6brsp0Tq6urL0ccc8XH8XERIIOMi3xCxpUY3qFWpaxxY0Jcxk2PCCCQHgXTJlckiqtlj6kzPmSTXdgCgVwIIJC50OLYjAQkjFvVJg4YMOCKoUOHvpXxBA6AgMUEEEiLg+OSaRLFfQcOHKjVetOThg8f/oZLtmMrBDojgEB2RobtWROQON5VUlJSqXVgNmR9EgdCwAECCKQDQbLYxOdkW6XqjA9YbCOmQSBvAghk3ugSfeLrugPG1BnnUWdM9PfAe+cRSO9DHJyDps6o3uokjpN0e+CO4HqmJwjYSQCBtDMu1lklcfyT1oGpTKVS66wzDoMgEBIBBDIksB51+4J8MXXG+zzyCVcgkBUBBDIrTMk7SBnjNrVzBw8efNmQIUOak0cAjyHQrRsCybegPYFmCeOcnj17njdy5Mjt7XfyGQJJIoBAJinaGXyVMN6ri73N7YFrMxzKbggkggACmYgwd+2khHGNmp4nUXlv10eyFwLJIoBAJive7b3dLmE875RTTplDnbE9Gj5DgBpkUr8Dps54mdq5yhq3JRUCfkMgEwEyyEyEPNsvUbxPC2RVlpeXm8t3eEEAAl0QQCC7gOPZrnW60NsskHW3Z37hDgRCI4BAhobWmo5NnfF8PYasTo8hM7cK8oIABLIkgEBmCcq1wySKb+mSnXllZWUTR40a9bpr9mMvBGwggEDaEIWAbZA4PqBmrmd8PuCu6Q4CiSKAQHoUbonierVq/TJ9p0du4QoEYiOAQMaGPriBJYrm0WOTVWecTZ0xOK70BAEE0uHvgITR1BmvUDtH602/5rArmA4BKwkgkFaGJbNREseH1Eyd0SyvygsCEAiBAAIZAtQwu5QoblQzdcbbwxyHviEAAW41dOk78IaE8YLjjjtultaBaXLJcGyFgKsEyCDtj9x+mXhljx49Juj2wK32m4uFEPCHAAJpcSyVMdbr9kAtA5N61mIzMQ0C3hJAIO0M7Z+1cuBY1RlvtdM8rIJAMgggkBbFWRnjm7pkZ8rAgQNrqDNaFBhMSSwBBNKO0O+XOF7Vq1evs0eMGLHFDpOwAgIQQCDj/w48ojqjnkJWsSp+U7AAAhBoTQCBbE0jwvfKGF/UcGfoQu8/RjgsQ0EAAjkQQCBzgBXQoTvVz4V6qvcMXbazN6A+6QYCEAiBAAIZAtROujR1xqs1nR6vy3Ze7eQYNkMAAhYRQCCjCcajEseUptMroxmOUSAAgSAIIJBBUOykD4niS9pl6ox/6OQQNkMAAhYTQCBDCI6EcZeuZ7yoX79+lw4bNqwxhCHoEgIQiIAAAhkgZAnjAXV3je6CGa/Ldv4RYNd0BQEIxEAAgQwIusRxqbLGlB5cuyKgLukGAhCImQACWXgA/ipxPFN1xt8X3hU9QAACNhFAIPOPxj81lb64b9++06gz5g+RMyFgMwEEMsfopOuM1+r5jONGjx79co6nczgEIOAQAQQyh2BJHJeln8+4PIfTOBQCEHCUAAKZReAkjJv0A8xZqjPemMXhHAIBCHhCAIHsOpCmzniJDpkqcdzT9aHshQAEfCOAQHYQ0XSd8Xr9PUtP9f57B4ewCQIQSAABBLJdkCWKT6iNkTA+1W4XHyEAgYQRQCAPBfxvemsyxhvSGeShPbyDAAQSSaAokV63clpiuFttUp8+fU7SXTBmWm1uF+QFAQhAoFtiM8i0EN6oB9eeqQfXmuyRFwQgAIE2BJIqkE+Kgnk+4xNtaPABAhCAQCsCiRJIZY3mF2lTZ2Qq3epLwFsIQKBjAomoQUoY96hN7t279yBljdelp9cdE2ErBCAAgTSBJGSQN8lX81TvzUQdAhCAQC4EfBbI5coUTZ1xWS5AOBYCEIBACwEfBfJlCeM41RmvZSrdEmb+QgAC+RDwqQbZKEGc0r9/f1NnXIg45vN14BwIQKA1AV8yyEVlZWVnjBo16q+tneM9BCAAgUIIuC6QZv0Xsw7M0kIgcC4EIACBjgg4KZCaPpsVA8erzngNU+mOwso2CEAgCAKu1SAb9XzGCzWdNnXGqxHHIL4C9AEBCHRGwKUM8mYtdzBW602/1JkzbIcABCAQJAHrBVJZYoNaStPpJUE6Tl8QgAAEMhGwWSBfkTCeLWE0U+n9mRxhPwQgAIGgCVhXg5QY7k2vN23qjFchjkGHnP4gAIFsCdiWQd6i9aartd70X7J1gOMgAAEIhEXAFoFcpazR1BkXh+Uo/UIAAhDIlUCsAqnp86tab3oCU+lcw8bxEIBAFATiqkE2SRwv0XIHg3QXzJXUGaMINWNAAAK5Eog8g5QY3iphHKt1YP6cq7EcDwEIQCBKAlEK5LMSR/N8xvooHWQsCEAAAvkSCF0gJYpb03VGptL5RonzIACBWAiEWYM0dcZpWgfmRNUZL9d7LvaOJcQMCgEI5EsglAxSYni7WrUu29mYr2GcBwEIQCBuAoEKpERxtRyqUJ3xobgdY3wIQAAChRIIRCAljK+pnTNgwIArhg4d+lahRnE+BCAAARsIFCSQEsV9cmK26oznDx8+/A0bHMIGCEAAAkERKEQg7ywpKakaM2bMhqCMoR8IQAACNhHIWSCVNT6vy3Yq9Mv0AzY5gi0QgAAEgiaQi0C+rgdKTFSdcR51xqDDQH8QgICNBDIKZLrOWCdxnKTlDnbY6AQ2QQACEAiDQCaBvFvrwFSlUql1YQxOnxCAAARsJtCZQL4goytVZ7zPZuOxDQIQgECYBNoIpKbT29TOHTx48GVDhgxpDnNg+oYABCBgO4EWgWyWMM7p2bPneSNHjtxuu9HYBwEIQCAKAkYg71Gr1O2Ba6MYkDEgAAEIuELg/wBbMyzjuLUpwQAAAABJRU5ErkJggg==')
     }
@@ -344,7 +398,7 @@ struct HTMLTemplates
     }
 
     .activity.activity-assertion-failure > p {
-      color: red;
+      color: var(--status-failed);
     }
 
     .sub-activities {
@@ -386,18 +440,18 @@ struct HTMLTemplates
     }
   
     .iteration {
-      margin-left: 10px;
+      margin-left: var(--space-sm);
     }
 
     .test-summary p, .test-summary-group p, .iteration p, .activity p {
-      font-size: 12px;
-      padding: 4px 4px 4px 52px;
-      border-bottom: 1px solid #EEE;
+      font-size: var(--font-size-sm);
+      padding: var(--space-xs) var(--space-xs) var(--space-xs) 52px;
+      border-bottom: 1px solid var(--color-border-faint);
     }
 
     .test-summary-group > p {
-      background-color: #F6F6F6;
-      font-weight: 500;
+      background-color: var(--color-bg-group-header);
+      font-weight: var(--font-weight-medium);
     }
 
     .test-summary-group > p > .drop-down-icon {
@@ -405,9 +459,9 @@ struct HTMLTemplates
     }
 
     .screenshot {
-      background-color: white;
-      padding: 4px;
-      height: 600px;
+      background-color: var(--color-surface);
+      padding: var(--space-xs);
+      height: var(--preview-height);
       position: absolute;
       top:0;
       bottom: 0;
@@ -419,9 +473,9 @@ struct HTMLTemplates
     }
 
     .video {
-      background-color: white;
-      padding: 4px;
-      height: 600px;
+      background-color: var(--color-surface);
+      padding: var(--space-xs);
+      height: var(--preview-height);
       position: absolute;
       top:0;
       bottom: 0;
@@ -433,9 +487,9 @@ struct HTMLTemplates
     }
 
     .gif {
-      background-color: white;
-      padding: 4px;
-      height: 600px;
+      background-color: var(--color-surface);
+      padding: var(--space-xs);
+      height: var(--preview-height);
       position: absolute;
       top:0;
       bottom: 0;
@@ -451,14 +505,14 @@ struct HTMLTemplates
     }
 
     .screenshot-flow {
-        border: 1px solid #021a40;
-        background-color: white;
+        border: 1px solid var(--color-preview-border);
+        background-color: var(--color-surface);
         height: 200px;
     }
 
     .screenshot-tail {
-        border: 1px solid #021a40;
-        background-color: white;
+        border: 1px solid var(--color-preview-border);
+        background-color: var(--color-surface);
         height: 350px;
     }
 
@@ -476,22 +530,22 @@ struct HTMLTemplates
 
     .sidebar {
       position: relative;
-      background-color: #F2F2F2;
+      background-color: var(--color-bg-sidebar);
     }
 
     #left-sidebar {
       width: 200px;
-      border-right: 1px solid #BBB;
+      border-right: 1px solid var(--color-border-strong);
       display: flex;
       flex-direction: column;
     }
 
     #device-header {
-      color: #777;
-      font-size: 13px;
-      font-weight: 500;
-      margin: 16px 0 0px 10px;
-      border-bottom: 1px solid #ddd;
+      color: var(--color-text-muted);
+      font-size: var(--font-size-md);
+      font-weight: var(--font-weight-medium);
+      margin: 16px 0 0px var(--space-sm);
+      border-bottom: 1px solid var(--color-border-light);
     }
 
     #info-sections {
@@ -501,21 +555,21 @@ struct HTMLTemplates
 
     #report-issue {
       padding-top: 6px;
-      padding-bottom: 10px;
+      padding-bottom: var(--space-sm);
       width: 100%;
-      background-color: #F2F2F2;
+      background-color: var(--color-bg-sidebar);
       text-align: center;
-      border-top: 1px solid #BBB;
+      border-top: 1px solid var(--color-border-strong);
     }
 
     #report-issue a {
-      color: #666;
-      font-weight: 400;
+      color: var(--color-text-subtle);
+      font-weight: var(--font-weight-regular);
       font-size: 0.8em;
     }
 
     #report-issue a:active {
-      color: #666;
+      color: var(--color-text-subtle);
     }
 
     #main-content {
@@ -528,7 +582,7 @@ struct HTMLTemplates
       display: flex;
       flex-direction: column;
       width: 400px;
-      border-left: 1px solid #BBB;
+      border-left: 1px solid var(--color-border-strong);
     }
 
     .resizer {
@@ -550,9 +604,9 @@ struct HTMLTemplates
     }
 
     #right-sidebar h2 {
-      color: #AAA;
-      font-weight: 400;
-      font-size: 17px;
+      color: var(--color-text-placeholder);
+      font-weight: var(--font-weight-regular);
+      font-size: var(--font-size-xl);
       text-align: center;
       position: absolute;
       width: 100%;
@@ -583,19 +637,19 @@ struct HTMLTemplates
     }
 
     .list-item {
-      color: #111;
+      color: var(--color-text-primary);
     }
 
     .list-item.list-item-failed {
-      color: red;
+      color: var(--status-failed);
     }
 
     .list-item.selected {
-      background-color: #1780FA;
+      background-color: var(--color-accent);
     }
 
     .list-item.selected {
-      color: #FFF;
+      color: var(--color-on-accent);
     }
 
     </style>
@@ -1168,7 +1222,7 @@ struct HTMLTemplates
     <p class=\"list-item\">
       <span style=\"margin-left: [[PADDING]]px\" class=\"padding\"></span>
       <span class=\"icon left drop-down-icon\" onclick=\"toggle(this, '[[UUID]]')\"></span>
-      [[TITLE]] ([[TIME]])
+      [[TITLE]]
       <span class=\"icon paperclip-icon\" style=\"display: [[PAPER_CLIP_CLASS]]\"></span>
     </p>
     <div id=\"attachments-[[UUID]]\" class=\"attachments\">

--- a/Sources/XCTestHTMLReportCore/Classes/Models/Activity.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Models/Activity.swift
@@ -94,11 +94,6 @@ struct Activity: HTML {
             "PAPER_CLIP_CLASS": hasGlobalAttachment ? "inline-block" : "none",
             "PADDING": (subActivities.isEmpty && attachments.isEmpty) ? String(padding + 18) :
                 String(padding),
-            // Empty rather than a duration: the port carries no finish time
-            // (decision 1), and a fabricated `(0.00s)` would be worse than the
-            // stray `()` this leaves. Removing the placeholder itself is the
-            // redesign's call — the templates are frozen for this work.
-            "TIME": "",
             "ACTIVITY_TYPE_CLASS": cssClasses,
             "HAS_SUB-ACTIVITIES_CLASS": (subActivities.isEmpty && attachments.isEmpty) ?
                 "no-drop-down" : "",


### PR DESCRIPTION
Refs #439 (option C direction — this is the token layer the C-refresh lands on). **Zero visual change** beyond the ` ()` removal below.

## What

1. **33 CSS custom properties on `:root`**, at their current values, grouped and commented (brand / text / status / surfaces / borders / typography / spacing / component sizes). Every colour literal in the stylesheet now lives in the token block — `#1780FA` → `--color-accent`, `red` → `--status-failed`, the grays split by role (text vs border vs surface). The `"SF Pro Display"` stack is pinned exactly as-is (`--font-family-base`); the font fix is C-refresh scope. The px type scale (11/12/13/16/17/20), font weights (400/500), icon sizes (10/14/24), the preview height (600px), the one border-radius, and the two spacing steps that actually repeat (4px, 10px) are tokens too.
2. **`([[TIME]])` removed** from the activity template — the empty `()` on every activity row left behind when 5b emptied the duration (the migration's logged follow-up, now that #452 settled the template source of truth). The dead `"TIME": ""` supply in `Activity.swift` is gone with it (its only consumer).

## Judgment calls (one-offs left inline)

- Structural one-offs stay literal: header height 70px, sidebar widths 200/400px, screenshot-flow/tail heights 200/350px, indent offsets (22/28/52px, 24px `padding-left`), resizer geometry (6px, −4px), 1px border widths, `0.8em`, and the 14×11px preview-icon (non-square, so not coupled to `--icon-size`).
- `#DDD`/`#ddd` (same colour, two spellings) collapse into one `--color-border-light`; `white`/`#FFF`/`#FFFFFF` split semantically into `--color-surface` vs `--color-on-accent`.
- No new tokens for future values, no dark mode.

## The gate (byte-honest, one fixture generation)

`BaselineCaptureTests` + `XCHR_BASELINE_DIR`, before vs after, all three fixtures. The diff contains **only** the two permitted classes, enumerated:

| Fixture | `<style>` lines (−/+) | activity rows losing exactly ` ()` | any other line |
|---|---|---|---|
| TestResults | −92/+146 | 47 | **0** |
| SanityResults | −92/+146 | 4 | **0** |
| RetryResults | −92/+146 | 23 | **0** |

The +54 style-line delta is the `:root` block itself. Value round-trip proven mechanically: substituting every `var()` back with its definition and dropping `:root` reproduces the old stylesheet — all **103 rules value-identical** (modulo colour spelling `#ddd`→`#DDD` and one `width:24px`→`width: 24px` colon-spacing normalization). Every `var()` has a definition; no definition is unused.

## Tests

- Legacy leg: `swift test` — 100 tests, 0 failures (2 env-gated skips)
- Forced-modern leg: `XCHR_RESULT_READER=modern swift test` — 100 tests, 0 failures
- `DifferentialTests` 6/6 — both backends share the markup, parity confirmed, not assumed

## Hook note

First real consumer of the template-aware pre-commit hook (#452): a mixed commit (exempt `HTMLTemplates.swift` + regular `Activity.swift`) worked with zero friction — swiftformat skipped the template, linted the Swift file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)