### PR TITLE
Create the --output directory up front instead of failing late on index.html (fixes #446)

### DIFF
--- a/.github/workflows/toolchain-drift.yml
+++ b/.github/workflows/toolchain-drift.yml
@@ -133,15 +133,17 @@ jobs:
     # not degradation. A clean exit against a bundle produced by this exact
     # toolchain is the whole assertion. The exit code is captured as a step
     # output so the drift report can tell those two failures apart.
-    # `mkdir -p` first: xchtmlreport does not create the --output directory
-    # and fails late with a misleading error when it is missing (#444).
+    #
+    # No `mkdir -p` here: #445 added one to stop a missing --output directory
+    # from being misreported as toolchain drift, and #446 fixed the tool to
+    # create the directory itself. Pointing at an uncreated path is now part
+    # of what this step asserts — restoring the mkdir would hide a regression.
     - name: Run xchtmlreport against a fresh bundle
       id: tool
       if: steps.build.outcome == 'success' && steps.fixtures.outcome == 'success'
       continue-on-error: true
       timeout-minutes: 15
       run: |
-        mkdir -p "$RUNNER_TEMP/drift-report"
         exit_code=0
         swift run xchtmlreport \
           Tests/XCTestHTMLReportTests/Resources/TestResults.xcresult \

--- a/README.md
+++ b/README.md
@@ -213,8 +213,11 @@ and are still only visible as messages on stderr. See
 [#378](https://github.com/XCTestHTMLReport/XCTestHTMLReport/issues/378) and the
 follow-on work it tracks.
 
-Exit 1 covers failures to write the output — for example `-o` pointing at a
-directory that does not exist.
+Exit 1 covers failures to write the output. A missing `-o` directory is not one of
+them: it is created for you, intermediate components included, before any parsing
+or rendering starts. A directory that cannot be created — no write permission on
+the parent, or a file in the way — is an argument error (64), reported up front and
+naming the path.
 
 The report is still written when faults occur. To restore the pre-3.0 behaviour and
 always exit 0 on faults, pass `--lenient`. `--lenient` does not affect exit 1 or 64.

--- a/Sources/XCTestHTMLReport/XCTestHtmlReport.swift
+++ b/Sources/XCTestHTMLReport/XCTestHtmlReport.swift
@@ -24,7 +24,9 @@ struct HtmlOptions: ParsableArguments {
     @Option(
         name: .shortAndLong,
         parsing: .next,
-        help: ArgumentHelp("Output directory, defaults to the first provided xcresult"),
+        help: ArgumentHelp(
+            "Output directory (created if missing), defaults to the first provided xcresult"
+        ),
         completion: .directory
     )
     var output: String?
@@ -133,6 +135,8 @@ struct XCTestHtmlReport: ParsableCommand {
 
         Logger.substep("Writing report to \(path)")
 
+        try createOutputDirectory(at: path)
+
         let faultCollector = FaultCollector()
         let summary = Summary(
             resultPaths: summaryOptions.finalResults,
@@ -210,6 +214,33 @@ struct XCTestHtmlReport: ParsableCommand {
 
         Logger.error("Exiting non-zero. Pass --lenient to ignore faults.")
         throw ExitCode(3)
+    }
+
+    /// Called up front, before any parsing, rendering or attachment exporting.
+    ///
+    /// Until #446 a missing output directory surfaced only at the final
+    /// `write(toFile:)` — minutes in, as ArgumentParser's `The file
+    /// "index.html" doesn't exist.`, which names the wrong file and arrives
+    /// after the work is done (in linking mode, after payloads have already
+    /// been exported into the bundle). Creating it is what every CLI this one
+    /// sits next to does, and it is a no-op when the directory already exists,
+    /// which is the overwhelmingly common case.
+    ///
+    /// A directory that genuinely cannot be created — no write permission on
+    /// the parent, a file in the way — is a usage error, not a degraded
+    /// report: `ValidationError` exits 64 like the tool's other usage errors
+    /// rather than 3, which is reserved for collected faults.
+    private func createOutputDirectory(at path: String) throws {
+        do {
+            try FileManager.default.createDirectory(
+                atPath: path,
+                withIntermediateDirectories: true
+            )
+        } catch {
+            throw ValidationError(
+                "Could not create output directory \(path): \(error.localizedDescription)"
+            )
+        }
     }
 
     func validate() throws {

--- a/Tests/XCTestHTMLReportTests/CliTests.swift
+++ b/Tests/XCTestHTMLReportTests/CliTests.swift
@@ -143,4 +143,93 @@ final class CliTests: XCTestCase {
 
         XCTAssertEqual(status, 0, "--lenient restores 2.x exit behaviour")
     }
+
+    /// A scratch directory unique to the calling test, removed when it ends.
+    private func makeScratchDirectory(
+        _ name: String = #function
+    ) throws -> URL {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("xchr-\(name)-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        addTeardownBlock {
+            // Restore write permission first: the unwritable-output test drops
+            // it on a subdirectory, and removeItem cannot unlink through it.
+            let contents = FileManager.default.enumerator(atPath: root.path)?
+                .allObjects as? [String] ?? []
+            for entry in contents {
+                try? FileManager.default.setAttributes(
+                    [.posixPermissions: 0o755],
+                    ofItemAtPath: root.appendingPathComponent(entry).path
+                )
+            }
+            try? FileManager.default.removeItem(at: root)
+        }
+        return root
+    }
+
+    /// #446: the tool used to render the whole report and only then fail on
+    /// `write(toFile:)`, surfacing as `The file "index.html" doesn't exist.`
+    /// A missing output directory is created, like every comparable CLI does.
+    func testNonexistentNestedOutputDirectoryIsCreated() throws {
+        let testResultsUrl = try XCTUnwrap(testResultsUrl)
+        let output = try makeScratchDirectory()
+            .appendingPathComponent("nested/report/dir")
+
+        let (status, maybeStdOut, maybeStdErr) = try xchtmlreportCmd(
+            args: ["--output", output.path, testResultsUrl.path]
+        )
+
+        XCTAssertEqual(
+            status, 0,
+            "exited \(status).\nstdout:\n\(maybeStdOut ?? "")\nstderr:\n\(maybeStdErr ?? "")"
+        )
+        XCTAssertTrue(
+            FileManager.default
+                .fileExists(atPath: output.appendingPathComponent("index.html").path),
+            "index.html was not written to the created output directory"
+        )
+    }
+
+    /// The other half of #446: when the directory genuinely cannot be created,
+    /// say so — naming the path — and say it before minutes of parsing rather
+    /// than after. This is a usage error (exit 64, the code every other
+    /// `ValidationError` in this tool produces), never a report-degradation
+    /// fault (exit 3).
+    func testUnwritableOutputDirectoryFailsFastNamingThePath() throws {
+        try XCTSkipIf(getuid() == 0, "root bypasses directory permissions")
+        let testResultsUrl = try XCTUnwrap(testResultsUrl)
+
+        let readOnly = try makeScratchDirectory().appendingPathComponent("read-only")
+        try FileManager.default.createDirectory(
+            at: readOnly,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o555]
+        )
+        let output = readOnly.appendingPathComponent("report")
+
+        let (status, maybeStdOut, maybeStdErr) = try xchtmlreportCmd(
+            args: ["--verbose", "--output", output.path, testResultsUrl.path]
+        )
+
+        XCTAssertEqual(
+            status, 64,
+            "An unusable --output is a usage error, not a degraded report (3)"
+        )
+
+        let stdErr = try XCTUnwrap(maybeStdErr)
+        try XCTAssertContains(stdErr, "Could not create output directory")
+        try XCTAssertContains(stdErr, output.path)
+
+        // Fail *fast*: the old behaviour reached the write only after building
+        // the report, so this must not have got as far as rendering.
+        let stdOut = maybeStdOut ?? ""
+        XCTAssertFalse(
+            stdOut.contains("Building HTML"),
+            "Rendering ran before the output directory was checked:\n\(stdOut)"
+        )
+        XCTAssertFalse(
+            stdErr.contains("index.html"),
+            "Still blaming index.html for a missing output directory:\n\(stdErr)"
+        )
+    }
 }


### PR DESCRIPTION
Fixes #446.

## The bug

```
$ xchtmlreport TestResults.xcresult --output /some/missing/dir/report
... minutes of parsing, rendering and attachment exporting ...
Error: An error has occured while creating the report
Error: The file “index.html” doesn’t exist.
$ echo $?
1
```

Neither line names the real problem. The failure is the final
`html.write(toFile:)` in `run()`, so it arrives *after* all the work is done —
and in linking mode after payloads have already been exported into the bundle.
`index.html` is a red herring: the file that doesn't exist is the directory
above it. This is what made the first scheduled toolchain-drift run (#444) look
like toolchain drift.

## The fix

Create the output directory, intermediates included, before anything else
happens — before the `Summary` is built, before parsing, rendering or
exporting. Create-by-default is what every CLI this one sits next to does, and
it is a no-op on the overwhelmingly common path where the directory already
exists.

When the directory genuinely cannot be created — no write permission on the
parent, a file in the way — that is a **usage error, not a degraded report**:
it throws `ValidationError`, so it exits **64** like the tool's other usage
errors, never 3, which is reserved for collected faults. The message names the
path and the reason, and arrives before any work:

```
$ xchtmlreport TestResults.xcresult --output /read-only-dir/report
Error: Could not create output directory /read-only-dir/report: You don’t have
permission to save the file “report” in the folder “read-only-dir”.
Usage: xchtmlreport [<options>] [<results> ...]
$ echo $?
64
```

The `An error has occured while creating the report` string (typo included) is
untouched — this fix makes that path unreachable for a missing output
directory, and rewording it is a separate concern.

## The #445 workaround comes out

`.github/workflows/toolchain-drift.yml` gained a `mkdir -p "$RUNNER_TEMP/drift-report"`
in #445 specifically to stop this bug from being misreported as drift. It is
removed here, with a comment saying why it must not come back: pointing the
drift job at an uncreated path is now part of what the step asserts, so a
regression in the fix would show up as a failed scheduled run rather than
being masked.

(`test.yml`'s `mkdir -p "$RUNNER_TEMP/report"` is left alone — it came from
#457's render step, not from this bug.)

## Tests

Both written before the fix and watched fail against the old behaviour:

- `CliTests.testNonexistentNestedOutputDirectoryIsCreated` — renders to a
  nonexistent *nested* path, asserts exit 0 and that `index.html` is there.
  Before the fix: exit 1, no `index.html`.
- `CliTests.testUnwritableOutputDirectoryFailsFastNamingThePath` — a `0o555`
  parent, asserts exit 64, that stderr names the path, and — the fail-*fast*
  half — that `Building HTML` never ran and that stderr no longer blames
  `index.html`. Before the fix: exit 1, all four assertions failed. Skipped
  when running as root, which ignores directory permissions.

## Docs

`README.md`'s exit-code section documented the old behaviour verbatim ("Exit 1
covers failures to write the output — for example `-o` pointing at a directory
that does not exist"). Corrected. The `--output` help text now says the
directory is created if missing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The HTML report command now automatically creates missing output directories, including nested paths.
* **Bug Fixes**
  * Invalid or unwritable output paths now fail quickly with exit code 64 and a path-specific diagnostic.
  * Output-writing failures continue to use exit code 1.
* **Documentation**
  * Updated command-line documentation to clarify output-directory creation and exit-code behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->