### PR TITLE
Publish a permanent demo render for every stable release under /v/

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,6 +26,13 @@ jobs:
         shellcheck --version
         find . -name '*.sh' -not -path './.build/*' -print0 | xargs -0 -r shellcheck
 
+    # assemble_site.py decides whether the Pages deployment goes out, and its
+    # failure mode is a green run that deletes published releases. It rides in
+    # this job because the tests are stdlib-only: no runner, toolchain or
+    # dependency beyond the python3 already on the image.
+    - name: Site assembler tests
+      run: python3 -m unittest discover -s scripts -p 'test_*.py' -v
+
   actions:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pages-release.yml
+++ b/.github/workflows/pages-release.yml
@@ -3,6 +3,11 @@ name: Demo Site (release)
 # Publishes a permanent render for each stable release under /v/<tag>/, so the
 # site can answer "what did the report look like in 3.0" and not only "what
 # does it look like right now".
+#
+# Version skew is inherent here: on a tag push GitHub runs the workflow files as
+# they existed *at the tag*, while `render-ref: main` means the sources and
+# scripts/assemble_site.py come from main. A future change to the assembler's
+# CLI can therefore break releases cut before that change.
 on:
   push:
     tags:
@@ -94,7 +99,7 @@ jobs:
         cd store
         git config user.name "github-actions[bot]"
         git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-        git add "v/$TAG/index.html" versions.json
+        git add "v/$TAG" versions.json
         git commit -m "Publish demo report for $TAG"
         git push
 

--- a/.github/workflows/pages-release.yml
+++ b/.github/workflows/pages-release.yml
@@ -1,0 +1,108 @@
+name: Demo Site (release)
+
+# Publishes a permanent render for each stable release under /v/<tag>/, so the
+# site can answer "what did the report look like in 3.0" and not only "what
+# does it look like right now".
+on:
+  push:
+    tags:
+    # Stable only. release.yml needs a second, separate pattern for
+    # `[0-9]+.[0-9]+.[0-9]+rc[0-9]+`, which is what tells us this one does not
+    # match release candidates.
+    - '[0-9]+.[0-9]+.[0-9]+'
+
+permissions:
+  contents: read
+
+# Deliberately NOT the `pages` group. This workflow calls pages.yml, and a
+# called reusable workflow evaluates its own `concurrency` — so if this one
+# already held `pages`, the call would wait for a group its own caller is
+# holding and the run would deadlock. This group protects the store push from
+# concurrent releases; pages.yml keeps serialising the deployment itself.
+concurrency:
+  group: pages-store
+  cancel-in-progress: false
+
+jobs:
+  publish-version:
+    runs-on: macos-latest
+    # The only job in either workflow that writes. It pushes one immutable
+    # directory into the pages-site store; everything else reads.
+    permissions:
+      contents: write
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
+
+    - name: Setup Xcode version
+      uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
+      with:
+        xcode-version: latest-stable
+
+    # No cache restore: this tag's sample app differs from main's, so the
+    # shared fixture key would miss anyway. A few minutes, a few times a year.
+    - name: Generate test fixtures
+      run: ./prepareTestResults.sh
+
+    - name: Verify fixture
+      run: |
+        plist="Tests/XCTestHTMLReportTests/Resources/TestResults.xcresult/Info.plist"
+        if [ ! -f "$plist" ]; then
+          echo "::error::missing or incomplete fixture: TestResults.xcresult"
+          exit 1
+        fi
+
+    - name: Build
+      run: swift build -c release --product xchtmlreport
+
+    - name: Render this release
+      run: |
+        mkdir -p render
+        .build/release/xchtmlreport -i \
+          -o render \
+          Tests/XCTestHTMLReportTests/Resources/TestResults.xcresult
+
+    # Checked out with credentials, because this one pushes.
+    - name: Check out the version store
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1 # zizmor: ignore[artipacked]
+      with:
+        ref: pages-site
+        path: store
+
+    # versions.json is written only after the render succeeded, so a failed
+    # build can never leave the store declaring a version whose directory does
+    # not exist. Re-running a tag overwrites its directory rather than
+    # appending, so a re-run cannot corrupt the store.
+    - name: Write the version into the store
+      env:
+        TAG: ${{ github.ref_name }}
+      run: |
+        mkdir -p "store/v/$TAG"
+        cp render/index.html "store/v/$TAG/index.html"
+        python3 - "$TAG" <<'PY'
+        import json, sys
+        tag = sys.argv[1]
+        with open("store/versions.json", encoding="utf-8") as handle:
+            versions = json.load(handle)
+        if tag not in versions:
+            versions.insert(0, tag)
+        with open("store/versions.json", "w", encoding="utf-8") as handle:
+            json.dump(versions, handle, indent=2)
+            handle.write("\n")
+        PY
+        cd store
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git add "v/$TAG/index.html" versions.json
+        git commit -m "Publish demo report for $TAG"
+        git push
+
+  # Reuses pages.yml wholesale rather than duplicating assembly and deploy.
+  deploy:
+    needs: publish-version
+    uses: ./.github/workflows/pages.yml
+    permissions:
+      contents: read
+      pages: write
+      id-token: write

--- a/.github/workflows/pages-release.yml
+++ b/.github/workflows/pages-release.yml
@@ -83,8 +83,16 @@ jobs:
       env:
         TAG: ${{ github.ref_name }}
       run: |
+        # Copy the whole render, not just index.html: `-i` yields one
+        # self-contained file today, but a render that ever emitted a sibling
+        # asset would otherwise be published half-complete, and the truncation
+        # guard only checks index.html so it would not notice. Clearing the
+        # directory first is what makes "a re-run overwrites" literally true —
+        # a plain copy would leave behind files an earlier render produced and
+        # this one no longer does.
+        rm -rf "store/v/$TAG"
         mkdir -p "store/v/$TAG"
-        cp render/index.html "store/v/$TAG/index.html"
+        cp -R render/. "store/v/$TAG/"
         python3 - "$TAG" <<'PY'
         import json, sys
         tag = sys.argv[1]
@@ -100,7 +108,16 @@ jobs:
         git config user.name "github-actions[bot]"
         git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
         git add "v/$TAG" versions.json
-        git commit -m "Publish demo report for $TAG"
+        # A re-run of an already-published tag can stage nothing. The render is
+        # rebuilt from freshly generated fixtures, so it almost never matches
+        # the stored one byte for byte — but if it ever did, a bare `git commit`
+        # would exit nonzero and take `deploy` down with it. Nothing staged
+        # means the store is already correct, which is success, not failure.
+        if git diff --cached --quiet; then
+          echo "store already up to date for $TAG"
+        else
+          git commit -m "Publish demo report for $TAG"
+        fi
         git push
 
   # Reuses pages.yml wholesale rather than duplicating assembly and deploy.

--- a/.github/workflows/pages-release.yml
+++ b/.github/workflows/pages-release.yml
@@ -106,3 +106,5 @@ jobs:
       contents: read
       pages: write
       id-token: write
+    with:
+      render-ref: main

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -28,6 +28,12 @@ permissions:
 # Pages has exactly one live deployment, so overlapping runs would race to be
 # last writer. Queue instead of cancelling: a merge that lands mid-run should
 # still publish, just after the run ahead of it.
+#
+# GitHub keeps at most one *pending* run per group even with
+# cancel-in-progress: false, so a release deploy waiting behind a merge run can
+# be cancelled by the next merge and report cancelled. Nothing is lost — the
+# store already holds the version and the next merge republishes it — and
+# `gh workflow run "Demo Site" --ref main` fixes it immediately.
 concurrency:
   group: pages
   cancel-in-progress: false

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -11,6 +11,16 @@ on:
   # pages-release.yml calls this after writing a version into the store, so
   # assembly and deployment exist in exactly one place.
   workflow_call:
+    inputs:
+      render-ref:
+        description: >-
+          Ref whose source is rendered into the site root. Callers must pass
+          `main`. A called workflow inherits the CALLER's event context, so a
+          release run would otherwise rebuild `/` from the tag and roll the
+          demo back until the next merge.
+        type: string
+        required: false
+        default: ''
 
 # Read-only by default; the deploy job widens this for itself alone.
 permissions:
@@ -29,6 +39,9 @@ jobs:
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
+        # Empty on push and workflow_dispatch, where github.sha is the
+        # triggering commit and already correct.
+        ref: ${{ inputs.render-ref || github.sha }}
         persist-credentials: false
 
     # The version store, checked out read-only. Its renders are immutable and

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -19,8 +19,7 @@ on:
           release run would otherwise rebuild `/` from the tag and roll the
           demo back until the next merge.
         type: string
-        required: false
-        default: ''
+        required: true
 
 # Read-only by default; the deploy job widens this for itself alone.
 permissions:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -8,6 +8,9 @@ on:
   push:
     branches: [ main ]
   workflow_dispatch:
+  # pages-release.yml calls this after writing a version into the store, so
+  # assembly and deployment exist in exactly one place.
+  workflow_call:
 
 # Read-only by default; the deploy job widens this for itself alone.
 permissions:
@@ -26,6 +29,16 @@ jobs:
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
+        persist-credentials: false
+
+    # The version store, checked out read-only. Its renders are immutable and
+    # main's is not stored here at all — that asymmetry is what keeps this
+    # workflow, which runs on every merge, free of write access.
+    - name: Check out the version store
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        ref: pages-site
+        path: _site
         persist-credentials: false
 
     - name: Setup Xcode version
@@ -81,10 +94,16 @@ jobs:
     # UI is what people come here to look at.
     - name: Render demo report
       run: |
-        mkdir -p _site
         .build/release/xchtmlreport -i \
           -o _site \
           Tests/XCTestHTMLReportTests/Resources/TestResults.xcresult
+
+    # Removes the store's .git, generates the version listing, and refuses to
+    # continue if the assembled tree does not match versions.json. deploy-pages
+    # replaces the entire site, so publishing a truncated tree would delete
+    # released versions in a run that still reported success.
+    - name: Assemble and verify the site
+      run: python3 scripts/assemble_site.py _site
 
     - name: Upload Pages artifact
       uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ visual/node_modules
 visual/test-results
 visual/playwright-report
 visual/fixtures
+
+# Byte-compiled by Python whenever a module under scripts/ is imported.
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 Xcode-like HTML report for Unit and UI Tests
 
-**[▶ Open a live report](https://xctesthtmlreport.github.io/XCTestHTMLReport/)** — rendered from this repository's own sample test run, republished on every merge to `main`.
+**[▶ Open a live report](https://xctesthtmlreport.github.io/XCTestHTMLReport/)** — rendered from this repository's own sample test run, republished on every merge to `main`. Past releases are at **[/v/](https://xctesthtmlreport.github.io/XCTestHTMLReport/v/)**.
 
 ![screenshot](https://i.imgur.com/NHRzoXG.jpg)
 

--- a/docs/superpowers/plans/2026-08-13-versioned-pages-publishing.md
+++ b/docs/superpowers/plans/2026-08-13-versioned-pages-publishing.md
@@ -1,0 +1,649 @@
+# Versioned Pages Publishing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Publish a rendered demo report for every stable release under
+`/v/<tag>/`, alongside `main`'s render at the root, without the frequent path
+ever needing write access.
+
+**Architecture:** A `pages-site` branch stores only immutable release renders.
+`pages.yml` checks it out read-only on every merge to `main`, renders `main` into
+the root, and deploys the whole tree. `pages-release.yml` is the only thing that
+writes: on a stable tag it renders that tag into the store, then calls
+`pages.yml` via `workflow_call` to assemble and deploy.
+
+**Tech Stack:** GitHub Actions, `actions/upload-pages-artifact` +
+`actions/deploy-pages`, Python 3 (assembly and guards), Swift 5.5 / SwiftPM for
+the render.
+
+**Spec:** `docs/superpowers/specs/2026-08-13-versioned-pages-publishing-design.md`
+
+## Global Constraints
+
+- **The prerequisite is already satisfied.** The `github-pages` environment now
+  carries `branch: main` and `tag: *.*.*` deployment policies. Deployment
+  policy patterns support `*` but **not** `+` or character classes, so `*.*.*`
+  is the tightest expressible form and would also admit `3.0.0rc1`. The real
+  stable-only gate is `pages-release.yml`'s trigger glob, which does support
+  `+`. Do not treat the loose policy as the filter.
+- `zizmor --min-severity low` audits `.github/workflows/`. Pin every action by
+  full commit SHA with a trailing `# vX.Y.Z` comment, set
+  `persist-credentials: false` on every checkout that does not push, and scope
+  `permissions` per job.
+- `actionlint` must be clean on every workflow file.
+- The `shell` CI job runs `shellcheck` over every `*.sh` in the repo and is a
+  **required** check. This plan adds no shell scripts, deliberately: macOS
+  runners ship bash 3.2 (no `mapfile`, no associative arrays), and the guards
+  are easier to get right in Python. Follow `scripts/select_simulator.py`'s
+  precedent.
+- Required status checks on `main` are `shell`, `swift`, `test (auto)`,
+  `test (modern)`, `dump`, `visual`. All must be green.
+- Do not change what `/` serves. It stays `main`'s render.
+- `pages.yml` renders the **real** `TestResults.xcresult` fixture (not the
+  synthetic one), so it needs the fixture cache and `prepareTestResults.sh`.
+  That is unchanged by this work — do not remove those steps.
+- The size ceiling is **800 MB** for the assembled site, against a 1 GB Pages
+  limit.
+- Never bypass the pre-commit hook (`core.hooksPath` → `.githooks/`). If git
+  signing fails with a keychain error, retry; never fall back to unsigned.
+
+## File Structure
+
+**Created:**
+
+| path | responsibility |
+|---|---|
+| `scripts/assemble_site.py` | assemble `_site`, generate the version listing, run all four guards |
+| `.github/workflows/pages-release.yml` | render a stable tag into the store, then call `pages.yml` |
+
+**Modified:**
+
+| path | change |
+|---|---|
+| `.github/workflows/pages.yml` | add `workflow_call`; check out the store; call the assembler |
+| `README.md` | link the version listing |
+
+**Created outside the working tree:** the `pages-site` branch (Task 2).
+
+---
+
+### Task 1: The assembler and its guards
+
+This script is where every failure mode this design worries about is caught.
+`deploy-pages` replaces the entire site, so a run that assembles an incomplete
+tree deletes published versions *and reports success*. Everything below exists
+to make that loud.
+
+**Files:**
+- Create: `scripts/assemble_site.py`
+
+**Interfaces:**
+- Produces: `python3 scripts/assemble_site.py <site-dir>` — exits 0 on a valid
+  assembled site, non-zero with a `::error::` line otherwise. Writes
+  `<site-dir>/v/index.html`. Removes `<site-dir>/.git`.
+
+- [ ] **Step 1: Write the script**
+
+```python
+#!/usr/bin/env python3
+"""Assemble the published Pages site and refuse to publish a damaged one.
+
+The site is main's render at the root plus one immutable directory per released
+version. `actions/deploy-pages` replaces the whole site on every deployment, so
+a run that assembles an incomplete tree would silently delete published versions
+and still finish green. Every check here exists to turn that into a failure.
+
+Usage: assemble_site.py <site-dir>
+"""
+
+import html
+import json
+import os
+import shutil
+import sys
+
+# 1 GB is the documented Pages site limit. Failing at 800 MB turns the ceiling
+# into a CI failure with headroom instead of a rejected deployment.
+MAX_BYTES = 800 * 1024 * 1024
+
+
+def fail(message):
+    print(f"::error::{message}", file=sys.stderr)
+    sys.exit(1)
+
+
+def directory_size(path):
+    total = 0
+    for root, _, files in os.walk(path):
+        for name in files:
+            total += os.path.getsize(os.path.join(root, name))
+    return total
+
+
+def render_listing(versions):
+    """A minimal static index. Deliberately depends on nothing in the report
+    templates, so template changes never churn it."""
+    items = "\n".join(
+        f'      <li><a href="./{html.escape(v)}/">{html.escape(v)}</a></li>'
+        for v in versions
+    )
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>XCTestHTMLReport — published versions</title>
+  <style>
+    body {{ font-family: system-ui, -apple-system, sans-serif; margin: 3rem auto;
+           max-width: 40rem; padding: 0 1rem; line-height: 1.6; }}
+    li {{ margin: 0.25rem 0; }}
+  </style>
+</head>
+<body>
+  <h1>Published versions</h1>
+  <p>Each link is the demo report as rendered by that release.
+     <a href="../">The site root</a> is always the current <code>main</code>.</p>
+  <ul>
+{items}
+  </ul>
+</body>
+</html>
+"""
+
+
+def main():
+    if len(sys.argv) != 2:
+        fail("usage: assemble_site.py <site-dir>")
+    site = sys.argv[1]
+
+    # actions/checkout leaves a full repository behind, and
+    # upload-pages-artifact packages whatever it is handed — without this the
+    # store's git history is published as browsable files.
+    shutil.rmtree(os.path.join(site, ".git"), ignore_errors=True)
+
+    manifest = os.path.join(site, "versions.json")
+    if not os.path.isfile(manifest):
+        fail(f"missing {manifest} — the pages-site store was not checked out")
+
+    if not os.path.isfile(os.path.join(site, "index.html")):
+        fail(f"missing {site}/index.html — main's render did not land")
+
+    with open(manifest, encoding="utf-8") as handle:
+        try:
+            versions = json.load(handle)
+        except json.JSONDecodeError as error:
+            fail(f"{manifest} is not valid JSON: {error}")
+
+    if not isinstance(versions, list) or any(not isinstance(v, str) for v in versions):
+        fail(f"{manifest} must be a flat array of version strings")
+
+    # Truncation guard. Every declared version must exist on disk. A version
+    # that vanished between the store and the artifact would otherwise deploy
+    # as a green run that quietly dropped it.
+    missing = [v for v in versions if not os.path.isfile(
+        os.path.join(site, "v", v, "index.html"))]
+    if missing:
+        fail(
+            f"versions.json declares {len(missing)} version(s) with no render: "
+            f"{', '.join(missing)}"
+        )
+
+    # The reverse direction matters too: a directory nobody declared means the
+    # manifest and the tree disagree, and the listing would omit a live page.
+    version_dir = os.path.join(site, "v")
+    on_disk = sorted(
+        name for name in os.listdir(version_dir)
+        if os.path.isdir(os.path.join(version_dir, name))
+    ) if os.path.isdir(version_dir) else []
+    undeclared = [name for name in on_disk if name not in versions]
+    if undeclared:
+        fail(
+            f"{len(undeclared)} version director(ies) not in versions.json: "
+            f"{', '.join(undeclared)}"
+        )
+
+    os.makedirs(version_dir, exist_ok=True)
+    with open(os.path.join(version_dir, "index.html"), "w", encoding="utf-8") as handle:
+        handle.write(render_listing(versions))
+
+    size = directory_size(site)
+    if size > MAX_BYTES:
+        fail(
+            f"assembled site is {size / 1024 / 1024:.0f} MB, over the "
+            f"{MAX_BYTES / 1024 / 1024:.0f} MB ceiling"
+        )
+
+    print(f"assembled {site}: {len(versions)} version(s), {size / 1024 / 1024:.1f} MB")
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 2: Verify the happy path**
+
+```bash
+cd /tmp && rm -rf sitetest && mkdir -p sitetest/v/3.1.0
+echo '<!doctype html>main' > sitetest/index.html
+echo '<!doctype html>v310' > sitetest/v/3.1.0/index.html
+echo '["3.1.0"]' > sitetest/versions.json
+python3 "$OLDPWD/scripts/assemble_site.py" sitetest; echo "exit=$?"
+cat sitetest/v/index.html | head -20
+```
+
+Expected: exit 0, prints `assembled sitetest: 1 version(s), 0.0 MB`, and
+`v/index.html` contains a link to `./3.1.0/`.
+
+- [ ] **Step 3: Verify the truncation guard fires**
+
+```bash
+cd /tmp && rm -rf sitetest2 && mkdir -p sitetest2/v
+echo '<!doctype html>main' > sitetest2/index.html
+echo '["3.1.0","3.0.0"]' > sitetest2/versions.json
+python3 "$OLDPWD/scripts/assemble_site.py" sitetest2; echo "exit=$?"
+```
+
+Expected: exit 1, `::error::versions.json declares 2 version(s) with no render: 3.1.0, 3.0.0`.
+
+**This is the guard the whole design rests on.** If it exits 0, stop and report —
+the design's central safety property is absent.
+
+- [ ] **Step 4: Verify the undeclared-directory guard fires**
+
+```bash
+cd /tmp && rm -rf sitetest3 && mkdir -p sitetest3/v/9.9.9
+echo '<!doctype html>main' > sitetest3/index.html
+echo '<!doctype html>v999' > sitetest3/v/9.9.9/index.html
+echo '[]' > sitetest3/versions.json
+python3 "$OLDPWD/scripts/assemble_site.py" sitetest3; echo "exit=$?"
+```
+
+Expected: exit 1, `::error::1 version director(ies) not in versions.json: 9.9.9`.
+
+- [ ] **Step 5: Verify the missing-store and missing-render guards fire**
+
+```bash
+cd /tmp && rm -rf sitetest4 && mkdir -p sitetest4
+python3 "$OLDPWD/scripts/assemble_site.py" sitetest4; echo "exit=$? (expect 1: missing versions.json)"
+echo '[]' > sitetest4/versions.json
+python3 "$OLDPWD/scripts/assemble_site.py" sitetest4; echo "exit=$? (expect 1: missing index.html)"
+```
+
+Expected: exit 1 both times, with the two distinct messages.
+
+- [ ] **Step 6: Verify `.git` removal**
+
+```bash
+cd /tmp && rm -rf sitetest5 && mkdir -p sitetest5/v sitetest5/.git
+echo secret > sitetest5/.git/config
+echo '<!doctype html>main' > sitetest5/index.html
+echo '[]' > sitetest5/versions.json
+python3 "$OLDPWD/scripts/assemble_site.py" sitetest5
+ls -a sitetest5 | grep -c '^\.git$' || echo "0 — .git removed, correct"
+```
+
+Expected: `.git` is gone.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /Users/tyler/Documents/XCTestHTMLReport
+chmod +x scripts/assemble_site.py
+git add scripts/assemble_site.py
+git commit -m "Site assembler that refuses to publish a truncated version store"
+```
+
+---
+
+### Task 2: Bootstrap the `pages-site` store
+
+**Files:** none in the working tree — this task creates a branch.
+
+**Interfaces:**
+- Produces: branch `pages-site` containing `versions.json` (`[]`) and `v/.gitkeep`.
+
+- [ ] **Step 1: Create the orphan branch**
+
+Do this in a scratch clone so the working tree is never left on the store
+branch:
+
+```bash
+cd /tmp && rm -rf storeinit
+git clone --no-checkout "$(git -C /Users/tyler/Documents/XCTestHTMLReport remote get-url origin)" storeinit
+cd storeinit
+git checkout --orphan pages-site
+git rm -rf --cached . 2>/dev/null || true
+rm -rf ./* 2>/dev/null || true
+mkdir -p v
+echo '[]' > versions.json
+touch v/.gitkeep
+git add versions.json v/.gitkeep
+git commit -m "Bootstrap the versioned Pages store"
+git push -u origin pages-site
+```
+
+`v/.gitkeep` exists because git cannot track an empty directory, and
+`assemble_site.py` lists `v/` before the first release adds anything to it.
+
+- [ ] **Step 2: Verify the branch exists and holds only the store**
+
+```bash
+git -C /Users/tyler/Documents/XCTestHTMLReport fetch origin
+git -C /Users/tyler/Documents/XCTestHTMLReport ls-tree -r --name-only origin/pages-site
+```
+
+Expected: exactly `v/.gitkeep` and `versions.json`. If any source file appears,
+the orphan branch was created wrong — delete it and redo, rather than
+committing a fix on top.
+
+- [ ] **Step 3: Confirm the main working tree is untouched**
+
+```bash
+cd /Users/tyler/Documents/XCTestHTMLReport
+git status --porcelain
+git rev-parse --abbrev-ref HEAD
+```
+
+Expected: clean, and still on the feature branch — not `pages-site`.
+
+---
+
+### Task 3: Assemble from the store in `pages.yml`
+
+**Files:**
+- Modify: `.github/workflows/pages.yml`
+
+**Interfaces:**
+- Consumes: `scripts/assemble_site.py`, branch `pages-site`.
+- Produces: `pages.yml` callable via `workflow_call`.
+
+- [ ] **Step 1: Add the `workflow_call` trigger**
+
+Replace the `on:` block:
+
+```yaml
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+  # pages-release.yml calls this after writing a version into the store, so
+  # assembly and deployment exist in exactly one place.
+  workflow_call:
+```
+
+- [ ] **Step 2: Check out the store before rendering**
+
+Insert immediately after the existing `actions/checkout` step in the `build`
+job:
+
+```yaml
+    # The version store, checked out read-only. Its renders are immutable and
+    # main's is not stored here at all — that asymmetry is what keeps this
+    # workflow, which runs on every merge, free of write access.
+    - name: Check out the version store
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        ref: pages-site
+        path: _site
+        persist-credentials: false
+```
+
+- [ ] **Step 3: Assemble after rendering**
+
+The existing `Render demo report` step does `mkdir -p _site` — remove that line,
+because the checkout above already created `_site` and `mkdir -p` on an existing
+directory is now misleading rather than harmful. The step becomes:
+
+```yaml
+    - name: Render demo report
+      run: |
+        .build/release/xchtmlreport -i \
+          -o _site \
+          Tests/XCTestHTMLReportTests/Resources/TestResults.xcresult
+```
+
+Then insert a new step directly before `Upload Pages artifact`:
+
+```yaml
+    # Removes the store's .git, generates the version listing, and refuses to
+    # continue if the assembled tree does not match versions.json. deploy-pages
+    # replaces the entire site, so publishing a truncated tree would delete
+    # released versions in a run that still reported success.
+    - name: Assemble and verify the site
+      run: python3 scripts/assemble_site.py _site
+```
+
+- [ ] **Step 4: Lint**
+
+```bash
+zizmor --min-severity low .github/workflows/pages.yml
+actionlint .github/workflows/pages.yml
+```
+
+Expected: both clean.
+
+- [ ] **Step 5: Commit and push**
+
+```bash
+git add .github/workflows/pages.yml
+git commit -m "Assemble the demo site from the versioned store"
+git push
+```
+
+**`pages.yml` triggers only on push to `main` and `workflow_dispatch`, so no PR
+run will exercise it.** That is the awkward part of this task: the change cannot
+be proven until it reaches `main`. Do not claim it works before then.
+
+Once merged, trigger it explicitly rather than waiting for the next merge:
+
+```bash
+gh workflow run "Demo Site" --ref main
+sleep 20 && gh run list --workflow=pages.yml --limit 1
+gh run watch "$(gh run list --workflow=pages.yml --limit 1 --json databaseId --jq '.[0].databaseId')"
+```
+
+Expected: both jobs green, and the `Assemble and verify the site` step printing
+`assembled _site: 0 version(s), ~11 MB`. Zero versions is correct before the
+first release.
+
+- [ ] **Step 6: Confirm the deployed site still serves main and now serves the listing**
+
+```bash
+curl -s -o /dev/null -w "root: HTTP %{http_code} %{size_download} bytes\n" -L https://xctesthtmlreport.github.io/XCTestHTMLReport/
+curl -s -o /dev/null -w "listing: HTTP %{http_code}\n" -L https://xctesthtmlreport.github.io/XCTestHTMLReport/v/
+```
+
+Expected: root 200 with roughly 11 MB, listing 200. The listing will show no
+versions until the first release — that is correct, not a failure.
+
+---
+
+### Task 4: `pages-release.yml`
+
+**Files:**
+- Create: `.github/workflows/pages-release.yml`
+
+**Interfaces:**
+- Consumes: `scripts/assemble_site.py`, branch `pages-site`, `pages.yml`'s
+  `workflow_call`.
+
+- [ ] **Step 1: Write the workflow**
+
+```yaml
+name: Demo Site (release)
+
+# Publishes a permanent render for each stable release under /v/<tag>/, so the
+# site can answer "what did the report look like in 3.0" and not only "what
+# does it look like right now".
+on:
+  push:
+    tags:
+    # Stable only. release.yml needs a second, separate pattern for
+    # `[0-9]+.[0-9]+.[0-9]+rc[0-9]+`, which is what tells us this one does not
+    # match release candidates.
+    - '[0-9]+.[0-9]+.[0-9]+'
+
+permissions:
+  contents: read
+
+# Deliberately NOT the `pages` group. This workflow calls pages.yml, and a
+# called reusable workflow evaluates its own `concurrency` — so if this one
+# already held `pages`, the call would wait for a group its own caller is
+# holding and the run would deadlock. This group protects the store push from
+# concurrent releases; pages.yml keeps serialising the deployment itself.
+concurrency:
+  group: pages-store
+  cancel-in-progress: false
+
+jobs:
+  publish-version:
+    runs-on: macos-latest
+    # The only job in either workflow that writes. It pushes one immutable
+    # directory into the pages-site store; everything else reads.
+    permissions:
+      contents: write
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
+
+    - name: Setup Xcode version
+      uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
+      with:
+        xcode-version: latest-stable
+
+    # No cache restore: this tag's sample app differs from main's, so the
+    # shared fixture key would miss anyway. A few minutes, a few times a year.
+    - name: Generate test fixtures
+      run: ./prepareTestResults.sh
+
+    - name: Verify fixture
+      run: |
+        plist="Tests/XCTestHTMLReportTests/Resources/TestResults.xcresult/Info.plist"
+        if [ ! -f "$plist" ]; then
+          echo "::error::missing or incomplete fixture: TestResults.xcresult"
+          exit 1
+        fi
+
+    - name: Build
+      run: swift build -c release --product xchtmlreport
+
+    - name: Render this release
+      run: |
+        mkdir -p render
+        .build/release/xchtmlreport -i \
+          -o render \
+          Tests/XCTestHTMLReportTests/Resources/TestResults.xcresult
+
+    # Checked out with credentials, because this one pushes.
+    - name: Check out the version store
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        ref: pages-site
+        path: store
+
+    # versions.json is written only after the render succeeded, so a failed
+    # build can never leave the store declaring a version whose directory does
+    # not exist. Re-running a tag overwrites its directory rather than
+    # appending, so a re-run cannot corrupt the store.
+    - name: Write the version into the store
+      env:
+        TAG: ${{ github.ref_name }}
+      run: |
+        mkdir -p "store/v/$TAG"
+        cp render/index.html "store/v/$TAG/index.html"
+        python3 - "$TAG" <<'PY'
+        import json, sys
+        tag = sys.argv[1]
+        with open("store/versions.json", encoding="utf-8") as handle:
+            versions = json.load(handle)
+        if tag not in versions:
+            versions.insert(0, tag)
+        with open("store/versions.json", "w", encoding="utf-8") as handle:
+            json.dump(versions, handle, indent=2)
+            handle.write("\n")
+        PY
+        cd store
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git add "v/$TAG/index.html" versions.json
+        git commit -m "Publish demo report for $TAG"
+        git push
+
+  # Reuses pages.yml wholesale rather than duplicating assembly and deploy.
+  deploy:
+    needs: publish-version
+    uses: ./.github/workflows/pages.yml
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+```
+
+- [ ] **Step 2: Lint**
+
+```bash
+zizmor --min-severity low .github/workflows/pages-release.yml
+actionlint .github/workflows/pages-release.yml
+```
+
+Expected: both clean. zizmor will notice the store checkout keeps its
+credentials; that is deliberate because the step pushes. If zizmor flags it as
+an error rather than a note, add a scoped suppression with a comment saying the
+job pushes — do not remove the credentials, which would break the push.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/pages-release.yml
+git commit -m "Publish a permanent demo render for every stable release"
+```
+
+- [ ] **Step 4: Confirm the deployment policy admits tag refs**
+
+```bash
+gh api repos/:owner/:repo/environments/github-pages/deployment-branch-policies \
+  --jq '.branch_policies[] | "\(.type): \(.name)"'
+```
+
+Expected: `branch: main` and `tag: *.*.*`. Without the tag entry the deploy job
+is rejected by the environment protection rule. Do not attempt to add it
+yourself — report it as missing.
+
+---
+
+### Task 5: Point people at it
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Add the listing link**
+
+In `README.md`, the line currently reading:
+
+```markdown
+**[▶ Open a live report](https://xctesthtmlreport.github.io/XCTestHTMLReport/)** — rendered from this repository's own sample test run, republished on every merge to `main`.
+```
+
+becomes:
+
+```markdown
+**[▶ Open a live report](https://xctesthtmlreport.github.io/XCTestHTMLReport/)** — rendered from this repository's own sample test run, republished on every merge to `main`. Past releases are at **[/v/](https://xctesthtmlreport.github.io/XCTestHTMLReport/v/)**.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add README.md
+git commit -m "Link the published version listing from the README"
+```
+
+- [ ] **Step 3: Push and confirm the branch is green**
+
+```bash
+git push
+gh pr checks --watch
+```
+
+Expected: `shell`, `swift`, `test (auto)`, `test (modern)`, `dump`, `visual` all
+green.

--- a/docs/superpowers/plans/2026-08-13-versioned-pages-publishing.md
+++ b/docs/superpowers/plans/2026-08-13-versioned-pages-publishing.md
@@ -46,6 +46,14 @@ the render.
   limit.
 - Never bypass the pre-commit hook (`core.hooksPath` → `.githooks/`). If git
   signing fails with a keychain error, retry; never fall back to unsigned.
+- **Amended during execution:** `pages.yml`'s `workflow_call` trigger takes a
+  **required** `render-ref` input, and `pages-release.yml` passes
+  `render-ref: main`. A called workflow inherits the *caller's* event context,
+  so on a tag push a checkout with no explicit `ref` resolves to the tag — the
+  site root would be rebuilt from the release tag and roll `/` back until the
+  next merge. Task 3 Step 1 and Task 4 Step 1 below carry the amended YAML;
+  `pages.yml:13-22` explains it inline. `required: true` rather than a default
+  so that a caller forgetting it fails loudly instead of silently.
 
 ## File Structure
 
@@ -54,6 +62,7 @@ the render.
 | path | responsibility |
 |---|---|
 | `scripts/assemble_site.py` | assemble `_site`, generate the version listing, run all four guards |
+| `scripts/test_assemble_site.py` | stdlib `unittest` cover for those guards (added after execution) |
 | `.github/workflows/pages-release.yml` | render a stable tag into the store, then call `pages.yml` |
 
 **Modified:**
@@ -61,6 +70,7 @@ the render.
 | path | change |
 |---|---|
 | `.github/workflows/pages.yml` | add `workflow_call`; check out the store; call the assembler |
+| `.github/workflows/lint.yml` | run the assembler tests in the existing `shell` job (added after execution) |
 | `README.md` | link the version listing |
 
 **Created outside the working tree:** the `pages-site` branch (Task 2).
@@ -81,6 +91,14 @@ to make that loud.
 - Produces: `python3 scripts/assemble_site.py <site-dir>` — exits 0 on a valid
   assembled site, non-zero with a `::error::` line otherwise. Writes
   `<site-dir>/v/index.html`. Removes `<site-dir>/.git`.
+
+**Amended after execution:** the shipped script has since gained three more
+guards — entries must match `MAJOR.MINOR.PATCH`, may not repeat, and a failure
+writing the listing is reported as `::error::` rather than a traceback — and the
+listing sorts by version rather than by publication order. `scripts/assemble_site.py`
+is the authority; the source below is the state at the end of this task. Steps 2-6
+are now automated in `scripts/test_assemble_site.py`, which `lint.yml`'s `shell`
+job runs on every push and pull request.
 
 - [ ] **Step 1: Write the script**
 
@@ -286,8 +304,9 @@ Expected: `.git` is gone.
 
 - [ ] **Step 7: Commit**
 
+From the repository root:
+
 ```bash
-cd /Users/tyler/Documents/XCTestHTMLReport
 chmod +x scripts/assemble_site.py
 git add scripts/assemble_site.py
 git commit -m "Site assembler that refuses to publish a truncated version store"
@@ -308,8 +327,9 @@ Do this in a scratch clone so the working tree is never left on the store
 branch:
 
 ```bash
+origin_url="$(git remote get-url origin)"
 cd /tmp && rm -rf storeinit
-git clone --no-checkout "$(git -C /Users/tyler/Documents/XCTestHTMLReport remote get-url origin)" storeinit
+git clone --no-checkout "$origin_url" storeinit
 cd storeinit
 git checkout --orphan pages-site
 git rm -rf --cached . 2>/dev/null || true
@@ -327,9 +347,11 @@ git push -u origin pages-site
 
 - [ ] **Step 2: Verify the branch exists and holds only the store**
 
+Back in the repository root:
+
 ```bash
-git -C /Users/tyler/Documents/XCTestHTMLReport fetch origin
-git -C /Users/tyler/Documents/XCTestHTMLReport ls-tree -r --name-only origin/pages-site
+git fetch origin
+git ls-tree -r --name-only origin/pages-site
 ```
 
 Expected: exactly `v/.gitkeep` and `versions.json`. If any source file appears,
@@ -339,7 +361,6 @@ committing a fix on top.
 - [ ] **Step 3: Confirm the main working tree is untouched**
 
 ```bash
-cd /Users/tyler/Documents/XCTestHTMLReport
 git status --porcelain
 git rev-parse --abbrev-ref HEAD
 ```
@@ -369,7 +390,21 @@ on:
   # pages-release.yml calls this after writing a version into the store, so
   # assembly and deployment exist in exactly one place.
   workflow_call:
+    inputs:
+      render-ref:
+        description: >-
+          Ref whose source is rendered into the site root. Callers must pass
+          `main`. A called workflow inherits the CALLER's event context, so a
+          release run would otherwise rebuild `/` from the tag and roll the
+          demo back until the next merge.
+        type: string
+        required: true
 ```
+
+The `build` job's own checkout then takes `ref: ${{ inputs.render-ref ||
+github.sha }}`. On `push` and `workflow_dispatch` the `inputs` context is
+empty, so the fallback resolves to the triggering commit — what the checkout
+used implicitly before.
 
 - [ ] **Step 2: Check out the store before rendering**
 
@@ -566,7 +601,7 @@ jobs:
         cd store
         git config user.name "github-actions[bot]"
         git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-        git add "v/$TAG/index.html" versions.json
+        git add "v/$TAG" versions.json
         git commit -m "Publish demo report for $TAG"
         git push
 
@@ -578,7 +613,13 @@ jobs:
       contents: read
       pages: write
       id-token: write
+    with:
+      render-ref: main
 ```
+
+`render-ref: main` is not optional — see Global Constraints. Without it the
+called workflow inherits this workflow's tag event and rebuilds the site root
+from the tag.
 
 - [ ] **Step 2: Lint**
 

--- a/docs/superpowers/specs/2026-08-13-versioned-pages-publishing-design.md
+++ b/docs/superpowers/specs/2026-08-13-versioned-pages-publishing-design.md
@@ -1,0 +1,200 @@
+# Versioned demo reports on GitHub Pages
+
+## Problem
+
+`pages.yml` publishes one rendered report to
+`https://xctesthtmlreport.github.io/XCTestHTMLReport/` on every merge to `main`,
+replacing whatever was there. The site therefore only ever answers "what does
+the report look like right now."
+
+It cannot answer "what did the report look like in 3.0" — a question that has
+practical weight, because 4.0 deliberately breaks the report's visual contract
+(#439) and because the tool's users are running released versions, not `main`.
+
+## Decision
+
+Publish release renders alongside `main`'s under versioned paths:
+
+```
+/                    main, republished on every merge (unchanged behaviour)
+/v/3.1.0/            a stable release, written once, never rewritten
+/v/index.html        generated listing
+```
+
+Stable releases only. Forward-only — no backfill of 2.x or 3.0.0.
+
+## The constraint that shapes everything
+
+`actions/deploy-pages` **replaces the entire site** on each deployment. There is
+no incremental publish. Every deploy must therefore upload `main`'s render *and*
+every version, which means versions have to persist somewhere outside the run.
+
+Measured, not assumed:
+
+| quantity | value |
+|---|---|
+| current live site | **11,096,947 bytes** (rendered `-i`, attachments inlined) |
+| commits to `main` | **48 in 90 days** ≈ 190/year |
+| stable releases | ~2–4/year |
+| Pages site limit | 1 GB |
+
+Per-*commit* versioning was considered and rejected on this arithmetic:
+11.1 MB × 190/year ≈ **2.1 GB/year**, exceeding the Pages limit within about six
+months. The bulk is four `.mp4` screen recordings at ~1.5 MB each, which `-z`
+image downsizing does not touch. Per-*release* versioning costs ~44 MB/year.
+
+## Prerequisite: the `github-pages` environment must permit tag refs
+
+**This blocks the release path and requires a maintainer settings change.**
+
+The `github-pages` environment carries a deployment branch policy admitting
+exactly one ref: the branch `main`. A workflow triggered by a tag push runs with
+`ref = refs/tags/<tag>`, so `deploy-pages` from that run is rejected by the
+protection rule.
+
+The fix is to add a **tag** policy entry alongside the existing branch entry,
+matching the stable release pattern. Until that exists, `pages-release.yml`
+cannot deploy and the versioned paths will never appear.
+
+Working around it instead — having the release workflow signal a `main`-ref run
+to do the deploy — is not viable: workflow runs triggered by `GITHUB_TOKEN` do
+not themselves trigger further workflow runs, so the chain breaks silently.
+
+## Architecture
+
+### The version store
+
+A `pages-site` branch holds **only** immutable version renders:
+
+```
+v/3.1.0/index.html
+versions.json        ["3.2.0", "3.1.0"] — newest first
+```
+
+`versions.json` is a flat array of tag strings in descending release order. It
+is the declared inventory the truncation guard checks the assembled site
+against, and the input the listing page is generated from — so the two can never
+disagree about what is published.
+
+`main`'s render is deliberately **not** stored. It changes on every merge and is
+cheap to regenerate, so storing it would mean writing 11 MB to a branch 190
+times a year — either bloating git history permanently or forcing an orphan
+force-push whose object reuse degrades after garbage collection.
+
+Keeping the store immutable is what allows the frequent path to be read-only.
+
+### `pages.yml` (modified)
+
+Triggers: `push` to `main`, `workflow_dispatch`, and a new `workflow_call` so the
+release workflow can reuse it.
+
+- **`build`** (macOS, `contents: read`) — checkout `main`; checkout `pages-site`
+  into `_site/`; **delete `_site/.git`**; build the release binary; render `main`
+  into `_site/index.html`; generate `_site/v/index.html`; upload the Pages
+  artifact.
+
+  The `.git` deletion is not incidental. `actions/checkout` with `path: _site`
+  leaves a full repository there, and `upload-pages-artifact` packages whatever
+  it is given — so without the deletion every deploy publishes the store's git
+  history as browsable files.
+- **`deploy`** (ubuntu, `pages: write`, `id-token: write`) — unchanged.
+
+**No write permission anywhere in this path**, which is the design's main
+security property: the workflow that runs 190 times a year only reads.
+
+### `pages-release.yml` (new)
+
+Trigger: `push` to tags matching `[0-9]+.[0-9]+.[0-9]+`.
+
+Stable-only filtering falls out of the glob at no cost. `release.yml` already
+requires two separate patterns — `[0-9]+.[0-9]+.[0-9]+` and
+`[0-9]+.[0-9]+.[0-9]+rc[0-9]+` — which is direct evidence the first does not
+match `3.0.0rc1`.
+
+- **`publish-version`** (macOS, `contents: write`) — checkout the tag, build,
+  render, write `v/<tag>/index.html` into `pages-site`, update `versions.json`,
+  push.
+- **`deploy`** — `uses: ./.github/workflows/pages.yml`, so assembly and
+  deployment exist in one place rather than two.
+
+`contents: write` appears in exactly one job, on a path that runs a few times a
+year. This mirrors `release.yml`, which already declares permissions per job
+rather than at workflow level, with a comment explaining why.
+
+## Guards
+
+Each of these prevents a **green build that loses data** — the failure mode that
+motivated rejecting the alternative designs.
+
+1. **Truncation guard.** After assembly, count `_site/v/*` against
+   `versions.json`. Fewer than declared fails the run. Without it, a version
+   silently disappearing from a deploy looks like success.
+2. **Size guard.** Fail if `_site` exceeds 800 MB, so the ceiling arrives as a
+   CI failure with headroom rather than a Pages rejection at 1 GB.
+3. **Idempotency.** Re-running a tag overwrites `v/<tag>/` rather than appending,
+   so a re-run cannot corrupt the store.
+4. **Bootstrap.** `pages-site` is created during implementation carrying
+   `versions.json` as `[]`, so the first `pages.yml` run does not fail checking
+   out a branch that does not exist.
+
+## Discoverability
+
+`/v/index.html` is generated at assembly time from `versions.json`: a minimal
+static page listing each published version newest-first, each linking to
+`./<tag>/`. No styling beyond what keeps it legible, and no dependency on the
+report templates. The README gains a line pointing at it.
+
+A version switcher *inside* each report was rejected: it would require
+post-processing the rendered HTML, which is invasive and would churn the
+committed golden snapshots on every template change. The listing touches
+nothing.
+
+## Alternatives rejected
+
+**Reconstruct from the live site.** Fetch `versions.json` from the published
+site, re-download each version, add the new one, re-upload. Needs no branch and
+no write permission — genuinely attractive. Rejected because a 404 or a brief
+outage drops a version from the next deploy while the run still reports success.
+
+**Re-render every version on every deploy.** Fully stateless: check out each tag
+and rebuild. Rejected on cost — O(N) macOS builds per merge to `main`, so the
+tenth release adds roughly half an hour to every merge.
+
+## Scope
+
+**In:** the `pages-site` store, the `pages.yml` modification, `pages-release.yml`,
+the four guards, `/v/index.html`, and the README line.
+
+**Out:**
+
+- Backfilling 2.x and 3.0.0.
+- Publishing release candidates.
+- A version switcher inside the report.
+- Reducing render size (`-z`, dropping videos). Worth revisiting only if the
+  size guard ever fires.
+- Changing what `/` shows. It stays `main`.
+
+## Risks
+
+**The environment policy is not changed.** Then `pages-release.yml` fails at the
+deploy step on the first release. The failure is loud rather than silent, but the
+prerequisite above must land first.
+
+**A tag render fails to build.** `publish-version` fails, so `deploy` — which
+declares `needs: publish-version` — never runs and the live site is left
+untouched. The release simply has no versioned page, and the workflow run is
+red. That is the correct outcome, and it comes from job ordering rather than
+from any guard.
+
+`versions.json` is written **after** a successful render, never before, so a
+failed render cannot leave the store declaring a version whose directory does
+not exist.
+
+**Double render on release.** A tag push renders the tag, then renders `main`
+again during assembly — roughly three extra minutes, a few times a year. Caching
+`main`'s render to avoid it would add state to save two minutes and is not worth
+it.
+
+**Site growth outlives the assumption.** At ~44 MB/year the 1 GB limit is two
+decades away, but the size guard exists so the assumption is checked rather than
+trusted.

--- a/scripts/assemble_site.py
+++ b/scripts/assemble_site.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Assemble the published Pages site and refuse to publish a damaged one.
+
+The site is main's render at the root plus one immutable directory per released
+version. `actions/deploy-pages` replaces the whole site on every deployment, so
+a run that assembles an incomplete tree would silently delete published versions
+and still finish green. Every check here exists to turn that into a failure.
+
+Usage: assemble_site.py <site-dir>
+"""
+
+import html
+import json
+import os
+import shutil
+import sys
+
+# 1 GB is the documented Pages site limit. Failing at 800 MB turns the ceiling
+# into a CI failure with headroom instead of a rejected deployment.
+MAX_BYTES = 800 * 1024 * 1024
+
+
+def fail(message):
+    print(f"::error::{message}", file=sys.stderr)
+    sys.exit(1)
+
+
+def directory_size(path):
+    total = 0
+    for root, _, files in os.walk(path):
+        for name in files:
+            total += os.path.getsize(os.path.join(root, name))
+    return total
+
+
+def render_listing(versions):
+    """A minimal static index. Deliberately depends on nothing in the report
+    templates, so template changes never churn it."""
+    items = "\n".join(
+        f'      <li><a href="./{html.escape(v)}/">{html.escape(v)}</a></li>'
+        for v in versions
+    )
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>XCTestHTMLReport — published versions</title>
+  <style>
+    body {{ font-family: system-ui, -apple-system, sans-serif; margin: 3rem auto;
+           max-width: 40rem; padding: 0 1rem; line-height: 1.6; }}
+    li {{ margin: 0.25rem 0; }}
+  </style>
+</head>
+<body>
+  <h1>Published versions</h1>
+  <p>Each link is the demo report as rendered by that release.
+     <a href="../">The site root</a> is always the current <code>main</code>.</p>
+  <ul>
+{items}
+  </ul>
+</body>
+</html>
+"""
+
+
+def main():
+    if len(sys.argv) != 2:
+        fail("usage: assemble_site.py <site-dir>")
+    site = sys.argv[1]
+
+    # actions/checkout leaves a full repository behind, and
+    # upload-pages-artifact packages whatever it is handed — without this the
+    # store's git history is published as browsable files.
+    shutil.rmtree(os.path.join(site, ".git"), ignore_errors=True)
+
+    manifest = os.path.join(site, "versions.json")
+    if not os.path.isfile(manifest):
+        fail(f"missing {manifest} — the pages-site store was not checked out")
+
+    if not os.path.isfile(os.path.join(site, "index.html")):
+        fail(f"missing {site}/index.html — main's render did not land")
+
+    with open(manifest, encoding="utf-8") as handle:
+        try:
+            versions = json.load(handle)
+        except json.JSONDecodeError as error:
+            fail(f"{manifest} is not valid JSON: {error}")
+
+    if not isinstance(versions, list) or any(not isinstance(v, str) for v in versions):
+        fail(f"{manifest} must be a flat array of version strings")
+
+    # Truncation guard. Every declared version must exist on disk. A version
+    # that vanished between the store and the artifact would otherwise deploy
+    # as a green run that quietly dropped it.
+    missing = [v for v in versions if not os.path.isfile(
+        os.path.join(site, "v", v, "index.html"))]
+    if missing:
+        fail(
+            f"versions.json declares {len(missing)} version(s) with no render: "
+            f"{', '.join(missing)}"
+        )
+
+    # The reverse direction matters too: a directory nobody declared means the
+    # manifest and the tree disagree, and the listing would omit a live page.
+    version_dir = os.path.join(site, "v")
+    on_disk = sorted(
+        name for name in os.listdir(version_dir)
+        if os.path.isdir(os.path.join(version_dir, name))
+    ) if os.path.isdir(version_dir) else []
+    undeclared = [name for name in on_disk if name not in versions]
+    if undeclared:
+        fail(
+            f"{len(undeclared)} version director(ies) not in versions.json: "
+            f"{', '.join(undeclared)}"
+        )
+
+    os.makedirs(version_dir, exist_ok=True)
+    with open(os.path.join(version_dir, "index.html"), "w", encoding="utf-8") as handle:
+        handle.write(render_listing(versions))
+
+    size = directory_size(site)
+    if size > MAX_BYTES:
+        fail(
+            f"assembled site is {size / 1024 / 1024:.0f} MB, over the "
+            f"{MAX_BYTES / 1024 / 1024:.0f} MB ceiling"
+        )
+
+    print(f"assembled {site}: {len(versions)} version(s), {size / 1024 / 1024:.1f} MB")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/assemble_site.py
+++ b/scripts/assemble_site.py
@@ -12,12 +12,20 @@ Usage: assemble_site.py <site-dir>
 import html
 import json
 import os
+import re
 import shutil
 import sys
 
 # 1 GB is the documented Pages site limit. Failing at 800 MB turns the ceiling
 # into a CI failure with headroom instead of a rejected deployment.
 MAX_BYTES = 800 * 1024 * 1024
+
+# pages-release.yml's tag glob only ever writes MAJOR.MINOR.PATCH, so anything
+# else means the manifest was written by something other than this design.
+# Rejecting it here is what keeps a hostile or hand-edited versions.json from
+# reaching the filesystem or the generated hrefs, and what makes the listing's
+# integer sort total rather than a crash.
+VERSION = re.compile(r"[0-9]+\.[0-9]+\.[0-9]+")
 
 
 def fail(message):
@@ -36,9 +44,16 @@ def directory_size(path):
 def render_listing(versions):
     """A minimal static index. Deliberately depends on nothing in the report
     templates, so template changes never churn it."""
+    # versions.json stays in publication order — the manifest records what
+    # happened. The page sorts by version instead, because a maintenance release
+    # on an older line is published last and would otherwise sit at the top,
+    # where a reader reads it as "the latest version".
+    ordered = sorted(
+        versions, key=lambda v: tuple(int(p) for p in v.split(".")), reverse=True
+    )
     items = "\n".join(
         f'      <li><a href="./{html.escape(v)}/">{html.escape(v)}</a></li>'
-        for v in versions
+        for v in ordered
     )
     return f"""<!doctype html>
 <html lang="en">
@@ -90,6 +105,19 @@ def main():
     if not isinstance(versions, list) or any(not isinstance(v, str) for v in versions):
         fail(f"{manifest} must be a flat array of version strings")
 
+    malformed = [v for v in versions if not VERSION.fullmatch(v)]
+    if malformed:
+        fail(
+            f"{manifest} declares {len(malformed)} entr(ies) that are not "
+            f"MAJOR.MINOR.PATCH: {', '.join(malformed)}"
+        )
+
+    # publish-version dedupes before it writes, so a repeat means the manifest
+    # did not come from it. The listing would render the version twice.
+    duplicates = sorted({v for v in versions if versions.count(v) > 1})
+    if duplicates:
+        fail(f"{manifest} lists {', '.join(duplicates)} more than once")
+
     # Truncation guard. Every declared version must exist on disk. A version
     # that vanished between the store and the artifact would otherwise deploy
     # as a green run that quietly dropped it.
@@ -115,9 +143,15 @@ def main():
             f"{', '.join(undeclared)}"
         )
 
-    os.makedirs(version_dir, exist_ok=True)
-    with open(os.path.join(version_dir, "index.html"), "w", encoding="utf-8") as handle:
-        handle.write(render_listing(versions))
+    # Routed through fail() like every other failure here: a raw traceback in
+    # the log would be the one place an operator gets no ::error:: annotation.
+    listing = os.path.join(version_dir, "index.html")
+    try:
+        os.makedirs(version_dir, exist_ok=True)
+        with open(listing, "w", encoding="utf-8") as handle:
+            handle.write(render_listing(versions))
+    except OSError as error:
+        fail(f"could not write {listing}: {error}")
 
     size = directory_size(site)
     if size > MAX_BYTES:

--- a/scripts/test_assemble_site.py
+++ b/scripts/test_assemble_site.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""Tests for assemble_site.py, the script that stands between a damaged version
+store and a deployment that silently deletes released reports.
+
+Every guard here was verified by hand during implementation, in shell
+transcripts that no longer exist. This file is the version of that verification
+that survives, and that the next person to touch `render_listing` or the
+undeclared-directory predicate runs without knowing it exists.
+
+Standard library only, deliberately: the repository has no Python test
+dependency and this needs none. The tests drive the real script as a
+subprocess and assert on what CI and an operator actually see — exit status,
+the `::error::` annotations, and the files left on disk.
+
+Run: python3 -m unittest discover -s scripts -p 'test_*.py'
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+SCRIPT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "assemble_site.py")
+
+
+class AssembleSiteTests(unittest.TestCase):
+    def setUp(self):
+        self.site = tempfile.mkdtemp(prefix="assemble-site-")
+        self.addCleanup(shutil.rmtree, self.site, ignore_errors=True)
+
+    # --- fixtures ---------------------------------------------------------
+
+    def build_store(self, declared, rendered=None, root_index=True, gitkeep=True):
+        """Build the tree pages.yml hands the assembler: the pages-site store
+        checked out into the site directory, plus main's render at the root.
+
+        `rendered` defaults to `declared`; passing it is how a test makes the
+        manifest and the tree disagree.
+        """
+        versions_dir = os.path.join(self.site, "v")
+        os.makedirs(versions_dir, exist_ok=True)
+        if gitkeep:
+            # The real store ships this file — git cannot track an empty
+            # directory — so every fixture carries it too.
+            write(os.path.join(versions_dir, ".gitkeep"), "")
+        for version in declared if rendered is None else rendered:
+            os.makedirs(os.path.join(versions_dir, version), exist_ok=True)
+            write(os.path.join(versions_dir, version, "index.html"), f"<!doctype html>{version}")
+        if root_index:
+            write(os.path.join(self.site, "index.html"), "<!doctype html>main")
+        write(os.path.join(self.site, "versions.json"), json.dumps(declared) + "\n")
+
+    def assemble(self):
+        return subprocess.run(
+            [sys.executable, SCRIPT, self.site],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def listing(self):
+        with open(os.path.join(self.site, "v", "index.html"), encoding="utf-8") as handle:
+            return handle.read()
+
+    def assertFailedCleanly(self, result):
+        """Non-zero, with a GitHub annotation rather than a traceback — the
+        contract every failure path in the script keeps."""
+        self.assertEqual(result.returncode, 1, f"stdout={result.stdout!r}")
+        self.assertIn("::error::", result.stderr)
+        self.assertNotIn("Traceback", result.stderr)
+
+    # --- the store is well-formed ----------------------------------------
+
+    def test_happy_path_assembles_and_links_the_version(self):
+        self.build_store(["3.1.0"])
+
+        result = self.assemble()
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("1 version(s)", result.stdout)
+        self.assertIn('href="./3.1.0/"', self.listing())
+
+    def test_empty_store_assembles_a_valid_empty_listing(self):
+        """The state the site is in today, before the first release."""
+        self.build_store([])
+
+        result = self.assemble()
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("0 version(s)", result.stdout)
+        listing = self.listing()
+        self.assertIn("<h1>Published versions</h1>", listing)
+        self.assertIn("</html>", listing)
+        self.assertNotIn("<li>", listing)
+
+    def test_gitkeep_is_not_treated_as_a_version(self):
+        """The most load-bearing case in this file: `v/.gitkeep` is in the real
+        store, and a regression that reads it as an undeclared version fails
+        every merge to main until the first release exists."""
+        self.build_store([])
+        self.assertTrue(os.path.isfile(os.path.join(self.site, "v", ".gitkeep")))
+
+        result = self.assemble()
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertNotIn(".gitkeep", result.stderr)
+        self.assertNotIn(".gitkeep", self.listing())
+
+    def test_store_git_directory_is_removed(self):
+        """actions/checkout leaves it behind and upload-pages-artifact would
+        publish it."""
+        self.build_store([])
+        git_dir = os.path.join(self.site, ".git")
+        os.makedirs(git_dir)
+        write(os.path.join(git_dir, "config"), '[remote "origin"]\n')
+
+        result = self.assemble()
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertFalse(os.path.exists(git_dir))
+
+    # --- the listing ------------------------------------------------------
+
+    def test_listing_orders_by_version_not_by_publication(self):
+        # publish-version prepends, so a maintenance release on an older line
+        # is the newest entry in the manifest.
+        self.build_store(["3.1.1", "4.0.0", "3.1.0"])
+
+        result = self.assemble()
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        listing = self.listing()
+        self.assertLess(listing.index("4.0.0"), listing.index("3.1.1"))
+        self.assertLess(listing.index("3.1.1"), listing.index("3.1.0"))
+
+    def test_listing_sorts_numerically_not_lexically(self):
+        self.build_store(["9.0.0", "10.0.0"])
+
+        result = self.assemble()
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        listing = self.listing()
+        self.assertLess(listing.index("10.0.0"), listing.index("9.0.0"))
+
+    def test_manifest_is_left_in_publication_order(self):
+        """The manifest records what happened; only the page reorders."""
+        self.build_store(["3.1.1", "4.0.0", "3.1.0"])
+
+        self.assertEqual(self.assemble().returncode, 0)
+
+        with open(os.path.join(self.site, "versions.json"), encoding="utf-8") as handle:
+            self.assertEqual(json.load(handle), ["3.1.1", "4.0.0", "3.1.0"])
+
+    # --- the store is damaged ---------------------------------------------
+
+    def test_declared_version_with_no_render_fails(self):
+        """The guard the whole design rests on: deploy-pages replaces the site,
+        so assembling this tree would delete 3.0.0 in a green run."""
+        self.build_store(["3.1.0", "3.0.0"], rendered=["3.1.0"])
+
+        result = self.assemble()
+
+        self.assertFailedCleanly(result)
+        self.assertIn("3.0.0", result.stderr)
+        self.assertNotIn("3.1.0", result.stderr)
+
+    def test_undeclared_version_directory_fails(self):
+        self.build_store([], rendered=["9.9.9"])
+
+        result = self.assemble()
+
+        self.assertFailedCleanly(result)
+        self.assertIn("not in versions.json", result.stderr)
+        self.assertIn("9.9.9", result.stderr)
+
+    def test_missing_manifest_fails_with_its_own_message(self):
+        self.build_store(["3.1.0"])
+        os.remove(os.path.join(self.site, "versions.json"))
+
+        result = self.assemble()
+
+        self.assertFailedCleanly(result)
+        self.assertIn("pages-site store was not checked out", result.stderr)
+
+    def test_missing_root_render_fails_with_its_own_message(self):
+        self.build_store(["3.1.0"], root_index=False)
+
+        result = self.assemble()
+
+        self.assertFailedCleanly(result)
+        self.assertIn("main's render did not land", result.stderr)
+
+    def test_duplicate_manifest_entries_fail(self):
+        self.build_store(["3.1.0", "3.1.0"])
+
+        result = self.assemble()
+
+        self.assertFailedCleanly(result)
+        self.assertIn("more than once", result.stderr)
+        self.assertIn("3.1.0", result.stderr)
+
+    def test_entries_that_are_not_version_numbers_are_rejected(self):
+        for entry in ["../../etc", "3.1", "v3.1.0", "3.1.0 rc", "3.1.0#x"]:
+            with self.subTest(entry=entry):
+                # No directories: the format check must fire before the
+                # truncation guard catches these only by accident.
+                self.build_store([entry], rendered=[])
+
+                result = self.assemble()
+
+                self.assertFailedCleanly(result)
+                self.assertIn("MAJOR.MINOR.PATCH", result.stderr)
+
+    def test_unwritable_listing_path_fails_with_an_annotation(self):
+        """`v` as a file used to escape as a raw FileExistsError traceback,
+        the one failure with no annotation for the operator reading the log."""
+        write(os.path.join(self.site, "index.html"), "<!doctype html>main")
+        write(os.path.join(self.site, "versions.json"), "[]\n")
+        write(os.path.join(self.site, "v"), "not a directory")
+
+        result = self.assemble()
+
+        self.assertFailedCleanly(result)
+
+
+def write(path, text):
+    with open(path, "w", encoding="utf-8") as handle:
+        handle.write(text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why

`pages.yml` (#458) publishes one rendered report to
`https://xctesthtmlreport.github.io/XCTestHTMLReport/` on every merge to `main`,
replacing whatever was there. The site can therefore only ever answer "what does
the report look like right now."

It cannot answer "what did the report look like in 3.0" — a question with
practical weight, because 4.0 deliberately breaks the report's visual contract
(#439) and because this tool's users are running released versions, not `main`.

## What

Release renders are published alongside `main`'s, under versioned paths:

```
/                    main, republished on every merge (unchanged)
/v/3.1.0/            a stable release, written once, never rewritten
/v/index.html        generated listing
```

Stable releases only, forward-only — no backfill of 2.x or 3.0.0.

### The constraint that shapes everything

`actions/deploy-pages` **replaces the entire site** on each deployment; there is
no incremental publish. So every deploy must upload `main`'s render *and* every
version, which means versions have to persist outside the run.

Per-*commit* versioning was measured and rejected: the live site is 11,096,947
bytes, `main` takes ~190 commits/year, so 11.1 MB × 190 ≈ **2.1 GB/year** against
a 1 GB Pages limit — exceeded within about six months. Per-*release* versioning
costs ~44 MB/year.

### Pieces

- **`pages-site`** — an orphan branch holding only immutable version renders plus
  `versions.json`, a flat array of tags. It is both the declared inventory the
  truncation guard checks against and the input the listing is generated from, so
  the two cannot disagree. `main`'s render is deliberately *not* stored: it
  changes 190 times a year and is cheap to regenerate.
- **`scripts/assemble_site.py`** — deletes the store's `.git` (otherwise
  `upload-pages-artifact` publishes the store's git history as browsable files),
  generates `/v/index.html`, and runs the guards.
- **`pages.yml`** — now checks the store out into `_site/`, calls the assembler,
  and gains `workflow_call`. **No write permission anywhere in this path**, which
  is the main security property: the workflow that runs ~190 times a year only
  reads.
- **`pages-release.yml`** — on a stable tag, renders the tag, writes
  `v/<tag>/index.html` into the store, then `uses: ./.github/workflows/pages.yml`
  so assembly and deployment exist in one place. `contents: write` appears in
  **exactly one job** across both workflows.

### Guards

Each prevents a *green build that loses data*:

1. **Truncation** — `_site/v/*` is counted against `versions.json`; fewer than
   declared fails the run. Without it a version silently vanishing from a deploy
   looks like success.
2. **Size** — fails above 800 MB, so the ceiling arrives as a CI failure with
   headroom rather than a Pages rejection at 1 GB.
3. **Idempotency** — re-running a tag overwrites `v/<tag>/` rather than appending.
4. **Bootstrap** — `pages-site` already exists carrying `versions.json` as `[]`,
   so the first run does not fail checking out a missing branch.

`versions.json` is written only *after* a successful render, so a failed build
cannot leave the store declaring a version whose directory does not exist.

## Two things worth reviewing closely

**`render-ref`.** A called workflow inherits the **caller's** event context, so a
tag-triggered call to `pages.yml` would have rebuilt the site root from the *tag*
rather than `main` — rolling `/` back until the next merge, and contradicting
"`/` stays `main`'s render". `pages.yml` therefore takes a required
`workflow_call` input consumed as `ref: ${{ inputs.render-ref || github.sha }}`.
The `|| github.sha` is deliberate: it does not rely on `actions/checkout`'s
empty-`ref` behaviour, so the push-to-`main` path is *provably* unchanged.

**The concurrency groups are different on purpose.** `pages-release.yml` uses
`pages-store`, not `pages`. It calls `pages.yml` as a reusable workflow, and a
called workflow evaluates its own `concurrency` — sharing the group would make
the call wait on a group its own caller holds, and the run would deadlock.

## Testing

`scripts/test_assemble_site.py` — 14 cases, stdlib `unittest` only, no new
dependency — wired into `lint.yml`'s existing ubuntu `shell` job. It asserts on
real behaviour (exit codes, emitted `::error::` text, files on disk).

The suite was validated by a **negative control**: nine separate mutations, one
per guard, were each caught. The `v/.gitkeep` case matters most — the real store
ships that file, and if it were ever treated as an undeclared version it would
fail *every merge to `main`* until the first release.

`zizmor --min-severity low .github/workflows/` and `actionlint` are clean on
every workflow touched.

## Before the first release — needs a maintainer action

**`pages-site` has no branch protection** (`gh api
repos/:owner/:repo/branches/pages-site/protection` → 404). The truncation guard
compares `versions.json` against the tree, but both come from the same checkout,
so they move together: a force-push or hand-edit removing a version **and** its
manifest entry produces a self-consistent store, a green run, and a deploy that
permanently deletes that version. The store is the only copy outside the
published site.

Add a ruleset blocking force-push and deletion, allowing `github-actions[bot]` to
push. It cannot be a review requirement — `publish-version` pushes unattended.

## What this PR does not prove

`pages.yml` triggers only on push to `main`, `workflow_dispatch` and
`workflow_call`; `pages-release.yml` only on a stable tag push. **Neither can be
exercised by a pull request run.** After merge:

```bash
gh workflow run "Demo Site" --ref main
```

Expected: both jobs green and `assembled _site: 0 version(s)` — zero versions is
correct before the first release, and `/v/` will be a valid but empty listing
until the first stable tag.

The `github-pages` environment already carries the `tag: *.*.*` policy that the
release path needs; the stable-only filter is `pages-release.yml`'s trigger glob,
not that policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added versioned report publishing for stable releases under dedicated version URLs.
  - Added a release index so visitors can browse available report versions.
  - Updated the live report link to provide access to previous releases.

- **Bug Fixes**
  - Added validation and safeguards for incomplete, malformed, duplicate, or inconsistent release data.
  - Improved deployment assembly to ensure complete, reliable published sites.

- **Tests**
  - Added automated coverage for site assembly, version handling, required files, and deployment validation.

- **Documentation**
  - Added design and implementation documentation for versioned report publishing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->