### PR TITLE
Upload the rendered report as a PR artifact, per reader backend

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,3 +88,34 @@ jobs:
         name: xcresult-fixtures-${{ matrix.result_reader }}
         path: Tests/XCTestHTMLReportTests/Resources
         retention-days: 7
+
+    # A rendered report is what this tool actually ships, and until now nothing
+    # in CI let a reviewer look at one — the suite only ever compares report
+    # HTML as text (DifferentialTests, ReproducibilityTests). Rendering here
+    # costs an incremental build plus a few seconds, because this job already
+    # holds the fixtures.
+    #
+    # Both matrix legs render, and the job-level XCHR_RESULT_READER decides
+    # which reader each one exercises, so a PR touching the templates or either
+    # reader can be eyeballed per backend — the whole question during the 4.0
+    # migration (#391). Names are suffixed per leg for the same reason the
+    # fixture upload above is.
+    - name: Render sample report
+      run: |
+        swift build --product xchtmlreport
+        mkdir -p "$RUNNER_TEMP/report"
+        .build/debug/xchtmlreport -i \
+          -o "$RUNNER_TEMP/report" \
+          Tests/XCTestHTMLReportTests/Resources/TestResults.xcresult
+
+    # `-i` inlines every attachment as base64, making index.html self-contained
+    # (~9 MB) so it opens straight from the download. The default linking mode
+    # would emit a 460 KB file whose src attributes point back into the
+    # .xcresult bundle, which is not uploaded alongside it — every screenshot,
+    # video and log in the downloaded report would 404.
+    - name: Upload rendered report
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: report-${{ matrix.result_reader }}
+        path: ${{ runner.temp }}/report/index.html
+        retention-days: 14

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,17 +78,6 @@ jobs:
     - name: Run tests
       run: swift test -v
 
-    - name: Upload fixtures on failure
-      if: failure()
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-      with:
-        # Suffixed per matrix leg: upload-artifact v4+ refuses duplicate
-        # artifact names, so a run where both legs fail would otherwise lose
-        # the second leg's upload.
-        name: xcresult-fixtures-${{ matrix.result_reader }}
-        path: Tests/XCTestHTMLReportTests/Resources
-        retention-days: 7
-
     # A rendered report is what this tool actually ships, and until now nothing
     # in CI let a reviewer look at one — the suite only ever compares report
     # HTML as text (DifferentialTests, ReproducibilityTests). Rendering here
@@ -99,7 +88,7 @@ jobs:
     # which reader each one exercises, so a PR touching the templates or either
     # reader can be eyeballed per backend — the whole question during the 4.0
     # migration (#391). Names are suffixed per leg for the same reason the
-    # fixture upload above is.
+    # fixture upload below is.
     - name: Render sample report
       run: |
         swift build --product xchtmlreport
@@ -119,3 +108,19 @@ jobs:
         name: report-${{ matrix.result_reader }}
         path: ${{ runner.temp }}/report/index.html
         retention-days: 14
+
+    # Deliberately last. `if: failure()` is evaluated when the step is reached
+    # and a skipped step never runs again, so this only covers the steps above
+    # it: parked any earlier, a render that failed after the tests went green
+    # would upload nothing at all, leaving the failure undiagnosable without
+    # regenerating the bundles by hand. Keep it at the end of the job.
+    - name: Upload fixtures on failure
+      if: failure()
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        # Suffixed per matrix leg: upload-artifact v4+ refuses duplicate
+        # artifact names, so a run where both legs fail would otherwise lose
+        # the second leg's upload.
+        name: xcresult-fixtures-${{ matrix.result_reader }}
+        path: Tests/XCTestHTMLReportTests/Resources
+        retention-days: 7


### PR DESCRIPTION
## Why

Nothing in CI ever rendered the artifact this tool exists to produce. The suite compares report HTML as *text* only — `DifferentialTests` across backends, `ReproducibilityTests` across runs — so a change to `HTMLTemplates.swift` or to either reader can be green and still look wrong, with no way for a reviewer to see it short of building locally and generating fixtures by hand.

## What

Two steps appended to the `test` job. It already holds the fixtures, so this costs an incremental build plus a few seconds of render — no extra simulator work.

Both matrix legs render under the job-level `XCHR_RESULT_READER`, so each run publishes:

- `report-auto` — what users get today
- `report-modern` — the path that becomes the only path once Apple removes the legacy commands

Downloading both and diffing them by eye is the question worth asking on every PR until #391 lands.

## Why `-i`

| mode | output | portable? |
|---|---|---|
| `--rendering-mode linking` (default) | 460 KB `index.html` | ❌ `src="TestResults.xcresult/…mp4"` points back into the bundle, which isn't uploaded alongside |
| `-i` (inline) | 8.6 MB single `index.html` | ✅ self-contained, opens straight from the download |

Measured locally against `TestResults.xcresult`. Inline is the only mode that survives being downloaded on its own.

## Notes

- Renders only when tests pass; a failing run still gets the existing `xcresult-fixtures-*` upload.
- Fork-PR safe — `upload-artifact` needs no write token.
- `zizmor --min-severity low` and `actionlint` both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated generation of self-contained test reports, including embedded attachments.
  * Test reports are now preserved as downloadable build artifacts for 14 days, making it easier to review results after automated runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->