### PR TITLE
Escape attachment filenames and stop interpolating them into JavaScript (fixes #463)

### DIFF
--- a/Sources/XCTestHTMLReportCore/Classes/HTMLTemplates.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/HTMLTemplates.swift
@@ -795,7 +795,8 @@ struct HTMLTemplates
       margin-right: -4px;
     }
 
-    #right-sidebar h2 {
+    #right-sidebar h2,
+    #file-attachment {
       color: var(--color-text-placeholder);
       font-weight: var(--font-weight-regular);
       font-size: var(--font-size-xl);
@@ -972,9 +973,10 @@ struct HTMLTemplates
         padding-bottom: 50vh;
       }
 
-      /* Both the placeholder and the file-download link are `h2`s the
-         desktop sheet centres absolutely; in a bottom sheet they flow. */
-      #right-sidebar h2 {
+      /* The placeholder and the file-download link are both centred
+         absolutely by the desktop sheet; in a bottom sheet they flow. */
+      #right-sidebar h2,
+      #file-attachment {
         position: static;
         width: auto;
         margin: var(--space-sm);
@@ -1004,30 +1006,30 @@ struct HTMLTemplates
         </ul>
       </header>
       <div id=\"container\">
-        <div id=\"left-sidebar\" class=\"sidebar\">
+        <nav id=\"left-sidebar\" class=\"sidebar\" aria-label=\"Devices\">
           <div class=\"resizer\"></div>
-          <h4 id=\"device-header\">Devices</h4>
+          <h2 id=\"device-header\">Devices</h2>
           <ul id=\"info-sections\">
             <li class=\"section\">
               [[DEVICES]]
             </li>
           </ul>
           <div id=\"report-issue\"><a href=\"https://github.com/TitouanVanBelle/XCTestHTMLReport/blob/master/CONTRIBUTING.md#reporting-issues\">Report an issue</a></div>
-        </div>
+        </nav>
 
-        <div id=\"main-content\">
+        <main id=\"main-content\">
           [[RUNS]]
-        </div>
+        </main>
 
-        <div id=\"right-sidebar\" class=\"sidebar\">
+        <aside id=\"right-sidebar\" class=\"sidebar\" aria-label=\"Attachment preview\">
           <div class=\"resizer\"></div>
           <h2>No Selected Attachment</h2>
-          <img src=\"\" class=\"displayed-screenshot\" id=\"screenshot\" loading=\"lazy\"/>
-          <img src=\"\" class=\"displayed-gif\" id=\"gif\" loading=\"lazy\"/>
-          <iframe id=\"text-attachment\" src=\"\" loading=\"lazy\"></iframe>
-          <h2 id=\"file-attachment\"><a target=\"_blank\"/></h2>
+          <img src=\"\" class=\"displayed-screenshot\" id=\"screenshot\" alt=\"\" loading=\"lazy\"/>
+          <img src=\"\" class=\"displayed-gif\" id=\"gif\" alt=\"\" loading=\"lazy\"/>
+          <iframe id=\"text-attachment\" src=\"\" title=\"Selected attachment\" loading=\"lazy\"></iframe>
+          <p id=\"file-attachment\"><a target=\"_blank\"></a></p>
           <video class=\"displayed-video\" controls src=\"\" id=\"video\" preload=\"none\"/>
-        </div>
+        </aside>
         <div class=\"clear\"></div>
       </div>
     </div>
@@ -1311,6 +1313,7 @@ struct HTMLTemplates
       var image = document.getElementById('screenshot-'+filename);
       screenshot.style.display = \"block\";
       screenshot.src = image.src;
+      screenshot.alt = image.alt;
     }
 
     function showVideo(filename) {
@@ -1334,6 +1337,7 @@ struct HTMLTemplates
     var gf = document.getElementById('gif-'+filename);
     gif.style.display = \"block\";
     gif.src = gf.src;
+    gif.alt = gf.alt;
     gif.play();
     }
     
@@ -1490,7 +1494,7 @@ struct HTMLTemplates
           <li class=\"selected\">All Messages</li>
         </ul>
       </div>
-      <iframe id=\"logs-iframe\" src=\"[[LOG_SOURCE]]\" loading=\"lazy\"></iframe>
+      <iframe id=\"logs-iframe\" src=\"[[LOG_SOURCE]]\" title=\"Run log\" loading=\"lazy\"></iframe>
     </div>
   </div>
   """
@@ -1580,7 +1584,7 @@ struct HTMLTemplates
     <span class=\"icon left screenshot-icon\" style=\"margin-left: [[PADDING]]px\"></span>
     [[NAME]]
     <span class=\"icon preview-icon\" data=\"[[FILENAME]]\" onclick=\"showScreenshot(this.getAttribute('data'))\"></span>
-    <img class=\"screenshot\" src=\"[[SOURCE]]\" id=\"screenshot-[[FILENAME]]\" loading=\"lazy\"/>
+    <img class=\"screenshot\" src=\"[[SOURCE]]\" id=\"screenshot-[[FILENAME]]\" alt=\"[[NAME]]\" loading=\"lazy\"/>
   </p>
   """
 
@@ -1589,7 +1593,7 @@ struct HTMLTemplates
     <span class="icon left screenshot-icon" style="margin-left: [[PADDING]]px"></span>
     [[NAME]]
   <span class=\"icon preview-icon\" data=\"[[FILENAME]]\" onclick=\"showGif(this.getAttribute('data'))\"></span>
-    <img class=\"gif\" src=\"[[SOURCE]]\" id=\"gif-[[FILENAME]]\" loading=\"lazy\"/>
+    <img class=\"gif\" src=\"[[SOURCE]]\" id=\"gif-[[FILENAME]]\" alt=\"[[NAME]]\" loading=\"lazy\"/>
   </p>
   """
 

--- a/Sources/XCTestHTMLReportCore/Classes/HTMLTemplates.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/HTMLTemplates.swift
@@ -1579,7 +1579,7 @@ struct HTMLTemplates
   <p class=\"attachment list-item\">
     <span class=\"icon left screenshot-icon\" style=\"margin-left: [[PADDING]]px\"></span>
     [[NAME]]
-    <span class=\"icon preview-icon\" data=\"[[FILENAME]]\" onclick=\"showScreenshot('[[FILENAME]]')\"></span>
+    <span class=\"icon preview-icon\" data=\"[[FILENAME]]\" onclick=\"showScreenshot(this.getAttribute('data'))\"></span>
     <img class=\"screenshot\" src=\"[[SOURCE]]\" id=\"screenshot-[[FILENAME]]\" loading=\"lazy\"/>
   </p>
   """
@@ -1588,7 +1588,7 @@ struct HTMLTemplates
   <p class="attachment list-item">
     <span class="icon left screenshot-icon" style="margin-left: [[PADDING]]px"></span>
     [[NAME]]
-  <span class=\"icon preview-icon\" data=\"[[FILENAME]]\" onclick=\"showGif('[[FILENAME]]')\"></span>
+  <span class=\"icon preview-icon\" data=\"[[FILENAME]]\" onclick=\"showGif(this.getAttribute('data'))\"></span>
     <img class=\"gif\" src=\"[[SOURCE]]\" id=\"gif-[[FILENAME]]\" loading=\"lazy\"/>
   </p>
   """
@@ -1597,7 +1597,7 @@ struct HTMLTemplates
   <p class=\"attachment list-item\">
     <span class=\"icon left video-icon\" style=\"margin-left: [[PADDING]]px\"></span>
     [[NAME]]
-    <span class=\"icon preview-icon\" data=\"[[FILENAME]]\" onclick=\"showVideo('[[FILENAME]]')\"></span>
+    <span class=\"icon preview-icon\" data=\"[[FILENAME]]\" onclick=\"showVideo(this.getAttribute('data'))\"></span>
     <video class=\"video\" controls src=\"[[SOURCE]]\" id=\"video-[[FILENAME]]\" preload=\"none\"/>
   </p>
   """
@@ -1606,7 +1606,7 @@ struct HTMLTemplates
   <p class=\"attachment list-item\">
     <span class=\"icon left text-icon\" style=\"margin-left: [[PADDING]]px\"></span>
     [[NAME]]
-    <span class=\"icon preview-icon\" data=\"[[SOURCE]]\" onclick=\"showText('[[SOURCE]]')\"></span>
+    <span class=\"icon preview-icon\" data=\"[[SOURCE]]\" onclick=\"showText(this.getAttribute('data'))\"></span>
   </p>
   """
 
@@ -1614,7 +1614,7 @@ struct HTMLTemplates
   <p class=\"attachment list-item\">
     <span class=\"icon left text-icon\" style=\"margin-left: [[PADDING]]px\"></span>
     [[NAME]]
-    <span class=\"icon preview-icon\" data=\"[[FILENAME]]\" onclick=\"showLinkAttachment('[[FILENAME]]')\"></span>
+    <span class=\"icon preview-icon\" data=\"[[FILENAME]]\" onclick=\"showLinkAttachment(this.getAttribute('data'))\"></span>
     <a class=\"file-attachment-link\" href=\"[[SOURCE]]\" id=\"file-attachment-[[FILENAME]]\"></a>
   </p>
   """

--- a/Sources/XCTestHTMLReportCore/Classes/Models/Attachment.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Models/Attachment.swift
@@ -304,9 +304,9 @@ struct Attachment: HTML {
     var htmlPlaceholderValues: [String: String] {
         [
             "PADDING": String(padding),
-            "SOURCE": source ?? "",
-            "FILENAME": filename,
-            "NAME": displayName,
+            "SOURCE": (source ?? "").stringByEscapingXMLChars,
+            "FILENAME": filename.stringByEscapingXMLChars,
+            "NAME": displayName.stringByEscapingXMLChars,
         ]
     }
 }

--- a/Sources/XCTestHTMLReportCore/Classes/Models/Iteration.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Models/Iteration.swift
@@ -66,7 +66,7 @@ extension Iteration {
     var htmlPlaceholderValues: [String: String] {
         [
             "UUID": uuid,
-            "TITLE": "Iteration \(iterationNumber ?? 0)",
+            "TITLE": "Iteration \(iterationNumber ?? 0)".stringByEscapingXMLChars,
             "DURATION": duration.formattedSeconds,
             "ICON_CLASS": status.cssClass,
             "SCREENSHOT_FLOW": testScreenshotFlow?.screenshots.accumulateHTMLAsString ?? "",

--- a/Sources/XCTestHTMLReportCore/Classes/Models/Run.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Models/Run.swift
@@ -150,7 +150,7 @@ struct Run: HTML {
     var htmlPlaceholderValues: [String: String] {
         [
             "DEVICE_IDENTIFIER": runDestination.targetDevice.uniqueIdentifier,
-            "LOG_SOURCE": logSource ?? "",
+            "LOG_SOURCE": (logSource ?? "").stringByEscapingXMLChars,
             "N_OF_TESTS": String(numberOfTests),
             "N_OF_PASSED_TESTS": String(numberOfPassedTests),
             "N_OF_SKIPPED_TESTS": String(numberOfSkippedTests),

--- a/Sources/XCTestHTMLReportCore/Classes/Models/RunDestination.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Models/RunDestination.swift
@@ -59,10 +59,10 @@ struct RunDestination: HTML {
     var htmlPlaceholderValues: [String: String] {
         [
             "DEVICE_RESULT": status.iconHTML,
-            "DEVICE_NAME": name,
+            "DEVICE_NAME": name.stringByEscapingXMLChars,
             "DEVICE_IDENTIFIER": targetDevice.uniqueIdentifier,
-            "DEVICE_MODEL": targetDevice.model,
-            "DEVICE_OS": targetDevice.osVersion,
+            "DEVICE_MODEL": targetDevice.model.stringByEscapingXMLChars,
+            "DEVICE_OS": targetDevice.osVersion.stringByEscapingXMLChars,
         ]
     }
 }

--- a/Sources/XCTestHTMLReportCore/Classes/Models/Test.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Models/Test.swift
@@ -202,7 +202,7 @@ extension TestGroup {
     var htmlPlaceholderValues: [String: String] {
         [
             "UUID": uuid,
-            "TITLE": title,
+            "TITLE": title.stringByEscapingXMLChars,
             "DURATION": duration.formattedSeconds,
             "ICON_CLASS": status.cssClass,
             "ITEM_CLASS": nodeKind.cssClass,
@@ -312,7 +312,7 @@ extension TestCase {
             let iteration = iterations[0]
             return [
                 "UUID": uuid,
-                "TITLE": title,
+                "TITLE": title.stringByEscapingXMLChars,
                 "DURATION": duration.formattedSeconds,
                 "ICON_CLASS": status.cssClass,
                 "ITEM_CLASS": nodeKind.cssClass,
@@ -325,7 +325,7 @@ extension TestCase {
         } else {
             return [
                 "UUID": uuid,
-                "TITLE": title,
+                "TITLE": title.stringByEscapingXMLChars,
                 "DURATION": duration.formattedSeconds,
                 "ICON_CLASS": status.cssClass,
                 "ITEM_CLASS": nodeKind.cssClass,

--- a/Sources/XCTestHTMLReportCore/Classes/Models/TestScreenshotFlow.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Models/TestScreenshotFlow.swift
@@ -45,13 +45,18 @@ struct ScreenshotFlowAttachment: HTML {
     let className: String
 
     var htmlTemplate: String {
-        "<img class=\"\(className)\" src=\"[[SRC]]\" id=\"screenshot-[[FILENAME]]\" loading=\"lazy\"/>"
+        "<img class=\"\(className)\" src=\"[[SRC]]\" id=\"screenshot-[[FILENAME]]\" "
+            + "alt=\"[[NAME]]\" loading=\"lazy\"/>"
     }
 
     var htmlPlaceholderValues: [String: String] {
         [
             "SRC": (attachment.source ?? "").stringByEscapingXMLChars,
             "FILENAME": attachment.filename.stringByEscapingXMLChars,
+            // The display name, not the file name: a real `.xcresult` names
+            // its payloads with an 80-character opaque id, and reading that
+            // aloud is worse than the missing `alt` this replaces.
+            "NAME": attachment.displayName.stringByEscapingXMLChars,
         ]
     }
 }

--- a/Sources/XCTestHTMLReportCore/Classes/Models/TestScreenshotFlow.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Models/TestScreenshotFlow.swift
@@ -50,8 +50,8 @@ struct ScreenshotFlowAttachment: HTML {
 
     var htmlPlaceholderValues: [String: String] {
         [
-            "SRC": attachment.source ?? "",
-            "FILENAME": attachment.filename,
+            "SRC": (attachment.source ?? "").stringByEscapingXMLChars,
+            "FILENAME": attachment.filename.stringByEscapingXMLChars,
         ]
     }
 }

--- a/Sources/XCTestHTMLReportCore/Classes/Protocols/HTML.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Protocols/HTML.swift
@@ -8,6 +8,22 @@
 
 import Foundation
 
+/// Values are substituted into the template verbatim, so escaping is the
+/// conformer's job and every placeholder falls into exactly one of three
+/// cases:
+///
+/// - **Leaf text** — a title, a file name, a device name, a source path.
+///   Escape it with `stringByEscapingXMLChars`. It is written straight into
+///   an attribute or a text node, and anything from an `.xcresult` is
+///   ultimately test-author controlled.
+/// - **Rendered markup** — a child's `html`, an icon's `iconHTML`. Escaping
+///   it would turn the report into a page of its own source. Pass it through.
+/// - **Opaque, by construction** — an `IdentifierPath.identifier` (a hex
+///   digest), a count, a CSS class from an enum. Escaping is a no-op.
+///
+/// Nothing here can enforce that split, so a new placeholder needs the
+/// author to say which case it is. `HTMLEscapingTests` pins the first and
+/// second; the third is pinned at `IdentifierPath.identifier`.
 protocol HTML {
     var htmlTemplate: String { get }
     var htmlPlaceholderValues: [String: String] { get }

--- a/Tests/XCTestHTMLReportTests/AccessibilitySeamTests.swift
+++ b/Tests/XCTestHTMLReportTests/AccessibilitySeamTests.swift
@@ -1,0 +1,65 @@
+//
+//  AccessibilitySeamTests.swift
+//
+//  The authority on the report's accessibility is `visual/tests/a11y.spec.ts`,
+//  which runs axe-core against a real browser. These are the two rules from it
+//  that can be checked on the markup alone, restated here so they hold in the
+//  `test` jobs too: `visual` is a separate workflow, and a template can lose an
+//  `alt` in a change that never runs a browser.
+//
+
+import XCTest
+@testable import XCTestHTMLReportCore
+
+final class AccessibilitySeamTests: XCTestCase {
+    private func renderedReport() -> String {
+        Summary(
+            parsedRuns: [SyntheticResult.parsedRun],
+            payloads: SyntheticResult.payloads,
+            renderingMode: .linking,
+            downsizeImagesEnabled: false,
+            downsizeScaleFactor: 0.5,
+            bundleNames: ["Synthetic"]
+        ).generatedHtmlReport()
+    }
+
+    /// Every `<tag …>` in the document, as its full source text.
+    private func elements(named tag: String, in html: String) throws -> [String] {
+        let regex = try NSRegularExpression(pattern: "<\(tag)\\b[^>]*>")
+        let range = NSRange(html.startIndex ..< html.endIndex, in: html)
+        return regex.matches(in: html, range: range).compactMap { match in
+            Range(match.range, in: html).map { String(html[$0]) }
+        }
+    }
+
+    /// axe-core `image-alt`. An empty `alt=""` counts: it is how a decorative
+    /// image declares itself, which is what the two preview placeholders are
+    /// until a screenshot is put in them.
+    func testEveryImageCarriesAnAltAttribute() throws {
+        let images = try elements(named: "img", in: renderedReport())
+        XCTAssertFalse(images.isEmpty, "the fixture must render images to be worth checking")
+
+        let missing = images.filter { !$0.contains("alt=") }
+        XCTAssertEqual(missing, [], "every <img> needs alt text, even if empty")
+    }
+
+    /// axe-core `frame-title`. A frame with no accessible name is announced as
+    /// nothing but "frame", so a screen reader user cannot tell the log pane
+    /// from the attachment pane.
+    func testEveryFrameCarriesATitleAttribute() throws {
+        let frames = try elements(named: "iframe", in: renderedReport())
+        XCTAssertFalse(frames.isEmpty, "the report must still render its frames")
+
+        let missing = frames.filter { !$0.contains("title=") }
+        XCTAssertEqual(missing, [], "every <iframe> needs an accessible name")
+    }
+
+    /// axe-core `landmark-one-main`, in the one form that survives outside a
+    /// browser: the element has to exist at all.
+    func testDocumentHasAMainLandmark() {
+        XCTAssertTrue(
+            renderedReport().contains("<main"),
+            "the report's content needs a main landmark to skip to"
+        )
+    }
+}

--- a/Tests/XCTestHTMLReportTests/HTMLEscapingTests.swift
+++ b/Tests/XCTestHTMLReportTests/HTMLEscapingTests.swift
@@ -1,0 +1,182 @@
+//
+//  HTMLEscapingTests.swift
+//
+//  Every value the `HTML` seam substitutes into a template is written into
+//  markup verbatim. Values that are already rendered HTML must stay that
+//  way; leaf text must not. These tests pin that split at the two places it
+//  can go wrong — a value breaking out of the attribute that holds it, and a
+//  value reaching a JavaScript string literal, where XML escaping cannot
+//  help because the browser decodes the attribute before compiling the JS.
+//
+
+import XCTest
+@testable import XCTestHTMLReportCore
+
+final class HTMLEscapingTests: XCTestCase {
+    private static let hostileFilename =
+        "FileName with DoubleQuote\"SingleQuote'LessThan<GreaterThan>Ampersand&.txt"
+
+    private static let escapedHostileFilename =
+        "FileName with DoubleQuote&quot;SingleQuote&apos;LessThan&lt;GreaterThan&gt;Ampersand&amp;.txt"
+
+    private func syntheticHTML() -> String {
+        Summary(
+            parsedRuns: [SyntheticResult.parsedRun],
+            payloads: SyntheticResult.payloads,
+            renderingMode: .linking,
+            downsizeImagesEnabled: false,
+            downsizeScaleFactor: 0.5,
+            bundleNames: ["Synthetic"]
+        ).generatedHtmlReport()
+    }
+
+    /// A run whose *every* leaf string is hostile. `Attachment` is only one
+    /// of the types feeding the substitution seam; this covers the titles,
+    /// identifiers and destination fields that `Test`, `Iteration`, `Run`
+    /// and `RunDestination` contribute.
+    private func hostileRunHTML() -> String {
+        let hostile = "\"'<>&"
+        let group = ParsedGroup(
+            name: "Suite\(hostile)",
+            identifier: "Suite\(hostile)",
+            duration: 1,
+            children: [.testCase(SyntheticResult.testCase(
+                name: "testHostile\(hostile)()",
+                iterations: [SyntheticResult.iteration(
+                    number: nil,
+                    status: .passed,
+                    activities: []
+                )]
+            ))]
+        )
+        let run = ParsedRun(
+            destination: ParsedDestination(
+                displayName: "Device\(hostile)",
+                deviceIdentifier: "identifier\(hostile)",
+                modelName: "Model\(hostile)",
+                operatingSystemVersion: "1.0\(hostile)"
+            ),
+            logReference: SyntheticResult.logReference,
+            testables: [ParsedTestable(targetName: "HostileTests", groups: [group])]
+        )
+        return Summary(
+            parsedRuns: [run],
+            payloads: SyntheticResult.payloads,
+            renderingMode: .linking,
+            downsizeImagesEnabled: false,
+            downsizeScaleFactor: 0.5,
+            bundleNames: ["Synthetic"]
+        ).generatedHtmlReport()
+    }
+
+    /// Every `foo="..."` in the rendered document, as raw attribute values.
+    private func attributeValues(named name: String, in html: String) throws -> [String] {
+        let pattern = "\(name)=\"([^\"]*)\""
+        let regex = try NSRegularExpression(pattern: pattern)
+        let range = NSRange(html.startIndex ..< html.endIndex, in: html)
+        return regex.matches(in: html, range: range).compactMap { match in
+            Range(match.range(at: 1), in: html).map { String(html[$0]) }
+        }
+    }
+
+    func testHostileFilenameIsWrittenIntoMarkupEscaped() {
+        let html = syntheticHTML()
+        XCTAssertTrue(
+            html.contains(Self.escapedHostileFilename),
+            "the filename must reach the document in its escaped form"
+        )
+        XCTAssertFalse(
+            html.contains(Self.hostileFilename),
+            "no raw copy of the filename may survive anywhere in the document"
+        )
+    }
+
+    /// The bug's visible symptom: the unescaped `<GreaterThan>` was parsed as
+    /// a start tag and a spurious element entered the DOM.
+    func testHostileFilenameDoesNotIntroduceAnElement() {
+        XCTAssertFalse(
+            syntheticHTML().contains("LessThan<GreaterThan>"),
+            "the filename's angle brackets must not be parsed as an element"
+        )
+    }
+
+    /// XML escaping alone cannot make a value safe inside a JS string
+    /// literal: the browser resolves `&apos;` back to `'` before the
+    /// attribute is compiled as JavaScript. The only fix is to stop
+    /// interpolating the value into the handler at all, so no `onclick` may
+    /// carry attachment-derived text.
+    func testNoOnclickHandlerEmbedsAnAttachmentFilename() throws {
+        let handlers = try attributeValues(named: "onclick", in: syntheticHTML())
+        XCTAssertFalse(handlers.isEmpty, "the report must still wire up click handlers")
+        let offenders = handlers.filter { $0.contains("FileName with DoubleQuote") }
+        XCTAssertEqual(
+            offenders,
+            [],
+            "a filename inside a JS string literal stays injectable however it is escaped"
+        )
+    }
+
+    /// `toggle(this, '...')` and `selectDevice('...', this)` interpolate too,
+    /// but what they interpolate is an `IdentifierPath.identifier` — the
+    /// first 128 bits of a SHA-256, hex encoded. That shape is what makes
+    /// them safe, so it is the thing worth pinning: if identifier generation
+    /// ever starts passing raw test or device names through, these handlers
+    /// become injectable and this test is the tripwire.
+    func testEveryIdentifierReachingAScriptHandlerIsAHexDigest() throws {
+        let interpolated = try attributeValues(named: "onclick", in: hostileRunHTML())
+            .filter { $0.hasPrefix("toggle(") || $0.hasPrefix("selectDevice(") }
+            .compactMap { handler -> String? in
+                guard let open = handler.firstIndex(of: "'") else {
+                    return nil
+                }
+                let rest = handler[handler.index(after: open)...]
+                guard let close = rest.firstIndex(of: "'") else {
+                    return nil
+                }
+                return String(rest[..<close])
+            }
+        XCTAssertFalse(interpolated.isEmpty, "the tree and device list must still pass ids")
+
+        let digest = try NSRegularExpression(pattern: "^[0-9a-f]{32}$")
+        let offenders = interpolated.filter { value in
+            digest.firstMatch(in: value, range: NSRange(location: 0, length: value.utf16.count))
+                == nil
+        }
+        XCTAssertEqual(
+            offenders,
+            [],
+            "only opaque digests may be interpolated into a JavaScript string literal"
+        )
+    }
+
+    func testHostileTestAndDeviceNamesAreEscaped() {
+        let html = hostileRunHTML()
+        XCTAssertTrue(
+            html.contains("testHostile&quot;&apos;&lt;&gt;&amp;()"),
+            "a test name must reach the document escaped"
+        )
+        XCTAssertTrue(
+            html.contains("Device&quot;&apos;&lt;&gt;&amp;"),
+            "a device name must reach the document escaped"
+        )
+        XCTAssertFalse(
+            html.contains("Model\"'<>&"),
+            "no raw copy of a destination field may survive"
+        )
+    }
+
+    /// The guard against over-correcting: values that are already rendered
+    /// HTML must pass through the seam untouched, or the whole report
+    /// collapses into escaped source text.
+    func testNestedMarkupIsNotEscaped() {
+        let html = syntheticHTML()
+        XCTAssertTrue(
+            html.contains("<span class=\"icon"),
+            "nested markup must remain markup, not become escaped text"
+        )
+        XCTAssertFalse(
+            html.contains("&lt;span"),
+            "a rendered child must never be escaped as if it were leaf text"
+        )
+    }
+}

--- a/Tests/XCTestHTMLReportTests/KnownLossMasker.swift
+++ b/Tests/XCTestHTMLReportTests/KnownLossMasker.swift
@@ -93,10 +93,21 @@ enum KnownLossMasker {
             // between the `<p>` and the name — so the anchor spans both
             // preceding lines. Anchoring on the icon span also keeps the rule
             // from ever touching a non-attachment `<p>`.
-            return replace(
+            let namedLines = replace(
                 html,
                 #"(<p class="attachment[^"]*">\n\s*<span class="icon left [a-z-]*icon"[^\n]*></span>\n)[^\n]*\n"#,
                 with: "$1ATTACHMENT_NAME\n"
+            )
+            // One divergence, two sites since #462: the same display name is
+            // also the `alt` of every attachment-derived image. Masking only
+            // the text line would let the `alt` reintroduce the difference
+            // this entry already accounts for. Matched on an exact class so
+            // the two `displayed-*` preview panes — whose `alt` is empty in
+            // both backends — stay compared.
+            return replace(
+                namedLines,
+                #"(<img class="(?:screenshot|screenshot-flow|screenshot-tail|gif)"[^\n]*?)alt="[^"]*""#,
+                with: "$1alt=\"ATTACHMENT_NAME\""
             )
         case "failureTitlePrefix":
             // Two shapes, not one. Verified on `TestResults`:

--- a/Tests/XCTestHTMLReportTests/Snapshots/index-inline.html
+++ b/Tests/XCTestHTMLReportTests/Snapshots/index-inline.html
@@ -1058,7 +1058,7 @@
       <p class="attachment list-item">
   <span class="icon left screenshot-icon" style="margin-left: 16px"></span>
   Screenshot
-  <span class="icon preview-icon" data="screenshot.png" onclick="showScreenshot('screenshot.png')"></span>
+  <span class="icon preview-icon" data="screenshot.png" onclick="showScreenshot(this.getAttribute('data'))"></span>
   <img class="screenshot" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" loading="lazy"/>
 </p>
   </div>
@@ -1101,12 +1101,12 @@
       <p class="attachment list-item">
   <span class="icon left screenshot-icon" style="margin-left: 36px"></span>
   Screenshot
-  <span class="icon preview-icon" data="screenshot.png" onclick="showScreenshot('screenshot.png')"></span>
+  <span class="icon preview-icon" data="screenshot.png" onclick="showScreenshot(this.getAttribute('data'))"></span>
   <img class="screenshot" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" loading="lazy"/>
 </p><p class="attachment list-item">
   <span class="icon left text-icon" style="margin-left: 36px"></span>
   Log
-  <span class="icon preview-icon" data="data:text/plain;base64,c3ludGhldGljIGF0dGFjaG1lbnQgYm9keQo=" onclick="showText('data:text/plain;base64,c3ludGhldGljIGF0dGFjaG1lbnQgYm9keQo=')"></span>
+  <span class="icon preview-icon" data="data:text/plain;base64,c3ludGhldGljIGF0dGFjaG1lbnQgYm9keQo=" onclick="showText(this.getAttribute('data'))"></span>
 </p>
   </div>
   <div id="activities-ac8aedc2d707d9bd771a8615d5f89301" class="sub-activities">
@@ -1149,7 +1149,7 @@
       <p class="attachment list-item">
   <span class="icon left screenshot-icon" style="margin-left: 16px"></span>
   Screenshot
-  <span class="icon preview-icon" data="screenshot.png" onclick="showScreenshot('screenshot.png')"></span>
+  <span class="icon preview-icon" data="screenshot.png" onclick="showScreenshot(this.getAttribute('data'))"></span>
   <img class="screenshot" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" loading="lazy"/>
 </p>
   </div>
@@ -1192,12 +1192,12 @@
       <p class="attachment list-item">
   <span class="icon left screenshot-icon" style="margin-left: 36px"></span>
   Screenshot
-  <span class="icon preview-icon" data="screenshot.png" onclick="showScreenshot('screenshot.png')"></span>
+  <span class="icon preview-icon" data="screenshot.png" onclick="showScreenshot(this.getAttribute('data'))"></span>
   <img class="screenshot" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" loading="lazy"/>
 </p><p class="attachment list-item">
   <span class="icon left text-icon" style="margin-left: 36px"></span>
   Log
-  <span class="icon preview-icon" data="data:text/plain;base64,c3ludGhldGljIGF0dGFjaG1lbnQgYm9keQo=" onclick="showText('data:text/plain;base64,c3ludGhldGljIGF0dGFjaG1lbnQgYm9keQo=')"></span>
+  <span class="icon preview-icon" data="data:text/plain;base64,c3ludGhldGljIGF0dGFjaG1lbnQgYm9keQo=" onclick="showText(this.getAttribute('data'))"></span>
 </p>
   </div>
   <div id="activities-65291edd1daadc2dda7056f8567bbbef" class="sub-activities">
@@ -1259,7 +1259,7 @@
       <p class="attachment list-item">
   <span class="icon left screenshot-icon" style="margin-left: 16px"></span>
   Screenshot
-  <span class="icon preview-icon" data="screenshot.png" onclick="showScreenshot('screenshot.png')"></span>
+  <span class="icon preview-icon" data="screenshot.png" onclick="showScreenshot(this.getAttribute('data'))"></span>
   <img class="screenshot" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" loading="lazy"/>
 </p>
   </div>
@@ -1301,12 +1301,12 @@
       <p class="attachment list-item">
   <span class="icon left screenshot-icon" style="margin-left: 36px"></span>
   Screenshot
-  <span class="icon preview-icon" data="screenshot.png" onclick="showScreenshot('screenshot.png')"></span>
+  <span class="icon preview-icon" data="screenshot.png" onclick="showScreenshot(this.getAttribute('data'))"></span>
   <img class="screenshot" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" loading="lazy"/>
 </p><p class="attachment list-item">
   <span class="icon left text-icon" style="margin-left: 36px"></span>
   Log
-  <span class="icon preview-icon" data="data:text/plain;base64,c3ludGhldGljIGF0dGFjaG1lbnQgYm9keQo=" onclick="showText('data:text/plain;base64,c3ludGhldGljIGF0dGFjaG1lbnQgYm9keQo=')"></span>
+  <span class="icon preview-icon" data="data:text/plain;base64,c3ludGhldGljIGF0dGFjaG1lbnQgYm9keQo=" onclick="showText(this.getAttribute('data'))"></span>
 </p>
   </div>
   <div id="activities-eea257a844e0587dce9a918f430ad0a4" class="sub-activities">

--- a/Tests/XCTestHTMLReportTests/Snapshots/index-inline.html
+++ b/Tests/XCTestHTMLReportTests/Snapshots/index-inline.html
@@ -788,7 +788,8 @@
     margin-right: -4px;
   }
 
-  #right-sidebar h2 {
+  #right-sidebar h2,
+  #file-attachment {
     color: var(--color-text-placeholder);
     font-weight: var(--font-weight-regular);
     font-size: var(--font-size-xl);
@@ -965,9 +966,10 @@
       padding-bottom: 50vh;
     }
 
-    /* Both the placeholder and the file-download link are `h2`s the
-       desktop sheet centres absolutely; in a bottom sheet they flow. */
-    #right-sidebar h2 {
+    /* The placeholder and the file-download link are both centred
+       absolutely by the desktop sheet; in a bottom sheet they flow. */
+    #right-sidebar h2,
+    #file-attachment {
       position: static;
       width: auto;
       margin: var(--space-sm);
@@ -997,9 +999,9 @@
       </ul>
     </header>
     <div id="container">
-      <div id="left-sidebar" class="sidebar">
+      <nav id="left-sidebar" class="sidebar" aria-label="Devices">
         <div class="resizer"></div>
-        <h4 id="device-header">Devices</h4>
+        <h2 id="device-header">Devices</h2>
         <ul id="info-sections">
           <li class="section">
               <ul class="device-info" onclick="selectDevice('42230e298d9d9e832714ebad20e680c6', this);">
@@ -1011,9 +1013,9 @@
           </li>
         </ul>
         <div id="report-issue"><a href="https://github.com/TitouanVanBelle/XCTestHTMLReport/blob/master/CONTRIBUTING.md#reporting-issues">Report an issue</a></div>
-      </div>
+      </nav>
 
-      <div id="main-content">
+      <main id="main-content">
         <div class="run" id="device_42230e298d9d9e832714ebad20e680c6">
   <div class="tests">
     <div class="tests-header">
@@ -1037,7 +1039,7 @@
           <span class="icon left test-icon"></span>
           SyntheticSuite (6.00s)
       </p>
-        <img class="screenshot-tail" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" loading="lazy"/>
+        <img class="screenshot-tail" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
   <div class="test-summary expected-failure">
       <span class="icon left test-result-icon"></span>
       <p class="list-item">
@@ -1046,7 +1048,7 @@
           testExpectedlyFails() (1.50s)
       </p>
       <div id="activities-1c6cdccfeb05445c9896526289e8c191" class="activities">
-          <img class="screenshot-flow" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" loading="lazy"/>
+          <img class="screenshot-flow" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
           <div class="activity activity-assertion-failure ">
   <p class="list-item">
     <span style="margin-left: 0px" class="padding"></span>
@@ -1059,7 +1061,7 @@
   <span class="icon left screenshot-icon" style="margin-left: 16px"></span>
   Screenshot
   <span class="icon preview-icon" data="screenshot.png" onclick="showScreenshot(this.getAttribute('data'))"></span>
-  <img class="screenshot" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" loading="lazy"/>
+  <img class="screenshot" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
 </p>
   </div>
   <div id="activities-eab1e43262f622153d7b29bf5870292c" class="sub-activities">
@@ -1067,7 +1069,7 @@
   </div>
 </div>
       </div>
-  </div>  <img class="screenshot-tail" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" loading="lazy"/><img class="screenshot-tail" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" loading="lazy"/>
+  </div>  <img class="screenshot-tail" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/><img class="screenshot-tail" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
   <div class="test-summary failed">
       <span class="icon left test-result-icon"></span>
       <p class="list-item">
@@ -1076,7 +1078,7 @@
           testFails() (1.50s)
       </p>
       <div id="activities-4abdbdaebf10baf0f23017525cf4a9be" class="activities">
-          <img class="screenshot-flow" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" loading="lazy"/><img class="screenshot-flow" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" loading="lazy"/>
+          <img class="screenshot-flow" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/><img class="screenshot-flow" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
           <div class="activity  no-drop-down">
   <p class="list-item">
     <span style="margin-left: 38px" class="padding"></span>
@@ -1102,7 +1104,7 @@
   <span class="icon left screenshot-icon" style="margin-left: 36px"></span>
   Screenshot
   <span class="icon preview-icon" data="screenshot.png" onclick="showScreenshot(this.getAttribute('data'))"></span>
-  <img class="screenshot" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" loading="lazy"/>
+  <img class="screenshot" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
 </p><p class="attachment list-item">
   <span class="icon left text-icon" style="margin-left: 36px"></span>
   Log
@@ -1150,7 +1152,7 @@
   <span class="icon left screenshot-icon" style="margin-left: 16px"></span>
   Screenshot
   <span class="icon preview-icon" data="screenshot.png" onclick="showScreenshot(this.getAttribute('data'))"></span>
-  <img class="screenshot" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" loading="lazy"/>
+  <img class="screenshot" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
 </p>
   </div>
   <div id="activities-35ad28c1a36df8df00034ad8eb0a2ffb" class="sub-activities">
@@ -1158,7 +1160,7 @@
   </div>
 </div>
       </div>
-  </div>  <img class="screenshot-tail" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" loading="lazy"/>
+  </div>  <img class="screenshot-tail" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
   <div class="test-summary succeeded">
       <span class="icon left test-result-icon"></span>
       <p class="list-item">
@@ -1167,7 +1169,7 @@
           testPasses() (1.50s)
       </p>
       <div id="activities-16170791d4b96668f53ace117678c387" class="activities">
-          <img class="screenshot-flow" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" loading="lazy"/>
+          <img class="screenshot-flow" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
           <div class="activity  no-drop-down">
   <p class="list-item">
     <span style="margin-left: 38px" class="padding"></span>
@@ -1193,7 +1195,7 @@
   <span class="icon left screenshot-icon" style="margin-left: 36px"></span>
   Screenshot
   <span class="icon preview-icon" data="screenshot.png" onclick="showScreenshot(this.getAttribute('data'))"></span>
-  <img class="screenshot" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" loading="lazy"/>
+  <img class="screenshot" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
 </p><p class="attachment list-item">
   <span class="icon left text-icon" style="margin-left: 36px"></span>
   Log
@@ -1247,7 +1249,7 @@
           Iteration 1 (1.50s)
       </p>
       <div id="activities-98ade9823d518704e870971ef0c6984c" class="activities">
-          <img class="screenshot-flow" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" loading="lazy"/>
+          <img class="screenshot-flow" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
           <div class="activity activity-assertion-failure ">
   <p class="list-item">
     <span style="margin-left: 0px" class="padding"></span>
@@ -1260,7 +1262,7 @@
   <span class="icon left screenshot-icon" style="margin-left: 16px"></span>
   Screenshot
   <span class="icon preview-icon" data="screenshot.png" onclick="showScreenshot(this.getAttribute('data'))"></span>
-  <img class="screenshot" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" loading="lazy"/>
+  <img class="screenshot" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
 </p>
   </div>
   <div id="activities-d52daa3211c83b468e246ec5568bb84b" class="sub-activities">
@@ -1276,7 +1278,7 @@
           Iteration 2 (1.50s)
       </p>
       <div id="activities-34758e281c83108eeca0f231788a3a00" class="activities">
-          <img class="screenshot-flow" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" loading="lazy"/>
+          <img class="screenshot-flow" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
           <div class="activity  no-drop-down">
   <p class="list-item">
     <span style="margin-left: 38px" class="padding"></span>
@@ -1302,7 +1304,7 @@
   <span class="icon left screenshot-icon" style="margin-left: 36px"></span>
   Screenshot
   <span class="icon preview-icon" data="screenshot.png" onclick="showScreenshot(this.getAttribute('data'))"></span>
-  <img class="screenshot" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" loading="lazy"/>
+  <img class="screenshot" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
 </p><p class="attachment list-item">
   <span class="icon left text-icon" style="margin-left: 36px"></span>
   Log
@@ -1364,20 +1366,20 @@
         <li class="selected">All Messages</li>
       </ul>
     </div>
-    <iframe id="logs-iframe" src="data:text/plain;base64,U3ludGhldGljIHJ1biBsb2cgbGluZSBvbmUKU3ludGhldGljIHJ1biBsb2cgbGluZSB0d28K" loading="lazy"></iframe>
+    <iframe id="logs-iframe" src="data:text/plain;base64,U3ludGhldGljIHJ1biBsb2cgbGluZSBvbmUKU3ludGhldGljIHJ1biBsb2cgbGluZSB0d28K" title="Run log" loading="lazy"></iframe>
   </div>
 </div>
-      </div>
+      </main>
 
-      <div id="right-sidebar" class="sidebar">
+      <aside id="right-sidebar" class="sidebar" aria-label="Attachment preview">
         <div class="resizer"></div>
         <h2>No Selected Attachment</h2>
-        <img src="" class="displayed-screenshot" id="screenshot" loading="lazy"/>
-        <img src="" class="displayed-gif" id="gif" loading="lazy"/>
-        <iframe id="text-attachment" src="" loading="lazy"></iframe>
-        <h2 id="file-attachment"><a target="_blank"/></h2>
+        <img src="" class="displayed-screenshot" id="screenshot" alt="" loading="lazy"/>
+        <img src="" class="displayed-gif" id="gif" alt="" loading="lazy"/>
+        <iframe id="text-attachment" src="" title="Selected attachment" loading="lazy"></iframe>
+        <p id="file-attachment"><a target="_blank"></a></p>
         <video class="displayed-video" controls src="" id="video" preload="none"/>
-      </div>
+      </aside>
       <div class="clear"></div>
     </div>
   </div>
@@ -1661,6 +1663,7 @@
     var image = document.getElementById('screenshot-'+filename);
     screenshot.style.display = "block";
     screenshot.src = image.src;
+    screenshot.alt = image.alt;
   }
 
   function showVideo(filename) {
@@ -1684,6 +1687,7 @@
   var gf = document.getElementById('gif-'+filename);
   gif.style.display = "block";
   gif.src = gf.src;
+  gif.alt = gf.alt;
   gif.play();
   }
   

--- a/Tests/XCTestHTMLReportTests/Snapshots/index.html
+++ b/Tests/XCTestHTMLReportTests/Snapshots/index.html
@@ -788,7 +788,8 @@
     margin-right: -4px;
   }
 
-  #right-sidebar h2 {
+  #right-sidebar h2,
+  #file-attachment {
     color: var(--color-text-placeholder);
     font-weight: var(--font-weight-regular);
     font-size: var(--font-size-xl);
@@ -965,9 +966,10 @@
       padding-bottom: 50vh;
     }
 
-    /* Both the placeholder and the file-download link are `h2`s the
-       desktop sheet centres absolutely; in a bottom sheet they flow. */
-    #right-sidebar h2 {
+    /* The placeholder and the file-download link are both centred
+       absolutely by the desktop sheet; in a bottom sheet they flow. */
+    #right-sidebar h2,
+    #file-attachment {
       position: static;
       width: auto;
       margin: var(--space-sm);
@@ -997,9 +999,9 @@
       </ul>
     </header>
     <div id="container">
-      <div id="left-sidebar" class="sidebar">
+      <nav id="left-sidebar" class="sidebar" aria-label="Devices">
         <div class="resizer"></div>
-        <h4 id="device-header">Devices</h4>
+        <h2 id="device-header">Devices</h2>
         <ul id="info-sections">
           <li class="section">
               <ul class="device-info" onclick="selectDevice('42230e298d9d9e832714ebad20e680c6', this);">
@@ -1011,9 +1013,9 @@
           </li>
         </ul>
         <div id="report-issue"><a href="https://github.com/TitouanVanBelle/XCTestHTMLReport/blob/master/CONTRIBUTING.md#reporting-issues">Report an issue</a></div>
-      </div>
+      </nav>
 
-      <div id="main-content">
+      <main id="main-content">
         <div class="run" id="device_42230e298d9d9e832714ebad20e680c6">
   <div class="tests">
     <div class="tests-header">
@@ -1037,7 +1039,7 @@
           <span class="icon left test-icon"></span>
           SyntheticSuite (6.00s)
       </p>
-        <img class="screenshot-tail" src="screenshot.png" id="screenshot-screenshot.png" loading="lazy"/>
+        <img class="screenshot-tail" src="screenshot.png" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
   <div class="test-summary expected-failure">
       <span class="icon left test-result-icon"></span>
       <p class="list-item">
@@ -1046,7 +1048,7 @@
           testExpectedlyFails() (1.50s)
       </p>
       <div id="activities-1c6cdccfeb05445c9896526289e8c191" class="activities">
-          <img class="screenshot-flow" src="screenshot.png" id="screenshot-screenshot.png" loading="lazy"/>
+          <img class="screenshot-flow" src="screenshot.png" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
           <div class="activity activity-assertion-failure ">
   <p class="list-item">
     <span style="margin-left: 0px" class="padding"></span>
@@ -1059,7 +1061,7 @@
   <span class="icon left screenshot-icon" style="margin-left: 16px"></span>
   Screenshot
   <span class="icon preview-icon" data="screenshot.png" onclick="showScreenshot(this.getAttribute('data'))"></span>
-  <img class="screenshot" src="screenshot.png" id="screenshot-screenshot.png" loading="lazy"/>
+  <img class="screenshot" src="screenshot.png" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
 </p>
   </div>
   <div id="activities-eab1e43262f622153d7b29bf5870292c" class="sub-activities">
@@ -1067,7 +1069,7 @@
   </div>
 </div>
       </div>
-  </div>  <img class="screenshot-tail" src="screenshot.png" id="screenshot-screenshot.png" loading="lazy"/><img class="screenshot-tail" src="screenshot.png" id="screenshot-screenshot.png" loading="lazy"/>
+  </div>  <img class="screenshot-tail" src="screenshot.png" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/><img class="screenshot-tail" src="screenshot.png" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
   <div class="test-summary failed">
       <span class="icon left test-result-icon"></span>
       <p class="list-item">
@@ -1076,7 +1078,7 @@
           testFails() (1.50s)
       </p>
       <div id="activities-4abdbdaebf10baf0f23017525cf4a9be" class="activities">
-          <img class="screenshot-flow" src="screenshot.png" id="screenshot-screenshot.png" loading="lazy"/><img class="screenshot-flow" src="screenshot.png" id="screenshot-screenshot.png" loading="lazy"/>
+          <img class="screenshot-flow" src="screenshot.png" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/><img class="screenshot-flow" src="screenshot.png" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
           <div class="activity  no-drop-down">
   <p class="list-item">
     <span style="margin-left: 38px" class="padding"></span>
@@ -1102,7 +1104,7 @@
   <span class="icon left screenshot-icon" style="margin-left: 36px"></span>
   Screenshot
   <span class="icon preview-icon" data="screenshot.png" onclick="showScreenshot(this.getAttribute('data'))"></span>
-  <img class="screenshot" src="screenshot.png" id="screenshot-screenshot.png" loading="lazy"/>
+  <img class="screenshot" src="screenshot.png" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
 </p><p class="attachment list-item">
   <span class="icon left text-icon" style="margin-left: 36px"></span>
   Log
@@ -1150,7 +1152,7 @@
   <span class="icon left screenshot-icon" style="margin-left: 16px"></span>
   Screenshot
   <span class="icon preview-icon" data="screenshot.png" onclick="showScreenshot(this.getAttribute('data'))"></span>
-  <img class="screenshot" src="screenshot.png" id="screenshot-screenshot.png" loading="lazy"/>
+  <img class="screenshot" src="screenshot.png" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
 </p>
   </div>
   <div id="activities-35ad28c1a36df8df00034ad8eb0a2ffb" class="sub-activities">
@@ -1158,7 +1160,7 @@
   </div>
 </div>
       </div>
-  </div>  <img class="screenshot-tail" src="screenshot.png" id="screenshot-screenshot.png" loading="lazy"/>
+  </div>  <img class="screenshot-tail" src="screenshot.png" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
   <div class="test-summary succeeded">
       <span class="icon left test-result-icon"></span>
       <p class="list-item">
@@ -1167,7 +1169,7 @@
           testPasses() (1.50s)
       </p>
       <div id="activities-16170791d4b96668f53ace117678c387" class="activities">
-          <img class="screenshot-flow" src="screenshot.png" id="screenshot-screenshot.png" loading="lazy"/>
+          <img class="screenshot-flow" src="screenshot.png" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
           <div class="activity  no-drop-down">
   <p class="list-item">
     <span style="margin-left: 38px" class="padding"></span>
@@ -1193,7 +1195,7 @@
   <span class="icon left screenshot-icon" style="margin-left: 36px"></span>
   Screenshot
   <span class="icon preview-icon" data="screenshot.png" onclick="showScreenshot(this.getAttribute('data'))"></span>
-  <img class="screenshot" src="screenshot.png" id="screenshot-screenshot.png" loading="lazy"/>
+  <img class="screenshot" src="screenshot.png" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
 </p><p class="attachment list-item">
   <span class="icon left text-icon" style="margin-left: 36px"></span>
   Log
@@ -1247,7 +1249,7 @@
           Iteration 1 (1.50s)
       </p>
       <div id="activities-98ade9823d518704e870971ef0c6984c" class="activities">
-          <img class="screenshot-flow" src="screenshot.png" id="screenshot-screenshot.png" loading="lazy"/>
+          <img class="screenshot-flow" src="screenshot.png" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
           <div class="activity activity-assertion-failure ">
   <p class="list-item">
     <span style="margin-left: 0px" class="padding"></span>
@@ -1260,7 +1262,7 @@
   <span class="icon left screenshot-icon" style="margin-left: 16px"></span>
   Screenshot
   <span class="icon preview-icon" data="screenshot.png" onclick="showScreenshot(this.getAttribute('data'))"></span>
-  <img class="screenshot" src="screenshot.png" id="screenshot-screenshot.png" loading="lazy"/>
+  <img class="screenshot" src="screenshot.png" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
 </p>
   </div>
   <div id="activities-d52daa3211c83b468e246ec5568bb84b" class="sub-activities">
@@ -1276,7 +1278,7 @@
           Iteration 2 (1.50s)
       </p>
       <div id="activities-34758e281c83108eeca0f231788a3a00" class="activities">
-          <img class="screenshot-flow" src="screenshot.png" id="screenshot-screenshot.png" loading="lazy"/>
+          <img class="screenshot-flow" src="screenshot.png" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
           <div class="activity  no-drop-down">
   <p class="list-item">
     <span style="margin-left: 38px" class="padding"></span>
@@ -1302,7 +1304,7 @@
   <span class="icon left screenshot-icon" style="margin-left: 36px"></span>
   Screenshot
   <span class="icon preview-icon" data="screenshot.png" onclick="showScreenshot(this.getAttribute('data'))"></span>
-  <img class="screenshot" src="screenshot.png" id="screenshot-screenshot.png" loading="lazy"/>
+  <img class="screenshot" src="screenshot.png" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
 </p><p class="attachment list-item">
   <span class="icon left text-icon" style="margin-left: 36px"></span>
   Log
@@ -1364,20 +1366,20 @@
         <li class="selected">All Messages</li>
       </ul>
     </div>
-    <iframe id="logs-iframe" src="20264b52b84cb3e65c5ff06be4bb344d.log" loading="lazy"></iframe>
+    <iframe id="logs-iframe" src="20264b52b84cb3e65c5ff06be4bb344d.log" title="Run log" loading="lazy"></iframe>
   </div>
 </div>
-      </div>
+      </main>
 
-      <div id="right-sidebar" class="sidebar">
+      <aside id="right-sidebar" class="sidebar" aria-label="Attachment preview">
         <div class="resizer"></div>
         <h2>No Selected Attachment</h2>
-        <img src="" class="displayed-screenshot" id="screenshot" loading="lazy"/>
-        <img src="" class="displayed-gif" id="gif" loading="lazy"/>
-        <iframe id="text-attachment" src="" loading="lazy"></iframe>
-        <h2 id="file-attachment"><a target="_blank"/></h2>
+        <img src="" class="displayed-screenshot" id="screenshot" alt="" loading="lazy"/>
+        <img src="" class="displayed-gif" id="gif" alt="" loading="lazy"/>
+        <iframe id="text-attachment" src="" title="Selected attachment" loading="lazy"></iframe>
+        <p id="file-attachment"><a target="_blank"></a></p>
         <video class="displayed-video" controls src="" id="video" preload="none"/>
-      </div>
+      </aside>
       <div class="clear"></div>
     </div>
   </div>
@@ -1661,6 +1663,7 @@
     var image = document.getElementById('screenshot-'+filename);
     screenshot.style.display = "block";
     screenshot.src = image.src;
+    screenshot.alt = image.alt;
   }
 
   function showVideo(filename) {
@@ -1684,6 +1687,7 @@
   var gf = document.getElementById('gif-'+filename);
   gif.style.display = "block";
   gif.src = gf.src;
+  gif.alt = gf.alt;
   gif.play();
   }
   

--- a/Tests/XCTestHTMLReportTests/Snapshots/index.html
+++ b/Tests/XCTestHTMLReportTests/Snapshots/index.html
@@ -1058,7 +1058,7 @@
       <p class="attachment list-item">
   <span class="icon left screenshot-icon" style="margin-left: 16px"></span>
   Screenshot
-  <span class="icon preview-icon" data="screenshot.png" onclick="showScreenshot('screenshot.png')"></span>
+  <span class="icon preview-icon" data="screenshot.png" onclick="showScreenshot(this.getAttribute('data'))"></span>
   <img class="screenshot" src="screenshot.png" id="screenshot-screenshot.png" loading="lazy"/>
 </p>
   </div>
@@ -1101,12 +1101,12 @@
       <p class="attachment list-item">
   <span class="icon left screenshot-icon" style="margin-left: 36px"></span>
   Screenshot
-  <span class="icon preview-icon" data="screenshot.png" onclick="showScreenshot('screenshot.png')"></span>
+  <span class="icon preview-icon" data="screenshot.png" onclick="showScreenshot(this.getAttribute('data'))"></span>
   <img class="screenshot" src="screenshot.png" id="screenshot-screenshot.png" loading="lazy"/>
 </p><p class="attachment list-item">
   <span class="icon left text-icon" style="margin-left: 36px"></span>
   Log
-  <span class="icon preview-icon" data="FileName with DoubleQuote"SingleQuote'LessThan<GreaterThan>Ampersand&.txt" onclick="showText('FileName with DoubleQuote"SingleQuote'LessThan<GreaterThan>Ampersand&.txt')"></span>
+  <span class="icon preview-icon" data="FileName with DoubleQuote&quot;SingleQuote&apos;LessThan&lt;GreaterThan&gt;Ampersand&amp;.txt" onclick="showText(this.getAttribute('data'))"></span>
 </p>
   </div>
   <div id="activities-ac8aedc2d707d9bd771a8615d5f89301" class="sub-activities">
@@ -1149,7 +1149,7 @@
       <p class="attachment list-item">
   <span class="icon left screenshot-icon" style="margin-left: 16px"></span>
   Screenshot
-  <span class="icon preview-icon" data="screenshot.png" onclick="showScreenshot('screenshot.png')"></span>
+  <span class="icon preview-icon" data="screenshot.png" onclick="showScreenshot(this.getAttribute('data'))"></span>
   <img class="screenshot" src="screenshot.png" id="screenshot-screenshot.png" loading="lazy"/>
 </p>
   </div>
@@ -1192,12 +1192,12 @@
       <p class="attachment list-item">
   <span class="icon left screenshot-icon" style="margin-left: 36px"></span>
   Screenshot
-  <span class="icon preview-icon" data="screenshot.png" onclick="showScreenshot('screenshot.png')"></span>
+  <span class="icon preview-icon" data="screenshot.png" onclick="showScreenshot(this.getAttribute('data'))"></span>
   <img class="screenshot" src="screenshot.png" id="screenshot-screenshot.png" loading="lazy"/>
 </p><p class="attachment list-item">
   <span class="icon left text-icon" style="margin-left: 36px"></span>
   Log
-  <span class="icon preview-icon" data="FileName with DoubleQuote"SingleQuote'LessThan<GreaterThan>Ampersand&.txt" onclick="showText('FileName with DoubleQuote"SingleQuote'LessThan<GreaterThan>Ampersand&.txt')"></span>
+  <span class="icon preview-icon" data="FileName with DoubleQuote&quot;SingleQuote&apos;LessThan&lt;GreaterThan&gt;Ampersand&amp;.txt" onclick="showText(this.getAttribute('data'))"></span>
 </p>
   </div>
   <div id="activities-65291edd1daadc2dda7056f8567bbbef" class="sub-activities">
@@ -1259,7 +1259,7 @@
       <p class="attachment list-item">
   <span class="icon left screenshot-icon" style="margin-left: 16px"></span>
   Screenshot
-  <span class="icon preview-icon" data="screenshot.png" onclick="showScreenshot('screenshot.png')"></span>
+  <span class="icon preview-icon" data="screenshot.png" onclick="showScreenshot(this.getAttribute('data'))"></span>
   <img class="screenshot" src="screenshot.png" id="screenshot-screenshot.png" loading="lazy"/>
 </p>
   </div>
@@ -1301,12 +1301,12 @@
       <p class="attachment list-item">
   <span class="icon left screenshot-icon" style="margin-left: 36px"></span>
   Screenshot
-  <span class="icon preview-icon" data="screenshot.png" onclick="showScreenshot('screenshot.png')"></span>
+  <span class="icon preview-icon" data="screenshot.png" onclick="showScreenshot(this.getAttribute('data'))"></span>
   <img class="screenshot" src="screenshot.png" id="screenshot-screenshot.png" loading="lazy"/>
 </p><p class="attachment list-item">
   <span class="icon left text-icon" style="margin-left: 36px"></span>
   Log
-  <span class="icon preview-icon" data="FileName with DoubleQuote"SingleQuote'LessThan<GreaterThan>Ampersand&.txt" onclick="showText('FileName with DoubleQuote"SingleQuote'LessThan<GreaterThan>Ampersand&.txt')"></span>
+  <span class="icon preview-icon" data="FileName with DoubleQuote&quot;SingleQuote&apos;LessThan&lt;GreaterThan&gt;Ampersand&amp;.txt" onclick="showText(this.getAttribute('data'))"></span>
 </p>
   </div>
   <div id="activities-eea257a844e0587dce9a918f430ad0a4" class="sub-activities">

--- a/Tests/XCTestHTMLReportTests/SummarySeamTests.swift
+++ b/Tests/XCTestHTMLReportTests/SummarySeamTests.swift
@@ -62,30 +62,14 @@ final class SummarySeamTests: XCTestCase {
 
     /// `SyntheticResultTests.testCoversHostileAttachmentFilename` proves the
     /// *fixture* contains a filename with `"` `'` `<` `>` `&`. This proves
-    /// the *render* escapes it — and it does not: `HTMLTemplates.swift`
-    /// interpolates the raw filename into `onclick="showText('[[SOURCE]]')"`
-    /// with no attribute escaping, so the embedded `"` breaks out of the
-    /// `onclick` attribute early. The committed goldens already contain the
-    /// broken markup this produces.
+    /// the *render* escapes it.
     ///
-    /// This is a known, pre-existing HTML-injection defect in
-    /// `HTMLTemplates.swift` / `Attachment.swift`, out of scope to fix here.
-    /// `XCTExpectFailure` records it without turning the suite red: today it
-    /// passes-as-expected-failure, and the moment someone fixes the
-    /// escaping, this assertion starts succeeding, `XCTExpectFailure` turns
-    /// that into a *failure* (an unexpectedly-passing expected failure), and
-    /// the fix has to update this test — which is the signal that the
-    /// defect is gone.
+    /// Until #463 it did not: `Attachment` handed the raw filename to the
+    /// substitution seam, so the embedded `"` terminated the attribute it
+    /// was written into and `<GreaterThan>` entered the DOM as an element.
+    /// The assertion was carried as an `XCTExpectFailure` from #461 until
+    /// the escaping landed.
     func testHostileAttachmentFilenameDoesNotBreakOutOfAttribute() {
-        XCTExpectFailure("""
-        Known defect: HTMLTemplates.swift does not attribute-escape \
-        attachment filenames, so a filename containing a double quote \
-        breaks out of the onclick="showText('...')" attribute. Fixing the \
-        escaping in HTMLTemplates.swift / Attachment.swift is out of scope \
-        here; when it is fixed, this test will start passing and should be \
-        promoted out of XCTExpectFailure.
-        """)
-
         let html = summary().generatedHtmlReport()
         XCTAssertFalse(
             html.contains("onclick=\"showText('FileName with DoubleQuote\""),

--- a/visual/tests/a11y.spec.ts
+++ b/visual/tests/a11y.spec.ts
@@ -5,28 +5,20 @@ import { resolve } from 'node:path';
 
 const reportURL = pathToFileURL(resolve(__dirname, '../fixtures/report.html')).href;
 
-// The first real run found real, uncorrected violations, so the gate is
-// deliberately open (GATING_IMPACTS = []) rather than asserting a clean
-// result that does not exist yet. Fixing them is #440's job, not this
-// spec's; this test's only job is to keep every finding visible so nothing
-// is silently lost. Known findings as of the first run:
+// The gate was held open (GATING_IMPACTS = []) from #461 until #462, because
+// the first real run found six uncorrected violations and a spec cannot
+// assert a clean result that does not exist yet. #462 cleared all six —
+// image-alt (critical, 6 nodes), frame-title (serious), heading-order,
+// landmark-one-main, region and empty-heading — so the gate is closed again
+// and any new critical or serious finding fails the build.
 //
-//   critical  image-alt          x6  — screenshot/gif/tail <img> elements
-//                                       and the No-Selected-Attachment state
-//                                       carry no alt text
-//   serious   frame-title        x1  — the text-attachment <iframe> has no
-//                                       accessible name
-//   moderate  heading-order          — heading levels skip
-//   moderate  landmark-one-main      — no <main> landmark
-//   moderate  region                 — content outside a landmark region
-//   minor     empty-heading          — a heading element with no text
-//
-// #440 tracks the fix. Restore the gate (e.g. back to
-// ['critical', 'serious']) once those are cleared — at which point this
-// test's name and body should go back to asserting zero violations.
-const GATING_IMPACTS: string[] = [];
+// Moderate and minor stay informational rather than gating. That is the
+// level #462 prescribed, and it keeps the failure mode proportionate: a
+// missing alt or an unnamed frame blocks a merge, a debatable landmark
+// question gets logged for a human to weigh.
+const GATING_IMPACTS: string[] = ['critical', 'serious'];
 
-test('reports accessibility violations (gate open pending #440)', async ({ page }) => {
+test('reports no critical or serious accessibility violations', async ({ page }) => {
   await page.goto(reportURL);
   const results = await new AxeBuilder({ page }).analyze();
 

--- a/visual/tests/injection.spec.ts
+++ b/visual/tests/injection.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect } from '@playwright/test';
+import { pathToFileURL } from 'node:url';
+import { resolve } from 'node:path';
+
+const reportURL = pathToFileURL(resolve(__dirname, '../fixtures/report.html')).href;
+
+// The synthetic fixture carries one attachment whose file name contains every
+// character that has to be escaped on the way into markup. Asserting on the
+// rendered source only proves the bytes changed; these assert on what the
+// browser actually built out of them.
+const HOSTILE_FILENAME =
+  'FileName with DoubleQuote"SingleQuote\'LessThan<GreaterThan>Ampersand&.txt';
+
+const previewIcons = (page: import('@playwright/test').Page) =>
+  page.locator('.attachment .preview-icon');
+
+test('a hostile attachment filename does not put an element in the DOM', async ({ page }) => {
+  await page.goto(reportURL);
+
+  // Unescaped, `<GreaterThan>` was parsed as a start tag: the parser built an
+  // element out of an attachment's name.
+  await expect(page.locator('greaterthan')).toHaveCount(0);
+});
+
+test('a hostile attachment filename reaches its attribute whole', async ({ page }) => {
+  await page.goto(reportURL);
+
+  const names = await previewIcons(page).evaluateAll((nodes) =>
+    nodes.map((node) => node.getAttribute('data')));
+
+  expect(names.length, 'the fixture must render attachment previews').toBeGreaterThan(0);
+  expect(
+    names,
+    'the embedded double quote must not terminate the attribute and truncate the name',
+  ).toContain(HOSTILE_FILENAME);
+});
+
+test('clicking a preview icon previews the attachment it names', async ({ page }) => {
+  await page.goto(reportURL);
+
+  const icons = previewIcons(page);
+  const index = (await icons.evaluateAll((nodes) =>
+    nodes.map((node) => node.getAttribute('data')))).indexOf(HOSTILE_FILENAME);
+  expect(index, 'the fixture must contain the hostile attachment').toBeGreaterThanOrEqual(0);
+
+  // Dispatched rather than clicked: the attachment sits inside a collapsed
+  // activity, and what is under test is the handler wiring, not the
+  // disclosure it lives behind.
+  await icons.nth(index).dispatchEvent('click');
+
+  await expect(
+    page.locator('#text-attachment'),
+    'the handler must open the file it names, not a prefix of it',
+  ).toHaveAttribute('src', HOSTILE_FILENAME);
+});


### PR DESCRIPTION
Closes #463.

An attachment filename containing `"` terminated the `data="…"` attribute it was written into, so the fixture's `<GreaterThan>` was parsed as a start tag and a spurious element entered the DOM. Since #458 publishes a rendered report to a public Pages URL on every merge, this is a stored-injection surface rather than a local-file curiosity.

## Escaping alone would have been a half-fix

`stringByEscapingXMLChars` maps `'` to `&apos;`, but a browser HTML-decodes an attribute value *before* compiling it as JavaScript. So `onclick="showText('&apos;;alert(1);&apos;')"` decodes straight back to a live breakout: escaping fixes `data="…"`, `src="…"` and `id="…"`, and cannot fix a value sitting inside a JS string literal.

So this is two halves:

**Escape every leaf value the seam substitutes.** Not just `Attachment`'s three, but the titles, log source, device fields and screenshot-flow sources contributed by `Test`, `Iteration`, `Run`, `RunDestination` and `TestScreenshotFlow` — the same seam feeds all of them, and a test title is as author-controlled as a filename. Values that are already rendered markup (`SUB_TESTS`, `ACTIVITIES`, `DEVICE_RESULT`, …) keep passing through untouched. Nothing in `HTML.swift` can enforce that split, so it now documents which of three cases a new placeholder falls into.

**Stop interpolating into handlers.** The five attachment templates now read the `data` attribute they already carry — `onclick="showScreenshot(this.getAttribute('data'))"` — instead of interpolating the filename into a JS string.

`toggle(this, '…')` and `selectDevice('…', this)` still interpolate, deliberately: what they pass is an `IdentifierPath.identifier`, the first 128 bits of a SHA-256 hex-encoded, which cannot contain a metacharacter. `testEveryIdentifierReachingAScriptHandlerIsAHexDigest` pins that shape so the assumption fails loudly if identifier generation ever changes.

## The injection and a broken feature were the same defect

A truncated `data` attribute meant clicking a preview opened a *prefix* of the filename. Both `data` and the `id="screenshot-…"` it looks up now carry the whole name, and they still agree because `getAttribute` returns the decoded value.

## Tests

- `SummarySeamTests.testHostileAttachmentFilenameDoesNotBreakOutOfAttribute` loses its `XCTExpectFailure` in the same commit — an unexpected pass would otherwise fail the suite on a correct fix.
- New `HTMLEscapingTests`: the hostile filename is escaped and no raw copy survives; no `onclick` carries attachment text; a run whose *every* leaf string is hostile renders escaped; identifiers reaching handlers are digests; and — guarding against over-correction — nested markup is still markup.
- New `visual/tests/injection.spec.ts`: no `<greaterthan>` element in the DOM, the whole filename reaches the attribute, and dispatching a click previews the file it names. All three fail against the pre-fix render; `behaviour.spec.ts` exercised no click path through `preview-icon`, so the handler change was otherwise unguarded in the browser.
- Both goldens refreshed; the diff is escaping and handler rewrites only.

Verified locally: 126 Swift tests, 0 failures (with generated `.xcresult` fixtures); 11 Playwright tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved report accessibility with semantic navigation landmarks, descriptive labels, media alt text, iframe titles, and lazy loading.
  * Enhanced attachment previews for screenshots, GIFs, videos, text files, and links while preserving filenames and content.

* **Bug Fixes**
  * Improved HTML escaping for attachment names, test titles, device details, log sources, and other report metadata.
  * Prevented special characters from creating unintended page elements or affecting attachment actions.

* **Documentation**
  * Clarified safe handling requirements for HTML placeholder values.

* **Tests**
  * Added coverage for HTML escaping, accessibility, attachment previews, and injection-resistant rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->