### PR TITLE
C-refresh part 1/2 — theme: dark mode, WCAG floors, system font, run-identity title (refs #439)

### DIFF
--- a/Sources/XCTestHTMLReportCore/Classes/HTMLTemplates.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/HTMLTemplates.swift
@@ -92,7 +92,15 @@ struct HTMLTemplates
        with the light theme, which is what the token layer bought us. */
     @media (prefers-color-scheme: dark) {
       :root {
-        --color-accent: #1E65C2;
+        /* The selection fill lands on three different backgrounds — the
+           sidebar (#232327, the lightest and so the binding one), the
+           surface, and the group header — and has to clear 3:1 against each
+           while still carrying white text at 4.5:1. That window is narrow:
+           at this hue no value clears both floors by more than ~7%, and this
+           one sits at its centre (sidebar 3.25, white 4.82). Splitting a
+           separate fill token would buy nothing, because the selected device
+           card needs both floors satisfied at once. */
+        --color-accent: #2170D6;
         --color-accent-text: #7FB0FF;
         --color-accent-soft: #274A73;
         --color-on-accent: #FFF;

--- a/Sources/XCTestHTMLReportCore/Classes/HTMLTemplates.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/HTMLTemplates.swift
@@ -156,7 +156,11 @@ struct HTMLTemplates
       color: var(--color-text-primary);
       background-color: var(--color-surface);
       width: 100%;
-      height: 70px;
+      /* Same reasoning as .toolbar: 70px is ~4px of slack over the title
+         band plus the Tests/Logs row, so any text scaling clipped it. The
+         two rows never wrap on their own — the pills that do wrap live in
+         .tests-header, not here. */
+      min-height: 70px;
     }
 
     #info-sections ul {

--- a/Sources/XCTestHTMLReportCore/Classes/HTMLTemplates.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/HTMLTemplates.swift
@@ -10,29 +10,41 @@ struct HTMLTemplates
   <html lang=\"en\">
   <head>
     <meta charset=\"utf-8\">
+    <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">
 
-    <title>XCHTMLReport</title>
+    <title>[[TITLE]]</title>
     <meta name=\"description\" content=\"Xcode Testing HTML Report\">
 
     <style type=\"text/css\">
 
-    /* Design tokens (#439). Every value matches the pre-token stylesheet
-       byte-for-byte in computed terms; retheme by editing this block only. */
+    /* Design tokens (#439). The token layer is the whole theme: every colour
+       the report paints comes from here, so the dark block below overrides
+       values only — it contains no selectors of its own. */
     :root {
-      /* Colour — brand */
-      --color-accent: #1780FA;
+      /* Follow the OS. Also gives form controls and scrollbars the right
+         appearance, which a background-colour alone does not. */
+      color-scheme: light dark;
+
+      /* Colour — brand.
+         --color-accent is the selection fill (white text sits on it);
+         --color-accent-text is the same blue used *as* text on a surface.
+         They are separate tokens because dark mode cannot satisfy both
+         roles with one value: a fill dark enough for white text is too
+         dark to read as text itself. */
+      --color-accent: #1163CC;
+      --color-accent-text: #1163CC;
       --color-accent-soft: #B1D3FE;
       --color-on-accent: #FFF;
 
       /* Colour — text */
       --color-text-primary: #111;
       --color-text-secondary: #333;
-      --color-text-muted: #777;
-      --color-text-subtle: #666;
-      --color-text-placeholder: #AAA;
+      --color-text-muted: #555;
+      --color-text-subtle: #555;
+      --color-text-placeholder: #6E6E73;
 
       /* Colour — status */
-      --status-failed: red;
+      --status-failed: #D70015;
 
       /* Colour — surfaces */
       --color-surface: #FFF;
@@ -43,12 +55,14 @@ struct HTMLTemplates
       --color-border-strong: #BBB;
       --color-border-medium: #CCC;
       --color-border-light: #DDD;
-      --color-border-faint: #EEE;
+      --color-border-faint: #E5E5E5;
       --color-preview-border: #021a40;
 
-      /* Typography — \"SF Pro Display\" stack pinned exactly as-is;
-         the font fix is C-refresh scope, not tokenization's */
-      --font-family-base: \"SF Pro Display\", \"SF Pro Icons\", \"Helvetica Neue\", \"Helvetica\", \"Arial\";
+      /* Typography — the system UI face, so the report looks native on the
+         platform it is read on. `system-ui` first, `-apple-system` for the
+         Safari versions that predate it, then named fallbacks, and a
+         generic family last so the chain can always terminate. */
+      --font-family-base: system-ui, -apple-system, \"Segoe UI\", Roboto, \"Helvetica Neue\", Helvetica, Arial, sans-serif;
       --font-size-xs: 11px;
       --font-size-sm: 12px;
       --font-size-md: 13px;
@@ -58,7 +72,11 @@ struct HTMLTemplates
       --font-weight-regular: 400;
       --font-weight-medium: 500;
 
-      /* Spacing — only the two steps the stylesheet actually repeats */
+      /* Spacing — the two steps used as a shared scale, i.e. repeated across
+         unrelated components. 2px and 6px each also appear four times, but
+         as component-local nudges (icon baseline shifts, the #title and
+         #report-issue paddings, the resizer's width) with no common meaning
+         to name, so they stay inline. */
       --space-xs: 4px;
       --space-sm: 10px;
 
@@ -70,12 +88,46 @@ struct HTMLTemplates
       --radius-sm: 3px;
     }
 
+    /* Dark theme. Token values only — every selector in the sheet is shared
+       with the light theme, which is what the token layer bought us. */
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --color-accent: #1E65C2;
+        --color-accent-text: #7FB0FF;
+        --color-accent-soft: #274A73;
+        --color-on-accent: #FFF;
+
+        --color-text-primary: #E8E8EA;
+        --color-text-secondary: #C9C9CE;
+        --color-text-muted: #9A9AA2;
+        --color-text-subtle: #9A9AA2;
+        --color-text-placeholder: #8A8A92;
+
+        --status-failed: #FF6E6A;
+
+        --color-surface: #161619;
+        --color-bg-sidebar: #232327;
+        --color-bg-group-header: #202024;
+
+        --color-border-strong: #3A3A40;
+        --color-border-medium: #33333A;
+        --color-border-light: #2E2E34;
+        --color-border-faint: #2A2A2F;
+        --color-preview-border: #3A3A40;
+      }
+    }
+
     html, body {
       margin: 0;
       padding: 0;
       font-family: var(--font-family-base);
       height: 100%;
       overflow: hidden;
+      /* Explicit, so the canvas is ours in both themes. Previously unset:
+         the white page was the browser default, which is what made dark
+         mode impossible to bolt on. */
+      background-color: var(--color-surface);
+      color: var(--color-text-primary);
     }
 
     body.dragging {
@@ -161,7 +213,12 @@ struct HTMLTemplates
 
     .toolbar {
       background-color: var(--color-surface);
-      height: 24px;
+      /* min-, not a fixed height: identical while the row fits on one line,
+         but lets it grow instead of spilling over the next element once the
+         pills wrap. Adding the viewport meta stopped phones from rendering
+         this page zoomed out at desktop width, which is what had been hiding
+         that overlap. The actual narrow-screen layout is PR 2's job. */
+      min-height: 24px;
       border-bottom: 1px solid var(--color-border-light);
       padding: var(--space-xs) var(--space-sm);
     }
@@ -199,7 +256,9 @@ struct HTMLTemplates
 
     ul.toggle-toolbar li:hover {
       background-color: var(--color-accent-soft);
-      color: var(--color-on-accent);
+      /* Primary, not --color-on-accent: the soft tint is a pale wash, and
+         white on it was 1.55:1. */
+      color: var(--color-text-primary);
     }
 
     ul.toggle-toolbar li.selected {
@@ -215,7 +274,7 @@ struct HTMLTemplates
 
     ul.toggle-toolbar.centered-toolbar li.selected {
       background-color: var(--color-surface);
-      color: var(--color-accent) !important;
+      color: var(--color-accent-text) !important;
     }
 
     ul.toggle-toolbar.centered-toolbar li:hover {
@@ -224,7 +283,7 @@ struct HTMLTemplates
     }
 
     .table-header {
-      height: 18px;
+      min-height: 18px;
       margin: 0;
       padding-top: 0;
     }

--- a/Sources/XCTestHTMLReportCore/Classes/Models/Summary.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Models/Summary.swift
@@ -14,6 +14,9 @@ public struct Summary {
     /// `generatedJsonReport()` can emit it without a second parse.
     private let parsedRuns: [ParsedRun]
     private let faultCollector: FaultCollector
+    /// Bundle file names in argument order, duplicates collapsed. Retained
+    /// only to title the page — see `title`.
+    private let bundleNames: [String]
 
     public enum RenderingMode {
         case inline
@@ -36,6 +39,8 @@ public struct Summary {
         var runs: [Run] = []
         var parsedRuns: [ParsedRun] = []
         self.faultCollector = faultCollector
+
+        bundleNames = Self.bundleNames(from: resultPaths)
 
         // The CLI already rejects an explicit `legacy` the toolchain cannot
         // honour in `validate()`. This arm is defence in depth for library
@@ -95,6 +100,24 @@ public struct Summary {
         }
         self.runs = runs
         self.parsedRuns = parsedRuns
+    }
+
+    /// Bundle file names for the title, in argument order.
+    ///
+    /// Names, not paths: the title has to survive a bundle moving directories
+    /// for the same reason the identifiers minted in `init` do. Duplicates are
+    /// collapsed because the same bundle may legitimately be passed twice.
+    private static func bundleNames(from resultPaths: [String]) -> [String] {
+        var seen = Set<String>()
+        return resultPaths.compactMap { path in
+            let name = URL(fileURLWithPath: path)
+                .deletingPathExtension()
+                .lastPathComponent
+            guard !name.isEmpty, seen.insert(name).inserted else {
+                return nil
+            }
+            return name
+        }
     }
 
     /// Reader and payload provider for one bundle on the resolved backend.
@@ -187,6 +210,23 @@ public struct Summary {
     }
 }
 
+extension Summary {
+    /// Tab title. Constant `XCHTMLReport` until #439: parked tabs from
+    /// different runs were indistinguishable (UI audit, finding 7).
+    ///
+    /// Derived from the bundle file names rather than from anything read out
+    /// of a bundle, which keeps it byte-identical across the legacy and
+    /// modern readers — the differential gate holds by construction rather
+    /// than by allow-list. Falls back to the product name when no bundle
+    /// yielded a usable name, so the title is never empty.
+    var title: String {
+        guard !bundleNames.isEmpty else {
+            return "XCTestHTMLReport"
+        }
+        return "\(bundleNames.joined(separator: ", ")) — XCTestHTMLReport"
+    }
+}
+
 extension Summary: HTML {
     var htmlTemplate: String {
         HTMLTemplates.index
@@ -205,6 +245,7 @@ extension Summary: HTML {
             "DEVICES": runs.map(\.runDestination.html).joined(),
             "RESULT_CLASS": resultClass,
             "RUNS": runs.map(\.html).joined(),
+            "TITLE": title.stringByEscapingXMLChars,
         ]
     }
 }


### PR DESCRIPTION
Part 1 of 2 of the Option C "conservative refresh" (refs #439). This is the **theme** half:
the token layer #455 built gets rethemed, gains a dark palette, and the head learns a viewport
and a per-run title. **Part 2 handles structure** — responsive collapse, SVG/status icons for
mixed & unknown, attachment labels — and is deliberately not here.

Today's three-pane identity is kept. Every selector is shared between light and dark; the dark
block overrides token *values* only, which is exactly what tokenizing bought.

## What changed

| # | Change | Where |
|---|---|---|
| 1 | `<meta name="viewport">`, `color-scheme: light dark`, explicit `background-color`/`color` on `html, body` | head + `:root` |
| 2 | Font stack: pinned `"SF Pro Display"` → `system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Helvetica, Arial, sans-serif` (generic family last, so the chain terminates) | `--font-family-base` |
| 3 | WCAG contrast fixes — 11 failing pairs → 0 (table below) | token values |
| 4 | `prefers-color-scheme: dark` block — 18 token overrides, **no selectors** | new `@media` block |
| 5 | Tab title carries run identity | `Summary.title` + `[[TITLE]]` |
| 6 | Carried nit from #455 review: the false spacing rationale at `HTMLTemplates.swift:61` | comment |

`body` previously set **no** background at all — the white canvas was a browser default
(audit finding, confirmed: computed `rgba(0,0,0,0)` before, `rgb(22,22,25)` in dark after).
That is what made dark mode impossible to bolt on.

## Contrast

Computed with a WCAG 2.1 relative-luminance implementation over every fg/bg pairing whose
tokens this PR touches, named by its CSS consumer. Floors: **4.5:1** normal text, **3:1**
large text / UI state.

### Before — 11 of 17 pairs failing

| Pair | fg on bg | Ratio |
|---|---|---|
| filter pill (rest) | `#777` on `#FFF` | 4.48 ✗ |
| table-header li | `#777` on `#FFF` | 4.48 ✗ |
| `#device-header` | `#777` on `#F2F2F2` | 4.00 ✗ |
| `#right-sidebar h2` placeholder | `#AAA` on `#F2F2F2` | 2.08 ✗ |
| selected row text | `#FFF` on `#1780FA` | 3.82 ✗ |
| selected filter pill text | `#FFF` on `#1780FA` | 3.82 ✗ |
| selected device card text | `#FFF` on `#1780FA` | 3.82 ✗ |
| Tests/Logs active tab text | `#1780FA` on `#FFF` | 3.82 ✗ |
| assertion failure text | `red` on `#FFF` | 4.00 ✗ |
| failed row text | `red` on `#FFF` | 4.00 ✗ |
| failed row on group header | `red` on `#F6F6F6` | 3.70 ✗ |
| hover pill text (not in the 11 — see note) | `#FFF` on `#B1D3FE` | **1.55** ✗ |

### After — light, 19 of 19 passing

| Pair | fg on bg | Ratio |
|---|---|---|
| row text `.list-item` | `#111` on `#FFF` | 18.88 |
| group header `.test-summary-group>p` | `#111` on `#F6F6F6` | 17.47 |
| device card `#info-sections li` | `#333` on `#F2F2F2` | 11.29 |
| filter pill (rest) | `#555` on `#FFF` | 7.46 |
| table-header li | `#555` on `#FFF` | 7.46 |
| `#device-header` | `#555` on `#F2F2F2` | 6.66 |
| `#report-issue a` | `#555` on `#F2F2F2` | 6.66 |
| `#right-sidebar h2` placeholder | `#6E6E73` on `#F2F2F2` | 4.53 |
| selected row text | `#FFF` on `#1163CC` | 5.71 |
| selected filter pill text | `#FFF` on `#1163CC` | 5.71 |
| selected device card text | `#FFF` on `#1163CC` | 5.71 |
| Tests/Logs active tab text | `#1163CC` on `#FFF` | 5.71 |
| hover pill text | `#111` on `#B1D3FE` | 12.25 |
| assertion failure text | `#D70015` on `#FFF` | 5.38 |
| failed row text | `#D70015` on `#FFF` | 5.38 |
| failed row on group header | `#D70015` on `#F6F6F6` | 4.98 |
| selection fill vs surface (UI, 3:1) | `#1163CC` on `#FFF` | 5.71 |
| selection fill vs sidebar (UI, 3:1) | `#1163CC` on `#F2F2F2` | 5.10 |
| selection fill vs group header (UI, 3:1) | `#1163CC` on `#F6F6F6` | 5.28 |

### After — dark, 19 of 19 passing

| Pair | fg on bg | Ratio |
|---|---|---|
| row text `.list-item` | `#E8E8EA` on `#161619` | 14.76 |
| group header `.test-summary-group>p` | `#E8E8EA` on `#202024` | 13.27 |
| device card `#info-sections li` | `#C9C9CE` on `#232327` | 9.49 |
| filter pill (rest) | `#9A9AA2` on `#161619` | 6.46 |
| table-header li | `#9A9AA2` on `#161619` | 6.46 |
| `#device-header` | `#9A9AA2` on `#232327` | 5.61 |
| `#report-issue a` | `#9A9AA2` on `#232327` | 5.61 |
| `#right-sidebar h2` placeholder | `#8A8A92` on `#232327` | 4.57 |
| selected row text | `#FFF` on `#2170D6` | 4.82 |
| selected filter pill text | `#FFF` on `#2170D6` | 4.82 |
| selected device card text | `#FFF` on `#2170D6` | 4.82 |
| Tests/Logs active tab text | `#7FB0FF` on `#161619` | 8.22 |
| hover pill text | `#E8E8EA` on `#274A73` | 7.42 |
| assertion failure text | `#FF6E6A` on `#161619` | 6.61 |
| failed row text | `#FF6E6A` on `#161619` | 6.61 |
| failed row on group header | `#FF6E6A` on `#202024` | 5.95 |
| selection fill vs surface (UI, 3:1) | `#2170D6` on `#161619` | 3.74 |
| selection fill vs sidebar (UI, 3:1) | `#2170D6` on `#232327` | 3.25 |
| selection fill vs group header (UI, 3:1) | `#2170D6` on `#202024` | 3.37 |

The selection fill is gated against **all three** backgrounds it can land on, not just the
surface: `.device-info.selected` sits on the sidebar (and is selected by default on every
load), `.list-item.selected` on the surface or on a group header. An earlier revision of this
PR listed only the surface pairing and used `#1E65C2`, which cleared the surface at 3.18 but
was **2.76** against the sidebar and 2.86 against the group header — caught in review, fixed
here. Both themes are now verified against the lightest of the three, which is the binding one.

The pane washes are a different thing and stay ungated: the sidebar and group-header
**backgrounds** are 1.12:1 and 1.08:1 against the surface, listed by the checker as
informational. They carry no state and no text of their own, and the panes are additionally
separated by a 1px border. WCAG 1.4.11 covers information required to *identify* components
and states; a decorative wash is neither.

## Deviations from the mockup (all deliberate)

1. **`--color-accent-text` is a new token.** The mockup uses one `--sel` for both the selection
   *fill* (white text on it) and the active-tab *text*. Dark cannot satisfy both roles with one
   value — a fill dark enough for white text is too dark to read as text. The mockup's own dark
   `--sel: #1e5fbf` used as tab text on its dark surface is **2.96:1** against a 4.5 floor.
   Split into fill + text; dark text is `#7FB0FF` (8.22:1).
2. **Dark selection fill `#2170D6`, not the mockup's `#1E5FBF`.** The mockup's value is
   **2.96:1** against its own dark surface — under the 3:1 UI floor. The replacement has to
   satisfy four constraints at once, because the fill lands on all three dark backgrounds and
   carries white text on every one of them: ≥3:1 against the sidebar (`#232327` — the lightest
   and therefore the binding one), the surface (`#161619`) and the group header (`#202024`),
   while white-on-fill stays ≥4.5:1. Raising lightness helps the first three and hurts the
   fourth, so the usable values form a narrow window: at this hue **no value clears both floors
   by more than ~7%**. `#2170D6` sits at that window's centre — same hue (214°) and saturation
   (73%) as before, lightness 43.9% → 48.4% — giving sidebar 3.25, surface 3.74, group header
   3.37, white-on-fill 4.82. Splitting a separate `--color-accent-fill` token would buy
   nothing: the selected device card needs the 3:1 and the 4.5:1 floors satisfied
   *simultaneously* on the same element, so no split can relax either one.
3. **Hover pill text is `--color-text-primary`, not `--color-on-accent`.** White on the pale
   `#B1D3FE` wash was **1.55:1** — the worst pair in the shipped sheet. The mockup leaves hover
   text at `--muted`, which passes in light (4.83:1) but is **3.25:1** against its dark
   `#274A73` hover; primary passes both (12.25 / 7.42).
4. **`--color-text-placeholder` kept as its own token** (`#6E6E73`) rather than collapsed into
   `--muted` as the mockup does. A placeholder reading lighter than body-muted is the right
   signal, and `#6E6E73` clears 4.5:1 anyway.
5. **`--color-border-faint` `#EEE` → `#E5E5E5`** to match the mockup's row separators. The other
   three border tokens keep their scale (the mockup collapses to two levels; ours are already
   at least as strong).

## The 375px question

Adding the viewport meta (item 1, in scope here) is what *stops phones rendering this page
zoomed out at desktop width* — which had been hiding the audit's finding 8. Rendered at true
375px, the filter pills wrap and the fixed-height `.toolbar` spilled over the table header,
overlapping it.

So this PR makes one containment change beyond pure theme: `.toolbar`/`.table-header` use
`min-height` instead of `height`. The row grows instead of overlapping when it wraps, and is
unchanged when it doesn't — measured at 1440, not assumed:

| Box | Before | After |
|---|---|---|
| `.tests-header` toolbar | h=33.00 top=70.00 | h=33.00 top=70.00 |
| `ul.table-header` | h=23.00 top=103.00 | h=23.00 top=103.00 |
| `#left-sidebar` / `#right-sidebar` | h=830.00 top=70.00 | h=830.00 top=70.00 |
| first `.summary` row | h=92.00 top=126.00 | h=**96.00** top=126.00 |

The single delta is the row block growing 4px — that is the **font** change (system-ui metrics
differ from Helvetica's), which is the intended effect, not the min-height swap.

`header` gets the same treatment (`height: 70px` → `min-height`) after review. Its own two rows
never wrap — the pills that do live in `.tests-header`, not in `header` — but 70px was ~4px of
slack over the title band plus the tabs row, so text scaling clipped it, and leaving it clamped
was inconsistent with the sibling toolbars. Re-measured: geometry unchanged.

**This is not the collapse work** — the sidebar still takes 200px of 375 and the right pane is
still off-canvas at that width. Those are PR 2. This is only "don't make it worse", per the
brief.

## Verification

- **Full suite green on both legs**: `XCHR_RESULT_READER=auto` and `=modern`.
- **DifferentialTests green.** Parity holds *by construction*: the markup is shared, and the
  one new dynamic value (the title) derives from the bundle **file name** — an input path, not
  anything read out of a bundle — so both readers produce the same bytes. No allow-list entry
  needed.
- **No test edits.** Nothing pinned `<title>XCHTMLReport</title>` or any token value;
  CoreTests' selectors and ReproducibilityTests pass unmodified.
- **`swiftformat --lint .`**: 0/71 files require formatting (HTMLTemplates.swift is excluded by
  `.swiftformat`, as declared).
- **12 screenshots**: 3 fixtures × {1440, 375} × {light, dark}, captured over CDP with
  `Emulation.setEmulatedMedia` so `prefers-color-scheme` is genuinely emulated. Each shot
  asserts the emulation took before capturing, so no shot can be mislabelled. Before-state
  shots captured for the same matrix.
- **The selection fill is verified three ways, not just arithmetically.** The ratios above are
  recomputed by parsing the token values straight out of `HTMLTemplates.swift`, so the table
  cannot drift from what the sheet paints; the contrast implementation is itself checked
  against 8 published reference pairs first. Then, in a real dark render at 1440 and 375, the
  *computed* cascade reports the selected card as `rgb(33,112,214)` directly on
  `rgb(35,35,39)` from `#left-sidebar` with `rgb(255,255,255)` text — confirming the sidebar,
  not the surface, is the backdrop. Finally the painted pixels sampled back out of those PNGs
  are `#2170D6` on `#232327` = **3.25:1**, matching the computed figure exactly.
- **The dark block is still tokens-only**: parsed after comment-stripping — one selector
  (`:root`), 18 custom-property declarations, **zero** structural declarations.

Title, verified across fixtures: `TestResults — XCTestHTMLReport`,
`SanityResults — XCTestHTMLReport`, `RetryResults — XCTestHTMLReport`. Passing one bundle twice
plus a second (the ReproducibilityTests collision case) collapses to
`TestResults, RetryResults — XCTestHTMLReport`.

## Known gaps, left for PR 2

- Mixed and unknown outcomes still render a **blank** status cell (`testInUnknownState()`,
  `testRetryOnFailure()` in RetryResults) — icons are PR 2.
- ~300KB of base64 PNG icons remain. They read acceptably in dark (status diamonds are
  colored; disclosure triangles and the paperclip/eye SVGs are mid-grays — `#8f8f8f` and
  `#828282`, both ≥4.5:1 on the dark surface), so no dark-mode-only hack was added to the
  token block.
- No run summary, no text filter, three-pane layout on a single-device run — unfixed **by
  design**, per the Option C decision.

refs #439



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Report titles now reflect the associated bundle names, with a fallback title when needed.
  * HTML report pages include improved metadata and support for dark mode.
  * Updated layouts better accommodate wrapped content in headers, toolbars, and tables.

* **Style**
  * Refined colors, typography, spacing, hover states, and selected states for a clearer, more consistent presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->