### PR TITLE
Publish a live demo report to GitHub Pages on every merge

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,108 @@
+name: Demo Site
+
+# The README's only pictures of this tool's output are two imgur uploads that
+# predate 4.0 and that nobody here controls. A report rendered from the current
+# tree on every merge replaces both with something that cannot go stale and
+# cannot be taken down by a third party.
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+# Read-only by default; the deploy job widens this for itself alone.
+permissions:
+  contents: read
+
+# Pages has exactly one live deployment, so overlapping runs would race to be
+# last writer. Queue instead of cancelling: a merge that lands mid-run should
+# still publish, just after the run ahead of it.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
+
+    - name: Setup Xcode version
+      uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
+      with:
+        xcode-version: latest-stable
+
+    # Same shared action, same key, same paths as test.yml — deliberately. A
+    # merge to main runs both workflows, and whichever reaches the cache first
+    # serves the other, so publishing the demo usually costs no simulator boot
+    # at all. Any divergence here would silently forfeit that (#436, #392).
+    - name: Compute fixture cache key
+      id: fixture-key
+      uses: ./.github/actions/fixture-cache-key
+
+    - name: Restore cached fixtures
+      id: fixture-cache
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      with:
+        path: |
+          Tests/XCTestHTMLReportTests/Resources/TestResults.xcresult
+          Tests/XCTestHTMLReportTests/Resources/SanityResults.xcresult
+          Tests/XCTestHTMLReportTests/Resources/RetryResults.xcresult
+        key: ${{ steps.fixture-key.outputs.key }}
+
+    - name: Generate test fixtures
+      if: steps.fixture-cache.outputs.cache-hit != 'true'
+      run: ./prepareTestResults.sh
+
+    # Only TestResults is rendered, so only TestResults has to be here. A cache
+    # hit that restored nothing would otherwise publish an empty report.
+    - name: Verify fixture
+      run: |
+        plist="Tests/XCTestHTMLReportTests/Resources/TestResults.xcresult/Info.plist"
+        if [ ! -f "$plist" ]; then
+          echo "::error::missing or incomplete fixture: TestResults.xcresult"
+          exit 1
+        fi
+
+    # Release, because the demo should be the binary users are handed rather
+    # than a debug build that merely renders the same bytes.
+    - name: Build
+      run: swift build -c release --product xchtmlreport
+
+    # `-i` inlines attachments as base64, yielding one self-contained ~9 MB
+    # index.html. The default linking mode would emit 460 KB whose src
+    # attributes point back into the .xcresult bundle; publishing that would
+    # mean 404ing every screenshot, video and log on the demo site.
+    #
+    # TestResults is the richest fixture on purpose — failures, retries,
+    # screenshots, screen recordings, and attachment filenames full of quotes
+    # and angle brackets. The demo showing red tests is the point: the failure
+    # UI is what people come here to look at.
+    - name: Render demo report
+      run: |
+        mkdir -p _site
+        .build/release/xchtmlreport -i \
+          -o _site \
+          Tests/XCTestHTMLReportTests/Resources/TestResults.xcresult
+
+    - name: Upload Pages artifact
+      uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+      with:
+        path: _site
+
+  # Split out so the macOS runner is released before the deploy waits on
+  # Pages, and because deploy-pages needs write scopes the build has no use for.
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ xcuserdata/
 Tests/XCTestHTMLReportTests/Resources/index.html
 Tests/XCTestHTMLReportTests/Resources/report.junit
 Tests/XCTestHTMLReportTests/Resources/report.json
+
+# Local demo render (see .github/workflows/pages.yml).
+/_site

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 
 Xcode-like HTML report for Unit and UI Tests
 
+**[▶ Open a live report](https://xctesthtmlreport.github.io/XCTestHTMLReport/)** — rendered from this repository's own sample test run, republished on every merge to `main`.
+
 ![screenshot](https://i.imgur.com/NHRzoXG.jpg)
 
 ## Features


### PR DESCRIPTION
## Why

Pages is **already enabled** on this repo — `build_type: workflow`, public, `https://xctesthtmlreport.github.io/XCTestHTMLReport/` — with **zero builds ever pushed to it**. Meanwhile the README's only pictures of this tool's output are two imgur uploads (`README.md:8`, `:14`) that predate 4.0 and that nobody here controls or can update.

Rendering the sample report from the current tree on every merge replaces both with one artifact that can't go stale and can't be taken down by a third party.

## What

New `pages.yml`: build on macOS → deploy on ubuntu.

- Reuses `./.github/actions/fixture-cache-key` with **the same key and the same paths** as `test.yml`, so a merge normally finds the cache warm and publishes without booting a simulator.
- Deploy is split out so the macOS runner is released early, and so `pages: write` / `id-token: write` live only on the job that needs them. Top level stays `contents: read`.
- `concurrency: pages` with `cancel-in-progress: false` — Pages has one live deployment, and a merge landing mid-run should still publish rather than be dropped.

README gets one line linking the live report. The stale imgur images are left alone deliberately — replacing them needs a committed screenshot, which is the headless-renderer work, not this.

## Verification

Ran the exact workflow command locally against the release binary:

```
mkdir -p _site && .build/release/xchtmlreport -i -o _site …/TestResults.xcresult
```

→ one self-contained **8.6 MB** `_site/index.html`. Served it over HTTP and opened it in a browser: renders correctly (16 tests, 9 passed / 1 skipped / 6 failed, device sidebar populated), and an inlined attachment previews fine from the standalone file. Payloads emitted as `data:` URIs:

| type | count |
|---|---|
| `image/png` | 11 |
| `video/mp4` | 4 |
| `text/plain` | 9 |
| `text/html` | 2 |

**Zero** external or relative refs. Linking mode would have emitted 460 KB whose `src` attributes point back into the `.xcresult`, 404ing every screenshot and video on the published site.

`zizmor --min-severity low` and `actionlint` both clean.

## Note

**The demo will show failing tests.** `TestResults.xcresult` deliberately contains failures, retries, and attachment filenames full of quotes and angle brackets. That's the point — the failure UI is what people come to this tool to look at — but it's public and permanent, so flagging it explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)