### PR TITLE
Clear the report's six axe-core accessibility violations and close the gate (fixes #462)

### DIFF
--- a/Sources/XCTestHTMLReportCore/Classes/HTMLTemplates.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/HTMLTemplates.swift
@@ -795,7 +795,8 @@ struct HTMLTemplates
       margin-right: -4px;
     }
 
-    #right-sidebar h2 {
+    #right-sidebar h2,
+    #file-attachment {
       color: var(--color-text-placeholder);
       font-weight: var(--font-weight-regular);
       font-size: var(--font-size-xl);
@@ -972,9 +973,10 @@ struct HTMLTemplates
         padding-bottom: 50vh;
       }
 
-      /* Both the placeholder and the file-download link are `h2`s the
-         desktop sheet centres absolutely; in a bottom sheet they flow. */
-      #right-sidebar h2 {
+      /* The placeholder and the file-download link are both centred
+         absolutely by the desktop sheet; in a bottom sheet they flow. */
+      #right-sidebar h2,
+      #file-attachment {
         position: static;
         width: auto;
         margin: var(--space-sm);
@@ -1004,30 +1006,30 @@ struct HTMLTemplates
         </ul>
       </header>
       <div id=\"container\">
-        <div id=\"left-sidebar\" class=\"sidebar\">
+        <nav id=\"left-sidebar\" class=\"sidebar\" aria-label=\"Devices\">
           <div class=\"resizer\"></div>
-          <h4 id=\"device-header\">Devices</h4>
+          <h2 id=\"device-header\">Devices</h2>
           <ul id=\"info-sections\">
             <li class=\"section\">
               [[DEVICES]]
             </li>
           </ul>
           <div id=\"report-issue\"><a href=\"https://github.com/TitouanVanBelle/XCTestHTMLReport/blob/master/CONTRIBUTING.md#reporting-issues\">Report an issue</a></div>
-        </div>
+        </nav>
 
-        <div id=\"main-content\">
+        <main id=\"main-content\">
           [[RUNS]]
-        </div>
+        </main>
 
-        <div id=\"right-sidebar\" class=\"sidebar\">
+        <aside id=\"right-sidebar\" class=\"sidebar\" aria-label=\"Attachment preview\">
           <div class=\"resizer\"></div>
           <h2>No Selected Attachment</h2>
-          <img src=\"\" class=\"displayed-screenshot\" id=\"screenshot\" loading=\"lazy\"/>
-          <img src=\"\" class=\"displayed-gif\" id=\"gif\" loading=\"lazy\"/>
-          <iframe id=\"text-attachment\" src=\"\" loading=\"lazy\"></iframe>
-          <h2 id=\"file-attachment\"><a target=\"_blank\"/></h2>
+          <img src=\"\" class=\"displayed-screenshot\" id=\"screenshot\" alt=\"\" loading=\"lazy\"/>
+          <img src=\"\" class=\"displayed-gif\" id=\"gif\" alt=\"\" loading=\"lazy\"/>
+          <iframe id=\"text-attachment\" src=\"\" title=\"Selected attachment\" loading=\"lazy\"></iframe>
+          <p id=\"file-attachment\"><a target=\"_blank\"></a></p>
           <video class=\"displayed-video\" controls src=\"\" id=\"video\" preload=\"none\"/>
-        </div>
+        </aside>
         <div class=\"clear\"></div>
       </div>
     </div>
@@ -1311,6 +1313,7 @@ struct HTMLTemplates
       var image = document.getElementById('screenshot-'+filename);
       screenshot.style.display = \"block\";
       screenshot.src = image.src;
+      screenshot.alt = image.alt;
     }
 
     function showVideo(filename) {
@@ -1334,6 +1337,7 @@ struct HTMLTemplates
     var gf = document.getElementById('gif-'+filename);
     gif.style.display = \"block\";
     gif.src = gf.src;
+    gif.alt = gf.alt;
     gif.play();
     }
     
@@ -1490,7 +1494,7 @@ struct HTMLTemplates
           <li class=\"selected\">All Messages</li>
         </ul>
       </div>
-      <iframe id=\"logs-iframe\" src=\"[[LOG_SOURCE]]\" loading=\"lazy\"></iframe>
+      <iframe id=\"logs-iframe\" src=\"[[LOG_SOURCE]]\" title=\"Run log\" loading=\"lazy\"></iframe>
     </div>
   </div>
   """
@@ -1580,7 +1584,7 @@ struct HTMLTemplates
     <span class=\"icon left screenshot-icon\" style=\"margin-left: [[PADDING]]px\"></span>
     [[NAME]]
     <span class=\"icon preview-icon\" data=\"[[FILENAME]]\" onclick=\"showScreenshot(this.getAttribute('data'))\"></span>
-    <img class=\"screenshot\" src=\"[[SOURCE]]\" id=\"screenshot-[[FILENAME]]\" loading=\"lazy\"/>
+    <img class=\"screenshot\" src=\"[[SOURCE]]\" id=\"screenshot-[[FILENAME]]\" alt=\"[[NAME]]\" loading=\"lazy\"/>
   </p>
   """
 
@@ -1589,7 +1593,7 @@ struct HTMLTemplates
     <span class="icon left screenshot-icon" style="margin-left: [[PADDING]]px"></span>
     [[NAME]]
   <span class=\"icon preview-icon\" data=\"[[FILENAME]]\" onclick=\"showGif(this.getAttribute('data'))\"></span>
-    <img class=\"gif\" src=\"[[SOURCE]]\" id=\"gif-[[FILENAME]]\" loading=\"lazy\"/>
+    <img class=\"gif\" src=\"[[SOURCE]]\" id=\"gif-[[FILENAME]]\" alt=\"[[NAME]]\" loading=\"lazy\"/>
   </p>
   """
 

--- a/Sources/XCTestHTMLReportCore/Classes/Models/TestScreenshotFlow.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Models/TestScreenshotFlow.swift
@@ -45,13 +45,18 @@ struct ScreenshotFlowAttachment: HTML {
     let className: String
 
     var htmlTemplate: String {
-        "<img class=\"\(className)\" src=\"[[SRC]]\" id=\"screenshot-[[FILENAME]]\" loading=\"lazy\"/>"
+        "<img class=\"\(className)\" src=\"[[SRC]]\" id=\"screenshot-[[FILENAME]]\" "
+            + "alt=\"[[NAME]]\" loading=\"lazy\"/>"
     }
 
     var htmlPlaceholderValues: [String: String] {
         [
             "SRC": (attachment.source ?? "").stringByEscapingXMLChars,
             "FILENAME": attachment.filename.stringByEscapingXMLChars,
+            // The display name, not the file name: a real `.xcresult` names
+            // its payloads with an 80-character opaque id, and reading that
+            // aloud is worse than the missing `alt` this replaces.
+            "NAME": attachment.displayName.stringByEscapingXMLChars,
         ]
     }
 }

--- a/Tests/XCTestHTMLReportTests/AccessibilitySeamTests.swift
+++ b/Tests/XCTestHTMLReportTests/AccessibilitySeamTests.swift
@@ -1,0 +1,65 @@
+//
+//  AccessibilitySeamTests.swift
+//
+//  The authority on the report's accessibility is `visual/tests/a11y.spec.ts`,
+//  which runs axe-core against a real browser. These are the two rules from it
+//  that can be checked on the markup alone, restated here so they hold in the
+//  `test` jobs too: `visual` is a separate workflow, and a template can lose an
+//  `alt` in a change that never runs a browser.
+//
+
+import XCTest
+@testable import XCTestHTMLReportCore
+
+final class AccessibilitySeamTests: XCTestCase {
+    private func renderedReport() -> String {
+        Summary(
+            parsedRuns: [SyntheticResult.parsedRun],
+            payloads: SyntheticResult.payloads,
+            renderingMode: .linking,
+            downsizeImagesEnabled: false,
+            downsizeScaleFactor: 0.5,
+            bundleNames: ["Synthetic"]
+        ).generatedHtmlReport()
+    }
+
+    /// Every `<tag …>` in the document, as its full source text.
+    private func elements(named tag: String, in html: String) throws -> [String] {
+        let regex = try NSRegularExpression(pattern: "<\(tag)\\b[^>]*>")
+        let range = NSRange(html.startIndex ..< html.endIndex, in: html)
+        return regex.matches(in: html, range: range).compactMap { match in
+            Range(match.range, in: html).map { String(html[$0]) }
+        }
+    }
+
+    /// axe-core `image-alt`. An empty `alt=""` counts: it is how a decorative
+    /// image declares itself, which is what the two preview placeholders are
+    /// until a screenshot is put in them.
+    func testEveryImageCarriesAnAltAttribute() throws {
+        let images = try elements(named: "img", in: renderedReport())
+        XCTAssertFalse(images.isEmpty, "the fixture must render images to be worth checking")
+
+        let missing = images.filter { !$0.contains("alt=") }
+        XCTAssertEqual(missing, [], "every <img> needs alt text, even if empty")
+    }
+
+    /// axe-core `frame-title`. A frame with no accessible name is announced as
+    /// nothing but "frame", so a screen reader user cannot tell the log pane
+    /// from the attachment pane.
+    func testEveryFrameCarriesATitleAttribute() throws {
+        let frames = try elements(named: "iframe", in: renderedReport())
+        XCTAssertFalse(frames.isEmpty, "the report must still render its frames")
+
+        let missing = frames.filter { !$0.contains("title=") }
+        XCTAssertEqual(missing, [], "every <iframe> needs an accessible name")
+    }
+
+    /// axe-core `landmark-one-main`, in the one form that survives outside a
+    /// browser: the element has to exist at all.
+    func testDocumentHasAMainLandmark() {
+        XCTAssertTrue(
+            renderedReport().contains("<main"),
+            "the report's content needs a main landmark to skip to"
+        )
+    }
+}

--- a/Tests/XCTestHTMLReportTests/KnownLossMasker.swift
+++ b/Tests/XCTestHTMLReportTests/KnownLossMasker.swift
@@ -93,10 +93,21 @@ enum KnownLossMasker {
             // between the `<p>` and the name — so the anchor spans both
             // preceding lines. Anchoring on the icon span also keeps the rule
             // from ever touching a non-attachment `<p>`.
-            return replace(
+            let namedLines = replace(
                 html,
                 #"(<p class="attachment[^"]*">\n\s*<span class="icon left [a-z-]*icon"[^\n]*></span>\n)[^\n]*\n"#,
                 with: "$1ATTACHMENT_NAME\n"
+            )
+            // One divergence, two sites since #462: the same display name is
+            // also the `alt` of every attachment-derived image. Masking only
+            // the text line would let the `alt` reintroduce the difference
+            // this entry already accounts for. Matched on an exact class so
+            // the two `displayed-*` preview panes — whose `alt` is empty in
+            // both backends — stay compared.
+            return replace(
+                namedLines,
+                #"(<img class="(?:screenshot|screenshot-flow|screenshot-tail|gif)"[^\n]*?)alt="[^"]*""#,
+                with: "$1alt=\"ATTACHMENT_NAME\""
             )
         case "failureTitlePrefix":
             // Two shapes, not one. Verified on `TestResults`:

--- a/Tests/XCTestHTMLReportTests/Snapshots/index-inline.html
+++ b/Tests/XCTestHTMLReportTests/Snapshots/index-inline.html
@@ -788,7 +788,8 @@
     margin-right: -4px;
   }
 
-  #right-sidebar h2 {
+  #right-sidebar h2,
+  #file-attachment {
     color: var(--color-text-placeholder);
     font-weight: var(--font-weight-regular);
     font-size: var(--font-size-xl);
@@ -965,9 +966,10 @@
       padding-bottom: 50vh;
     }
 
-    /* Both the placeholder and the file-download link are `h2`s the
-       desktop sheet centres absolutely; in a bottom sheet they flow. */
-    #right-sidebar h2 {
+    /* The placeholder and the file-download link are both centred
+       absolutely by the desktop sheet; in a bottom sheet they flow. */
+    #right-sidebar h2,
+    #file-attachment {
       position: static;
       width: auto;
       margin: var(--space-sm);
@@ -997,9 +999,9 @@
       </ul>
     </header>
     <div id="container">
-      <div id="left-sidebar" class="sidebar">
+      <nav id="left-sidebar" class="sidebar" aria-label="Devices">
         <div class="resizer"></div>
-        <h4 id="device-header">Devices</h4>
+        <h2 id="device-header">Devices</h2>
         <ul id="info-sections">
           <li class="section">
               <ul class="device-info" onclick="selectDevice('42230e298d9d9e832714ebad20e680c6', this);">
@@ -1011,9 +1013,9 @@
           </li>
         </ul>
         <div id="report-issue"><a href="https://github.com/TitouanVanBelle/XCTestHTMLReport/blob/master/CONTRIBUTING.md#reporting-issues">Report an issue</a></div>
-      </div>
+      </nav>
 
-      <div id="main-content">
+      <main id="main-content">
         <div class="run" id="device_42230e298d9d9e832714ebad20e680c6">
   <div class="tests">
     <div class="tests-header">
@@ -1037,7 +1039,7 @@
           <span class="icon left test-icon"></span>
           SyntheticSuite (6.00s)
       </p>
-        <img class="screenshot-tail" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" loading="lazy"/>
+        <img class="screenshot-tail" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
   <div class="test-summary expected-failure">
       <span class="icon left test-result-icon"></span>
       <p class="list-item">
@@ -1046,7 +1048,7 @@
           testExpectedlyFails() (1.50s)
       </p>
       <div id="activities-1c6cdccfeb05445c9896526289e8c191" class="activities">
-          <img class="screenshot-flow" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" loading="lazy"/>
+          <img class="screenshot-flow" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
           <div class="activity activity-assertion-failure ">
   <p class="list-item">
     <span style="margin-left: 0px" class="padding"></span>
@@ -1059,7 +1061,7 @@
   <span class="icon left screenshot-icon" style="margin-left: 16px"></span>
   Screenshot
   <span class="icon preview-icon" data="screenshot.png" onclick="showScreenshot(this.getAttribute('data'))"></span>
-  <img class="screenshot" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" loading="lazy"/>
+  <img class="screenshot" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
 </p>
   </div>
   <div id="activities-eab1e43262f622153d7b29bf5870292c" class="sub-activities">
@@ -1067,7 +1069,7 @@
   </div>
 </div>
       </div>
-  </div>  <img class="screenshot-tail" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" loading="lazy"/><img class="screenshot-tail" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" loading="lazy"/>
+  </div>  <img class="screenshot-tail" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/><img class="screenshot-tail" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
   <div class="test-summary failed">
       <span class="icon left test-result-icon"></span>
       <p class="list-item">
@@ -1076,7 +1078,7 @@
           testFails() (1.50s)
       </p>
       <div id="activities-4abdbdaebf10baf0f23017525cf4a9be" class="activities">
-          <img class="screenshot-flow" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" loading="lazy"/><img class="screenshot-flow" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" loading="lazy"/>
+          <img class="screenshot-flow" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/><img class="screenshot-flow" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
           <div class="activity  no-drop-down">
   <p class="list-item">
     <span style="margin-left: 38px" class="padding"></span>
@@ -1102,7 +1104,7 @@
   <span class="icon left screenshot-icon" style="margin-left: 36px"></span>
   Screenshot
   <span class="icon preview-icon" data="screenshot.png" onclick="showScreenshot(this.getAttribute('data'))"></span>
-  <img class="screenshot" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" loading="lazy"/>
+  <img class="screenshot" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
 </p><p class="attachment list-item">
   <span class="icon left text-icon" style="margin-left: 36px"></span>
   Log
@@ -1150,7 +1152,7 @@
   <span class="icon left screenshot-icon" style="margin-left: 16px"></span>
   Screenshot
   <span class="icon preview-icon" data="screenshot.png" onclick="showScreenshot(this.getAttribute('data'))"></span>
-  <img class="screenshot" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" loading="lazy"/>
+  <img class="screenshot" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
 </p>
   </div>
   <div id="activities-35ad28c1a36df8df00034ad8eb0a2ffb" class="sub-activities">
@@ -1158,7 +1160,7 @@
   </div>
 </div>
       </div>
-  </div>  <img class="screenshot-tail" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" loading="lazy"/>
+  </div>  <img class="screenshot-tail" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
   <div class="test-summary succeeded">
       <span class="icon left test-result-icon"></span>
       <p class="list-item">
@@ -1167,7 +1169,7 @@
           testPasses() (1.50s)
       </p>
       <div id="activities-16170791d4b96668f53ace117678c387" class="activities">
-          <img class="screenshot-flow" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" loading="lazy"/>
+          <img class="screenshot-flow" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
           <div class="activity  no-drop-down">
   <p class="list-item">
     <span style="margin-left: 38px" class="padding"></span>
@@ -1193,7 +1195,7 @@
   <span class="icon left screenshot-icon" style="margin-left: 36px"></span>
   Screenshot
   <span class="icon preview-icon" data="screenshot.png" onclick="showScreenshot(this.getAttribute('data'))"></span>
-  <img class="screenshot" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" loading="lazy"/>
+  <img class="screenshot" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
 </p><p class="attachment list-item">
   <span class="icon left text-icon" style="margin-left: 36px"></span>
   Log
@@ -1247,7 +1249,7 @@
           Iteration 1 (1.50s)
       </p>
       <div id="activities-98ade9823d518704e870971ef0c6984c" class="activities">
-          <img class="screenshot-flow" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" loading="lazy"/>
+          <img class="screenshot-flow" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
           <div class="activity activity-assertion-failure ">
   <p class="list-item">
     <span style="margin-left: 0px" class="padding"></span>
@@ -1260,7 +1262,7 @@
   <span class="icon left screenshot-icon" style="margin-left: 16px"></span>
   Screenshot
   <span class="icon preview-icon" data="screenshot.png" onclick="showScreenshot(this.getAttribute('data'))"></span>
-  <img class="screenshot" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" loading="lazy"/>
+  <img class="screenshot" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
 </p>
   </div>
   <div id="activities-d52daa3211c83b468e246ec5568bb84b" class="sub-activities">
@@ -1276,7 +1278,7 @@
           Iteration 2 (1.50s)
       </p>
       <div id="activities-34758e281c83108eeca0f231788a3a00" class="activities">
-          <img class="screenshot-flow" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" loading="lazy"/>
+          <img class="screenshot-flow" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
           <div class="activity  no-drop-down">
   <p class="list-item">
     <span style="margin-left: 38px" class="padding"></span>
@@ -1302,7 +1304,7 @@
   <span class="icon left screenshot-icon" style="margin-left: 36px"></span>
   Screenshot
   <span class="icon preview-icon" data="screenshot.png" onclick="showScreenshot(this.getAttribute('data'))"></span>
-  <img class="screenshot" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" loading="lazy"/>
+  <img class="screenshot" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
 </p><p class="attachment list-item">
   <span class="icon left text-icon" style="margin-left: 36px"></span>
   Log
@@ -1364,20 +1366,20 @@
         <li class="selected">All Messages</li>
       </ul>
     </div>
-    <iframe id="logs-iframe" src="data:text/plain;base64,U3ludGhldGljIHJ1biBsb2cgbGluZSBvbmUKU3ludGhldGljIHJ1biBsb2cgbGluZSB0d28K" loading="lazy"></iframe>
+    <iframe id="logs-iframe" src="data:text/plain;base64,U3ludGhldGljIHJ1biBsb2cgbGluZSBvbmUKU3ludGhldGljIHJ1biBsb2cgbGluZSB0d28K" title="Run log" loading="lazy"></iframe>
   </div>
 </div>
-      </div>
+      </main>
 
-      <div id="right-sidebar" class="sidebar">
+      <aside id="right-sidebar" class="sidebar" aria-label="Attachment preview">
         <div class="resizer"></div>
         <h2>No Selected Attachment</h2>
-        <img src="" class="displayed-screenshot" id="screenshot" loading="lazy"/>
-        <img src="" class="displayed-gif" id="gif" loading="lazy"/>
-        <iframe id="text-attachment" src="" loading="lazy"></iframe>
-        <h2 id="file-attachment"><a target="_blank"/></h2>
+        <img src="" class="displayed-screenshot" id="screenshot" alt="" loading="lazy"/>
+        <img src="" class="displayed-gif" id="gif" alt="" loading="lazy"/>
+        <iframe id="text-attachment" src="" title="Selected attachment" loading="lazy"></iframe>
+        <p id="file-attachment"><a target="_blank"></a></p>
         <video class="displayed-video" controls src="" id="video" preload="none"/>
-      </div>
+      </aside>
       <div class="clear"></div>
     </div>
   </div>
@@ -1661,6 +1663,7 @@
     var image = document.getElementById('screenshot-'+filename);
     screenshot.style.display = "block";
     screenshot.src = image.src;
+    screenshot.alt = image.alt;
   }
 
   function showVideo(filename) {
@@ -1684,6 +1687,7 @@
   var gf = document.getElementById('gif-'+filename);
   gif.style.display = "block";
   gif.src = gf.src;
+  gif.alt = gf.alt;
   gif.play();
   }
   

--- a/Tests/XCTestHTMLReportTests/Snapshots/index.html
+++ b/Tests/XCTestHTMLReportTests/Snapshots/index.html
@@ -788,7 +788,8 @@
     margin-right: -4px;
   }
 
-  #right-sidebar h2 {
+  #right-sidebar h2,
+  #file-attachment {
     color: var(--color-text-placeholder);
     font-weight: var(--font-weight-regular);
     font-size: var(--font-size-xl);
@@ -965,9 +966,10 @@
       padding-bottom: 50vh;
     }
 
-    /* Both the placeholder and the file-download link are `h2`s the
-       desktop sheet centres absolutely; in a bottom sheet they flow. */
-    #right-sidebar h2 {
+    /* The placeholder and the file-download link are both centred
+       absolutely by the desktop sheet; in a bottom sheet they flow. */
+    #right-sidebar h2,
+    #file-attachment {
       position: static;
       width: auto;
       margin: var(--space-sm);
@@ -997,9 +999,9 @@
       </ul>
     </header>
     <div id="container">
-      <div id="left-sidebar" class="sidebar">
+      <nav id="left-sidebar" class="sidebar" aria-label="Devices">
         <div class="resizer"></div>
-        <h4 id="device-header">Devices</h4>
+        <h2 id="device-header">Devices</h2>
         <ul id="info-sections">
           <li class="section">
               <ul class="device-info" onclick="selectDevice('42230e298d9d9e832714ebad20e680c6', this);">
@@ -1011,9 +1013,9 @@
           </li>
         </ul>
         <div id="report-issue"><a href="https://github.com/TitouanVanBelle/XCTestHTMLReport/blob/master/CONTRIBUTING.md#reporting-issues">Report an issue</a></div>
-      </div>
+      </nav>
 
-      <div id="main-content">
+      <main id="main-content">
         <div class="run" id="device_42230e298d9d9e832714ebad20e680c6">
   <div class="tests">
     <div class="tests-header">
@@ -1037,7 +1039,7 @@
           <span class="icon left test-icon"></span>
           SyntheticSuite (6.00s)
       </p>
-        <img class="screenshot-tail" src="screenshot.png" id="screenshot-screenshot.png" loading="lazy"/>
+        <img class="screenshot-tail" src="screenshot.png" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
   <div class="test-summary expected-failure">
       <span class="icon left test-result-icon"></span>
       <p class="list-item">
@@ -1046,7 +1048,7 @@
           testExpectedlyFails() (1.50s)
       </p>
       <div id="activities-1c6cdccfeb05445c9896526289e8c191" class="activities">
-          <img class="screenshot-flow" src="screenshot.png" id="screenshot-screenshot.png" loading="lazy"/>
+          <img class="screenshot-flow" src="screenshot.png" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
           <div class="activity activity-assertion-failure ">
   <p class="list-item">
     <span style="margin-left: 0px" class="padding"></span>
@@ -1059,7 +1061,7 @@
   <span class="icon left screenshot-icon" style="margin-left: 16px"></span>
   Screenshot
   <span class="icon preview-icon" data="screenshot.png" onclick="showScreenshot(this.getAttribute('data'))"></span>
-  <img class="screenshot" src="screenshot.png" id="screenshot-screenshot.png" loading="lazy"/>
+  <img class="screenshot" src="screenshot.png" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
 </p>
   </div>
   <div id="activities-eab1e43262f622153d7b29bf5870292c" class="sub-activities">
@@ -1067,7 +1069,7 @@
   </div>
 </div>
       </div>
-  </div>  <img class="screenshot-tail" src="screenshot.png" id="screenshot-screenshot.png" loading="lazy"/><img class="screenshot-tail" src="screenshot.png" id="screenshot-screenshot.png" loading="lazy"/>
+  </div>  <img class="screenshot-tail" src="screenshot.png" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/><img class="screenshot-tail" src="screenshot.png" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
   <div class="test-summary failed">
       <span class="icon left test-result-icon"></span>
       <p class="list-item">
@@ -1076,7 +1078,7 @@
           testFails() (1.50s)
       </p>
       <div id="activities-4abdbdaebf10baf0f23017525cf4a9be" class="activities">
-          <img class="screenshot-flow" src="screenshot.png" id="screenshot-screenshot.png" loading="lazy"/><img class="screenshot-flow" src="screenshot.png" id="screenshot-screenshot.png" loading="lazy"/>
+          <img class="screenshot-flow" src="screenshot.png" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/><img class="screenshot-flow" src="screenshot.png" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
           <div class="activity  no-drop-down">
   <p class="list-item">
     <span style="margin-left: 38px" class="padding"></span>
@@ -1102,7 +1104,7 @@
   <span class="icon left screenshot-icon" style="margin-left: 36px"></span>
   Screenshot
   <span class="icon preview-icon" data="screenshot.png" onclick="showScreenshot(this.getAttribute('data'))"></span>
-  <img class="screenshot" src="screenshot.png" id="screenshot-screenshot.png" loading="lazy"/>
+  <img class="screenshot" src="screenshot.png" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
 </p><p class="attachment list-item">
   <span class="icon left text-icon" style="margin-left: 36px"></span>
   Log
@@ -1150,7 +1152,7 @@
   <span class="icon left screenshot-icon" style="margin-left: 16px"></span>
   Screenshot
   <span class="icon preview-icon" data="screenshot.png" onclick="showScreenshot(this.getAttribute('data'))"></span>
-  <img class="screenshot" src="screenshot.png" id="screenshot-screenshot.png" loading="lazy"/>
+  <img class="screenshot" src="screenshot.png" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
 </p>
   </div>
   <div id="activities-35ad28c1a36df8df00034ad8eb0a2ffb" class="sub-activities">
@@ -1158,7 +1160,7 @@
   </div>
 </div>
       </div>
-  </div>  <img class="screenshot-tail" src="screenshot.png" id="screenshot-screenshot.png" loading="lazy"/>
+  </div>  <img class="screenshot-tail" src="screenshot.png" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
   <div class="test-summary succeeded">
       <span class="icon left test-result-icon"></span>
       <p class="list-item">
@@ -1167,7 +1169,7 @@
           testPasses() (1.50s)
       </p>
       <div id="activities-16170791d4b96668f53ace117678c387" class="activities">
-          <img class="screenshot-flow" src="screenshot.png" id="screenshot-screenshot.png" loading="lazy"/>
+          <img class="screenshot-flow" src="screenshot.png" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
           <div class="activity  no-drop-down">
   <p class="list-item">
     <span style="margin-left: 38px" class="padding"></span>
@@ -1193,7 +1195,7 @@
   <span class="icon left screenshot-icon" style="margin-left: 36px"></span>
   Screenshot
   <span class="icon preview-icon" data="screenshot.png" onclick="showScreenshot(this.getAttribute('data'))"></span>
-  <img class="screenshot" src="screenshot.png" id="screenshot-screenshot.png" loading="lazy"/>
+  <img class="screenshot" src="screenshot.png" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
 </p><p class="attachment list-item">
   <span class="icon left text-icon" style="margin-left: 36px"></span>
   Log
@@ -1247,7 +1249,7 @@
           Iteration 1 (1.50s)
       </p>
       <div id="activities-98ade9823d518704e870971ef0c6984c" class="activities">
-          <img class="screenshot-flow" src="screenshot.png" id="screenshot-screenshot.png" loading="lazy"/>
+          <img class="screenshot-flow" src="screenshot.png" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
           <div class="activity activity-assertion-failure ">
   <p class="list-item">
     <span style="margin-left: 0px" class="padding"></span>
@@ -1260,7 +1262,7 @@
   <span class="icon left screenshot-icon" style="margin-left: 16px"></span>
   Screenshot
   <span class="icon preview-icon" data="screenshot.png" onclick="showScreenshot(this.getAttribute('data'))"></span>
-  <img class="screenshot" src="screenshot.png" id="screenshot-screenshot.png" loading="lazy"/>
+  <img class="screenshot" src="screenshot.png" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
 </p>
   </div>
   <div id="activities-d52daa3211c83b468e246ec5568bb84b" class="sub-activities">
@@ -1276,7 +1278,7 @@
           Iteration 2 (1.50s)
       </p>
       <div id="activities-34758e281c83108eeca0f231788a3a00" class="activities">
-          <img class="screenshot-flow" src="screenshot.png" id="screenshot-screenshot.png" loading="lazy"/>
+          <img class="screenshot-flow" src="screenshot.png" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
           <div class="activity  no-drop-down">
   <p class="list-item">
     <span style="margin-left: 38px" class="padding"></span>
@@ -1302,7 +1304,7 @@
   <span class="icon left screenshot-icon" style="margin-left: 36px"></span>
   Screenshot
   <span class="icon preview-icon" data="screenshot.png" onclick="showScreenshot(this.getAttribute('data'))"></span>
-  <img class="screenshot" src="screenshot.png" id="screenshot-screenshot.png" loading="lazy"/>
+  <img class="screenshot" src="screenshot.png" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
 </p><p class="attachment list-item">
   <span class="icon left text-icon" style="margin-left: 36px"></span>
   Log
@@ -1364,20 +1366,20 @@
         <li class="selected">All Messages</li>
       </ul>
     </div>
-    <iframe id="logs-iframe" src="20264b52b84cb3e65c5ff06be4bb344d.log" loading="lazy"></iframe>
+    <iframe id="logs-iframe" src="20264b52b84cb3e65c5ff06be4bb344d.log" title="Run log" loading="lazy"></iframe>
   </div>
 </div>
-      </div>
+      </main>
 
-      <div id="right-sidebar" class="sidebar">
+      <aside id="right-sidebar" class="sidebar" aria-label="Attachment preview">
         <div class="resizer"></div>
         <h2>No Selected Attachment</h2>
-        <img src="" class="displayed-screenshot" id="screenshot" loading="lazy"/>
-        <img src="" class="displayed-gif" id="gif" loading="lazy"/>
-        <iframe id="text-attachment" src="" loading="lazy"></iframe>
-        <h2 id="file-attachment"><a target="_blank"/></h2>
+        <img src="" class="displayed-screenshot" id="screenshot" alt="" loading="lazy"/>
+        <img src="" class="displayed-gif" id="gif" alt="" loading="lazy"/>
+        <iframe id="text-attachment" src="" title="Selected attachment" loading="lazy"></iframe>
+        <p id="file-attachment"><a target="_blank"></a></p>
         <video class="displayed-video" controls src="" id="video" preload="none"/>
-      </div>
+      </aside>
       <div class="clear"></div>
     </div>
   </div>
@@ -1661,6 +1663,7 @@
     var image = document.getElementById('screenshot-'+filename);
     screenshot.style.display = "block";
     screenshot.src = image.src;
+    screenshot.alt = image.alt;
   }
 
   function showVideo(filename) {
@@ -1684,6 +1687,7 @@
   var gf = document.getElementById('gif-'+filename);
   gif.style.display = "block";
   gif.src = gf.src;
+  gif.alt = gf.alt;
   gif.play();
   }
   

--- a/visual/tests/a11y.spec.ts
+++ b/visual/tests/a11y.spec.ts
@@ -5,28 +5,20 @@ import { resolve } from 'node:path';
 
 const reportURL = pathToFileURL(resolve(__dirname, '../fixtures/report.html')).href;
 
-// The first real run found real, uncorrected violations, so the gate is
-// deliberately open (GATING_IMPACTS = []) rather than asserting a clean
-// result that does not exist yet. Fixing them is #440's job, not this
-// spec's; this test's only job is to keep every finding visible so nothing
-// is silently lost. Known findings as of the first run:
+// The gate was held open (GATING_IMPACTS = []) from #461 until #462, because
+// the first real run found six uncorrected violations and a spec cannot
+// assert a clean result that does not exist yet. #462 cleared all six —
+// image-alt (critical, 6 nodes), frame-title (serious), heading-order,
+// landmark-one-main, region and empty-heading — so the gate is closed again
+// and any new critical or serious finding fails the build.
 //
-//   critical  image-alt          x6  — screenshot/gif/tail <img> elements
-//                                       and the No-Selected-Attachment state
-//                                       carry no alt text
-//   serious   frame-title        x1  — the text-attachment <iframe> has no
-//                                       accessible name
-//   moderate  heading-order          — heading levels skip
-//   moderate  landmark-one-main      — no <main> landmark
-//   moderate  region                 — content outside a landmark region
-//   minor     empty-heading          — a heading element with no text
-//
-// #440 tracks the fix. Restore the gate (e.g. back to
-// ['critical', 'serious']) once those are cleared — at which point this
-// test's name and body should go back to asserting zero violations.
-const GATING_IMPACTS: string[] = [];
+// Moderate and minor stay informational rather than gating. That is the
+// level #462 prescribed, and it keeps the failure mode proportionate: a
+// missing alt or an unnamed frame blocks a merge, a debatable landmark
+// question gets logged for a human to weigh.
+const GATING_IMPACTS: string[] = ['critical', 'serious'];
 
-test('reports accessibility violations (gate open pending #440)', async ({ page }) => {
+test('reports no critical or serious accessibility violations', async ({ page }) => {
   await page.goto(reportURL);
   const results = await new AxeBuilder({ page }).analyze();
 


### PR DESCRIPTION
Closes #462. Stacked on #466 — both touch `HTMLTemplates.swift` and both invalidate the same two goldens, so they cannot be reviewed against `main` independently. Retarget to `main` once #466 merges.

`HTMLTemplates.swift` contained zero `alt=` and zero `title=` attributes anywhere in the file, which was the whole cause of both gating findings. All six violations are fixed.

| rule | impact | fix |
|---|---|---|
| `image-alt` | critical, 6 nodes | every `<img>` carries `alt` |
| `frame-title` | serious | `#text-attachment` and `#logs-iframe` are named |
| `heading-order` | moderate | `#device-header` h4 → h2, so levels no longer skip h1→h4 |
| `landmark-one-main` | moderate | `#main-content` div → `<main>` |
| `region` | moderate | sidebars → `<nav>` / `<aside>` with `aria-label`s |
| `empty-heading` | minor | `#file-attachment` h2 → `p` |

axe now reports **zero** violations at any impact, not just zero gating ones.

## Choices worth a second look

**Alt text is the display name, not the file name.** A real `.xcresult` names its payloads with an 80-character opaque id; reading that aloud is worse than the missing `alt` it replaces. `TestScreenshotFlow` gained a `NAME` placeholder for this. The two preview panes ship `alt=""` — how a decorative placeholder declares itself — and inherit the name of whatever `showScreenshot`/`showGif` puts in them.

**`#file-attachment` is a `p` now.** It holds a download link, not a section heading; it was empty at load because its text is set by JS. The two CSS rules that centred it as a heading name it directly instead, so it looks identical, and `querySelector("#right-sidebar h2")` still resolves to the placeholder.

**Landmarks changed elements, nothing else.** Every CSS rule and script hook involved is id- or class-based.

## The gate

`GATING_IMPACTS` goes back to `['critical', 'serious']`, so a new critical or serious finding fails the build. Left at `[]` the expectation was `expect([]).toEqual([])`, which cannot fail. Moderate and minor stay informational — the level #462 prescribed, and it keeps the failure mode proportionate. The test's name asserts what it checks again.

The two rules that survive without a browser are also restated as `AccessibilitySeamTests`, so they hold in the `test` jobs and not only in `visual`, which is a separate workflow.

## One knock-on worth flagging

`alt` puts the attachment display name in a second place, and that name is a divergence the modern reader **already** declares. `DifferentialTests` caught it immediately. The `attachmentDisplayNames` allow-list entry now masks both sites; masking only the text line would have let `alt` reintroduce a difference already accounted for. No new allow-list entry, and `testEveryAllowListEntryStillMasksARealDivergence` still passes.

Verified locally: 129 Swift tests, 0 failures; 11 Playwright tests, 0 failures. Goldens refreshed and read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)