### PR TITLE
Reject stub fixture bundles at the verify gate (fixes #454)

### DIFF
--- a/.github/workflows/pages-release.yml
+++ b/.github/workflows/pages-release.yml
@@ -50,13 +50,15 @@ jobs:
     - name: Generate test fixtures
       run: ./prepareTestResults.sh
 
+    # Same script as the other three workflows, scoped to the one bundle this
+    # job publishes: there is no cache here to poison, and failing a release
+    # over a stub Sanity or Retry bundle nothing in this job reads would be a
+    # false blocker. The render below is pushed immutably, so a stub that got
+    # through would sit under /v/<tag>/ as a permanently empty demo (#454).
     - name: Verify fixture
       run: |
-        plist="Tests/XCTestHTMLReportTests/Resources/TestResults.xcresult/Info.plist"
-        if [ ! -f "$plist" ]; then
-          echo "::error::missing or incomplete fixture: TestResults.xcresult"
-          exit 1
-        fi
+        ./scripts/verify_fixtures.sh \
+          Tests/XCTestHTMLReportTests/Resources/TestResults.xcresult
 
     - name: Build
       run: swift build -c release --product xchtmlreport

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -86,15 +86,17 @@ jobs:
       if: steps.fixture-cache.outputs.cache-hit != 'true'
       run: ./prepareTestResults.sh
 
-    # Only TestResults is rendered, so only TestResults has to be here. A cache
-    # hit that restored nothing would otherwise publish an empty report.
-    - name: Verify fixture
-      run: |
-        plist="Tests/XCTestHTMLReportTests/Resources/TestResults.xcresult/Info.plist"
-        if [ ! -f "$plist" ]; then
-          echo "::error::missing or incomplete fixture: TestResults.xcresult"
-          exit 1
-        fi
+    # All three bundles, not just the one rendered below: the post-job save
+    # writes the same three paths under the key test.yml restores from, so a
+    # stub Sanity or Retry bundle slipping through here would poison every PR
+    # run until the key rotates (#454). Failing here also stops that save — the
+    # cache action's post step runs under `post-if: success()` — and stops the
+    # render, since a cache hit that restored an empty bundle would otherwise
+    # publish an empty demo. The same script test.yml, toolchain-drift.yml and
+    # pages-release.yml call, so the four gates cannot drift apart; the script
+    # itself explains why presence alone is not evidence.
+    - name: Verify fixtures
+      run: ./scripts/verify_fixtures.sh
 
     # Release, because the demo should be the binary users are handed rather
     # than a debug build that merely renders the same bytes.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,18 +62,19 @@ jobs:
       if: steps.fixture-cache.outputs.cache-hit != 'true'
       run: ./prepareTestResults.sh
 
-    # Restored or freshly generated, the bundles must actually exist before
-    # the fast path is trusted: a cache hit that restored nothing would
-    # otherwise sail through as a suspiciously quick green run.
+    # Restored or freshly generated, the bundles must actually contain tests
+    # before the fast path is trusted: a cache hit that restored nothing would
+    # otherwise sail through as a suspiciously quick green run, and a stub left
+    # behind by a simulator that vanished mid-generation would fail the suite
+    # below with a confusing error instead of here (#454). The script explains
+    # what it asserts and why presence alone is not enough.
+    #
+    # This must stay ahead of `swift test`, and it is: the cache action's save
+    # runs post-job under `post-if: success()`, so failing here also stops a
+    # stub from being written to the cache under a key every later run would
+    # restore.
     - name: Verify fixtures
-      run: |
-        for bundle in TestResults SanityResults RetryResults; do
-          plist="Tests/XCTestHTMLReportTests/Resources/${bundle}.xcresult/Info.plist"
-          if [ ! -f "$plist" ]; then
-            echo "::error::missing or incomplete fixture: ${bundle}.xcresult"
-            exit 1
-          fi
-        done
+      run: ./scripts/verify_fixtures.sh
 
     - name: Run tests
       run: swift test -v

--- a/.github/workflows/toolchain-drift.yml
+++ b/.github/workflows/toolchain-drift.yml
@@ -111,19 +111,26 @@ jobs:
       id: fixtures
       continue-on-error: true
       timeout-minutes: 90
-      run: |
-        ./prepareTestResults.sh
-        for bundle in TestResults SanityResults RetryResults; do
-          plist="Tests/XCTestHTMLReportTests/Resources/${bundle}.xcresult/Info.plist"
-          if [ ! -f "$plist" ]; then
-            echo "::error::missing or incomplete fixture: ${bundle}.xcresult"
-            exit 1
-          fi
-        done
+      run: ./prepareTestResults.sh
+
+    # A separate step from generation on purpose. `prepareTestResults.sh`
+    # tolerates failing tests (`|| true`), which also swallows a simulator
+    # disappearing mid-run: xcodebuild still leaves a stub .xcresult behind and
+    # the script exits 0. Verifying separately keeps "generation blew up" and
+    # "generation produced empty bundles" as distinguishable faults in the
+    # report below, and everything downstream — the suite, the render, and the
+    # cache save — now hangs off this step rather than off generation, so a
+    # stub can neither produce confusing downstream failures nor be saved under
+    # a key test.yml would restore (#454).
+    - name: Verify fresh fixtures
+      id: verify
+      if: steps.fixtures.outcome == 'success'
+      continue-on-error: true
+      run: ./scripts/verify_fixtures.sh
 
     - name: Run test suite
       id: tests
-      if: steps.fixtures.outcome == 'success'
+      if: steps.verify.outcome == 'success'
       continue-on-error: true
       timeout-minutes: 45
       run: swift test -v
@@ -140,7 +147,7 @@ jobs:
     # of what this step asserts — restoring the mkdir would hide a regression.
     - name: Run xchtmlreport against a fresh bundle
       id: tool
-      if: steps.build.outcome == 'success' && steps.fixtures.outcome == 'success'
+      if: steps.build.outcome == 'success' && steps.verify.outcome == 'success'
       continue-on-error: true
       timeout-minutes: 15
       run: |
@@ -161,8 +168,13 @@ jobs:
     # this workflow restores from the cache. The key was computed by the
     # shared action before generation, so it matches test.yml's clean-tree
     # restore key exactly.
+    #
+    # Gated on the verify step, not on generation: this is the one place a stub
+    # bundle would do lasting damage, poisoning every PR run that hits the key
+    # until it rotates (#454). Verify only runs when generation succeeded, so
+    # its success implies both.
     - name: Save fixtures to cache
-      if: steps.fixture-key.outcome == 'success' && steps.fixtures.outcome == 'success'
+      if: steps.fixture-key.outcome == 'success' && steps.verify.outcome == 'success'
       uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: |
@@ -188,6 +200,7 @@ jobs:
         LEGACY: ${{ steps.legacy.outcome }}
         BUILD: ${{ steps.build.outcome }}
         FIXTURES: ${{ steps.fixtures.outcome }}
+        VERIFY: ${{ steps.verify.outcome }}
         TESTS: ${{ steps.tests.outcome }}
         TOOL: ${{ steps.tool.outcome }}
         TOOL_EXIT: ${{ steps.tool.outputs.exit_code }}
@@ -208,6 +221,9 @@ jobs:
           faults+=("Fixture generation (\`prepareTestResults.sh\`) failed on this toolchain.")
         elif [ "$FIXTURES" = "skipped" ]; then
           faults+=("Run aborted before fixture generation — a setup step failed; see the run log.")
+        fi
+        if [ "$VERIFY" = "failure" ]; then
+          faults+=("Fixture generation reported success but produced a bundle with no test data — the run log names it. Usually the runner's simulator went away mid-run and \`xcodebuild\` left a stub \`.xcresult\` behind (#454). Nothing was saved to the fixture cache, and the signals below were skipped because they would only have failed confusingly against the stub.")
         fi
         if [ "$TESTS" = "failure" ]; then
           faults+=("\`swift test\` failed against freshly generated fixtures.")
@@ -231,6 +247,7 @@ jobs:
           echo "| legacy xcresulttool marker | ${LEGACY} |"
           echo "| swift build | ${BUILD} |"
           echo "| fixture generation | ${FIXTURES} |"
+          echo "| fixtures contain test data | ${VERIFY} |"
           echo "| swift test | ${TESTS} |"
           echo "| xchtmlreport clean exit | ${TOOL} |"
         } > "$RUNNER_TEMP/summary.md"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,15 @@ swift test
 `prepareTestResults.sh` picks the newest available iPhone simulator automatically.
 No credentials or secrets are required for this part.
 
+If a simulator goes away mid-run, `xcodebuild` can leave an `.xcresult` behind
+that looks complete but holds no tests, and the suite then fails with a
+confusing error. `scripts/verify_fixtures.sh` — the same gate CI runs — catches
+that in a second:
+
+```bash
+./scripts/verify_fixtures.sh   # asserts each bundle actually contains tests
+```
+
 Regenerate fixtures after upgrading Xcode; `.xcresult` contents change between
 Xcode versions.
 

--- a/XCTestHTMLReportSampleApp/SampleAppUnitTests/SampleAppUnitTests.swift
+++ b/XCTestHTMLReportSampleApp/SampleAppUnitTests/SampleAppUnitTests.swift
@@ -14,12 +14,13 @@ class SampleAppUnitTests: XCTestCase {
         XCTAssert(false, "Test failed")
     }
 
-    /// Records with result `Expected Failure` in the xcresult — a status no
-    /// other test in `TestResults.xcresult` produces (`RetryTests`, which also
-    /// records one, is skipped from this bundle and lands in
-    /// `RetryResults.xcresult`). The report currently renders it as `.unknown`
-    /// (blank icon); the redesign's status-icon work needs a real case to
-    /// verify against. See #439.
+    /// Records with result `Expected Failure` in the xcresult — one of exactly
+    /// two such rows in `TestResults.xcresult`. `SwiftTestingSuite.knownIssue`
+    /// records the other from this same target, so the status has coverage from
+    /// both test frameworks; `RetryTests` records one too, but it is skipped
+    /// from this bundle and lands in `RetryResults.xcresult`. #439 has since
+    /// given the status its own `Status.expectedFailure` and glyph, and
+    /// `CoreTests`' bucket arithmetic subtracts exactly these two.
     func testExpectedFailure() {
         XCTExpectFailure("Intentional expected failure for fixture coverage") {
             XCTAssert(false, "This assertion fails inside XCTExpectFailure")

--- a/XCTestHTMLReportSampleApp/SampleAppUnitTests/SampleAppUnitTests.swift
+++ b/XCTestHTMLReportSampleApp/SampleAppUnitTests/SampleAppUnitTests.swift
@@ -15,9 +15,11 @@ class SampleAppUnitTests: XCTestCase {
     }
 
     /// Records with result `Expected Failure` in the xcresult — a status no
-    /// other fixture test produces. The report currently renders it as
-    /// `.unknown` (blank icon); the redesign's status-icon work needs a real
-    /// case to verify against. See #439.
+    /// other test in `TestResults.xcresult` produces (`RetryTests`, which also
+    /// records one, is skipped from this bundle and lands in
+    /// `RetryResults.xcresult`). The report currently renders it as `.unknown`
+    /// (blank icon); the redesign's status-icon work needs a real case to
+    /// verify against. See #439.
     func testExpectedFailure() {
         XCTExpectFailure("Intentional expected failure for fixture coverage") {
             XCTAssert(false, "This assertion fails inside XCTExpectFailure")
@@ -32,7 +34,12 @@ class SampleAppUnitTests: XCTestCase {
     /// 8×8 solid fill is ~100 bytes of PNG. See #439.
     func testWithPngAttachment() throws {
         let size = CGSize(width: 8, height: 8)
-        let image = UIGraphicsImageRenderer(size: size).image { context in
+        // `UIGraphicsImageRenderer` takes points and defaults to the screen's
+        // scale, so on a Retina simulator the plain `init(size:)` would emit a
+        // 16×16 or 24×24 PNG. Pin scale 1 so the fixture is the 8×8 it claims.
+        let format = UIGraphicsImageRendererFormat.default()
+        format.scale = 1
+        let image = UIGraphicsImageRenderer(size: size, format: format).image { context in
             UIColor.systemRed.setFill()
             context.fill(CGRect(origin: .zero, size: size))
         }

--- a/scripts/verify_fixtures.sh
+++ b/scripts/verify_fixtures.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 # Verifies that the .xcresult fixtures actually contain test data.
 #
-# Shared by test.yml and toolchain-drift.yml so the two gates cannot drift
-# apart, and runnable locally straight after ./prepareTestResults.sh.
+# Shared by every workflow that generates or restores fixtures — test.yml,
+# toolchain-drift.yml, pages.yml and pages-release.yml — so the gates cannot
+# drift apart, and runnable locally straight after ./prepareTestResults.sh.
 #
 # Presence is not evidence. When a CI runner's simulator vanished mid-generation
 # ("Unable to find a device matching the provided destination specifier"), the

--- a/scripts/verify_fixtures.sh
+++ b/scripts/verify_fixtures.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+# Verifies that the .xcresult fixtures actually contain test data.
+#
+# Shared by test.yml and toolchain-drift.yml so the two gates cannot drift
+# apart, and runnable locally straight after ./prepareTestResults.sh.
+#
+# Presence is not evidence. When a CI runner's simulator vanished mid-generation
+# ("Unable to find a device matching the provided destination specifier"), the
+# `|| true` in prepareTestResults.sh swallowed the failure and xcodebuild still
+# left a stub bundle behind: an Info.plist, a Data directory, and no tests. The
+# presence-only check this replaces passed that stub, so the test job failed
+# downstream with a confusing error instead of failing fast at generation — and
+# the stub came one step from being SAVED to the fixture cache under a valid
+# key, where it would have poisoned every restore until the key rotated (#454).
+#
+# `xcresulttool get test-results summary` exits 0 on such a stub and reports
+# `"totalTestCount": 0`, so the count is the assertion here, not the exit
+# status. That command is the modern surface the report itself already reads
+# through (ModernResultReader), so this gate needs no toolchain the tool does
+# not already need.
+#
+# Takes bundle paths as arguments, defaulting to the three CI fixtures. Every
+# bundle is checked before exiting, so one run names every offender rather than
+# stopping at the first.
+set -euo pipefail
+
+if [ "$#" -gt 0 ]; then
+    bundles=("$@")
+else
+    resources='Tests/XCTestHTMLReportTests/Resources'
+    bundles=(
+        "${resources}/TestResults.xcresult"
+        "${resources}/SanityResults.xcresult"
+        "${resources}/RetryResults.xcresult"
+    )
+fi
+
+# `::error::` so a rejection lands as an annotation on the CI run rather than as
+# one line somewhere in a very long log.
+fail() {
+    echo "::error::$1"
+}
+
+status=0
+for bundle in "${bundles[@]}"; do
+    name="$(basename "$bundle")"
+
+    if [ ! -f "${bundle}/Info.plist" ]; then
+        fail "missing or incomplete fixture: ${name}"
+        status=1
+        continue
+    fi
+
+    if ! summary="$(xcrun xcresulttool get test-results summary --path "$bundle" 2>&1)"; then
+        fail "unreadable fixture: ${name} — xcresulttool could not summarize it"
+        printf '%s\n' "$summary" >&2
+        status=1
+        continue
+    fi
+
+    total="$(printf '%s' "$summary" | python3 -c \
+        'import json, sys; print(json.load(sys.stdin).get("totalTestCount", ""))' \
+        2>/dev/null || true)"
+
+    case "$total" in
+    '' | *[!0-9]*)
+        fail "unreadable fixture: ${name} — no usable totalTestCount in the xcresulttool summary"
+        printf '%s\n' "$summary" >&2
+        status=1
+        continue
+        ;;
+    esac
+
+    if [ "$total" -eq 0 ]; then
+        fail "stub fixture: ${name} contains no tests (totalTestCount=0) — generation did not complete, so this bundle must not be trusted or cached"
+        status=1
+        continue
+    fi
+
+    echo "${name}: ${total} tests"
+done
+
+exit "$status"


### PR DESCRIPTION
Fixes #454.

## The hole

The fixture verify gate — duplicated inline in all four workflows that
generate or restore fixtures — asked only whether each `.xcresult` had an
`Info.plist`. During the #453 review a runner's simulator
vanished mid-`prepareTestResults.sh` (`Unable to find a device matching the
provided destination specifier`), the script's `|| true` swallowed it, and
`xcodebuild` still left a stub bundle behind: `Info.plist`, a `Data` directory,
zero tests. It passed the gate. The suite then failed downstream with a
confusing error instead of failing fast at generation — and the stub was one
step from being **saved to the fixture cache** under a valid key, where it
would have poisoned every hit until the key rotated. That last part is the
reason this is worth a gate rather than a better error message.

## The gate

`scripts/verify_fixtures.sh` asserts real test data per bundle. Note the shape
of the failure: `xcresulttool get test-results summary` **exits 0** on a stub
and reports `"totalTestCount": 0`, so the count is the assertion, not the exit
status. The command is the modern surface `ModernResultReader` already reads
through, so the gate needs no toolchain the tool itself does not.

One script, called from all four workflows, because every one of those copies
stands in front of something that outlives its own run: `test.yml`,
`toolchain-drift.yml` and `pages.yml` all write the shared fixture cache, and
`pages-release.yml` publishes an immutable per-tag render. `pages.yml` is the
worst of them — it restores, generates and post-job saves all three bundles
under the key `test.yml` restores from, on every merge to `main`, while
checking only `TestResults`. It checks every bundle before
exiting, so a run names every offender rather than the first, and it takes
bundle paths as arguments so a contributor can run it straight after
`prepareTestResults.sh` (now documented in CONTRIBUTING).

## Evidence

Run locally against three bundles built for the purpose:

```
### REAL bundle (xcodebuild test, 2 passing tests)
Real.xcresult: 2 tests
EXIT=0

### STUB bundle — the incident reproduced: test-without-building against a
### device id that does not exist, leaving Info.plist + empty Data/
::error::stub fixture: Stub.xcresult contains no tests (totalTestCount=0) — generation did not complete, so this bundle must not be trusted or cached
EXIT=1

### MIXED — real + stub + absent, one run naming every offender
Real.xcresult: 2 tests
::error::stub fixture: Stub.xcresult contains no tests (totalTestCount=0) — …
::error::missing or incomplete fixture: Nope.xcresult
EXIT=1

### CORRUPT — bundle whose summary command fails outright
::error::unreadable fixture: Corrupt.xcresult — xcresulttool could not summarize it
Error: item missing for id 0~RI-jeBjOT2eh…
EXIT=1
```

The old gate accepts every one of those stubs; each has an `Info.plist`.

## Ordering vs the cache save

- **`test.yml`** needs no reordering. `actions/cache` saves in its post-job step
  under `post-if: "success()"` (checked at the pinned SHA), so a failing gate
  before `swift test` already blocks the poisoned save.
- **`toolchain-drift.yml`** now verifies in its own step. Generation is allowed
  to fail *tests*, so folding the check into it conflated "generation blew up"
  with "generation produced empty bundles" — separate faults in the issue that
  workflow files. The suite, the render and `Save fixtures to cache` all hang
  off the verify step now instead of off generation, so a stub neither produces
  confusing downstream failures nor reaches the cache. The drift report gains a
  `fixtures contain test data` row and a fault line pointing at #454.
- **`pages.yml`** verifies **all three** bundles, not just the one it renders.
  It post-job saves all three under the key `test.yml` restores from, so
  checking only `TestResults` would let a stub `Sanity`/`Retry` bundle reach the
  shared cache on any merge to `main` and fail every PR run until the key
  rotates. Same `post-if: success()` property as `test.yml`: failing the gate
  also blocks the save, and blocks publishing an empty demo from a cache hit
  that restored nothing.
- **`pages-release.yml`** verifies just `TestResults`, the only bundle it
  publishes. No cache here to poison, and failing a release over a stub bundle
  nothing in the job reads would be a false blocker — but the render is pushed
  immutably under `/v/<tag>/`, so a stub that got through would be a
  permanently hosted empty demo. No version-skew hazard: a tag push runs the
  workflow file as it existed at the tag, and that job's checkout takes the tag
  with no `ref:` override, so the workflow and `scripts/verify_fixtures.sh`
  always travel together.

## Riders from the #453 review

- The `Expected Failure` doc comment now says what the bundle actually
  contains. `TestResults.xcresult` has **two** such rows, not one —
  `testExpectedFailure` and `SwiftTestingSuite.knownIssue`, both in the
  `SampleAppUnitTests` target, so `prepareTestResults.sh`'s
  `-skip-testing:SampleAppUITests/RetryTests` does not exclude the second.
  Measured with `xcresulttool get test-results tests` (21 rows; `{'Passed': 12,
  'Failed': 6, 'Expected Failure': 2, 'Skipped': 1}`), which is also what
  `CoreTests`' `all - skipped - 2` has encoded all along. The comment's second
  half — "renders it as `.unknown` (blank icon); the redesign's status-icon
  work needs a real case" — was stale: #439 landed and gave the status its own
  `Status.expectedFailure` and `expected-failure` glyph.
- The programmatic PNG pins its renderer to scale 1.
  `UIGraphicsImageRenderer(size:)` takes points and defaults to the screen
  scale, so on a Retina simulator the attachment was 16×16 or 24×24, not the
  8×8 its comment promises. (Sample app compiles: `TEST BUILD SUCCEEDED`.)

That second one changes the sample app, so it rotates the fixture cache key —
which means this PR's `test.yml` run regenerates from scratch and exercises the
new gate end to end against real bundles rather than restored ones.

`shellcheck` and `zizmor --min-severity low` are clean; `actionlint` reports
nothing in the four workflow files touched here (its two findings are
pre-existing, in `release.yml` and `test-artifacts.yml`). SHA pins untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of test result fixtures to prevent incomplete or empty results from being used in automated checks, reports, and demos.
  * Improved toolchain drift reporting by clearly indicating fixture verification outcomes.

* **Documentation**
  * Added contributor guidance for identifying and validating incomplete test result fixtures.

* **Tests**
  * Updated sample test fixtures and expected-failure documentation.
  * Ensured generated image attachments maintain consistent 8×8 pixel dimensions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
