### PR TITLE
Ready the repo for the 4.0.0rc1 release candidate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,7 @@ jobs:
     outputs:
       prerelease: ${{ steps.metadata.outputs.prerelease }}
       version: ${{ steps.metadata.outputs.version }}
+      base_version: ${{ steps.metadata.outputs.base_version }}
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -52,11 +53,17 @@ jobs:
         else
           VERSION="0.0.0-dryrun"
         fi
-        # `rc` tags carry no hyphen, so a `contains(github.ref, '-')` test
-        # never fired for them and release candidates shipped as full releases.
+        # `rc` tags carry no hyphen in the X.Y.ZrcN form this repo uses, so a
+        # `contains(github.ref, '-')` test never fired for them and release
+        # candidates shipped as full releases.
         if [[ "$VERSION" == *rc* ]]; then PRERELEASE=true; else PRERELEASE=false; fi
+        # Release notes are kept per X.Y.Z, so every candidate publishes the
+        # same document as the final release and the two cannot drift:
+        # 4.0.0rc1 and 4.0.0 both resolve to docs/release-notes/4.0.0.md.
+        BASE="${VERSION%%rc*}"
         {
           echo "version=${VERSION}"
+          echo "base_version=${BASE}"
           echo "prerelease=${PRERELEASE}"
           echo "bin_path=.build/universal/release/xchtmlreport"
           echo "archive_name=xchtmlreport-${VERSION}.zip"
@@ -142,6 +149,16 @@ jobs:
       contents: write
 
     steps:
+    # Sparse and credential-free: the only thing this job wants from the tree
+    # is the release-notes document. On a tag push the checkout is the tag, so
+    # a release always publishes the notes as they stood at the commit it was
+    # cut from rather than whatever main says today.
+    - name: Check out the release notes
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
+        sparse-checkout: docs/release-notes
+
     - name: Download
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       # Both are given explicitly because the default layout is not stable and
@@ -154,6 +171,48 @@ jobs:
         name: application
         path: application
 
+    - name: Compose the release body
+      id: notes
+      env:
+        NOTES_FILE: docs/release-notes/${{ needs.build.outputs.base_version }}.md
+        PRERELEASE: ${{ needs.build.outputs.prerelease }}
+        TAG: ${{ github.ref_name }}
+        # The archive the build job actually produced, so the banner names the
+        # asset that is really attached rather than a second guess at it.
+        ARCHIVE: xchtmlreport-${{ needs.build.outputs.version }}.zip
+      run: |
+        # Not every version has a hand-written document, and a missing one is
+        # not a reason to fail a release that is already built and notarized —
+        # it falls back to the generated notes alone.
+        if [[ ! -f "$NOTES_FILE" ]]; then
+          echo "::notice::no notes at ${NOTES_FILE}; publishing generated notes alone"
+          echo "have_notes=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+        # A candidate says so at the top of its own release page, where nobody
+        # can miss it. The banner is generated per tag rather than written into
+        # the document, because the document is shared with the final release.
+        if [[ "$PRERELEASE" == "true" ]]; then
+          {
+            echo "> [!IMPORTANT]"
+            echo "> **${TAG} is a release candidate**, published as a pre-release."
+            echo "> \`brew install xctesthtmlreport\` and"
+            echo "> \`mint install XCTestHTMLReport/XCTestHTMLReport\` keep resolving to the"
+            echo "> latest stable release, so this one is opt-in:"
+            echo ">"
+            echo "> \`\`\`bash"
+            echo "> mint install XCTestHTMLReport/XCTestHTMLReport@${TAG}"
+            echo "> \`\`\`"
+            echo ">"
+            echo "> Or download \`${ARCHIVE}\` below: a signed, notarized universal binary."
+            echo
+          } > release-body.md
+        else
+          : > release-body.md
+        fi
+        cat "$NOTES_FILE" >> release-body.md
+        echo "have_notes=true" >> "$GITHUB_OUTPUT"
+
     - name: Release
       # The GitHub CLI is preinstalled on the runner and does everything the
       # third-party release action was doing here, so the one job that handles
@@ -161,12 +220,13 @@ jobs:
       # a third party. Reported as superfluous by zizmor.
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        # This job deliberately has no checkout, so gh cannot work out which
-        # repository it is talking to from a git remote.
+        # The checkout above is sparse and has no credentials, so gh cannot
+        # work out which repository it is talking to from a git remote.
         GH_REPO: ${{ github.repository }}
         # Through the environment rather than interpolated into the script.
         TAG: ${{ github.ref_name }}
         PRERELEASE: ${{ needs.build.outputs.prerelease }}
+        HAVE_NOTES: ${{ steps.notes.outputs.have_notes }}
       # --verify-tag because `gh release create` otherwise invents a tag from
       # the default branch when the one it is given does not exist. The tag is
       # what triggered this run, so that can only ever mean something is wrong.
@@ -181,8 +241,19 @@ jobs:
       # re-run button should be able to do. Failed runs need no cleanup — with
       # assets, gh creates the release as a draft, uploads, then publishes, and
       # deletes the draft if any of that fails.
+      #
+      # --generate-notes stays even when a hand-written document exists: gh
+      # *prepends* --notes-file to the generated notes rather than replacing
+      # them, so the release body reads as the curated document followed by
+      # the automatic changelog and contributor list.
+      #
+      # --prerelease is what keeps a candidate off "Latest". GitHub never
+      # promotes a pre-release, so no --latest=false is needed alongside it.
       run: |
         args=(--generate-notes --verify-tag)
+        if [[ "$HAVE_NOTES" == "true" ]]; then
+          args+=(--notes-file release-body.md)
+        fi
         if [[ "$PRERELEASE" == "true" ]]; then
           args+=(--prerelease)
         fi

--- a/Sources/XCTestHTMLReport/Version.swift
+++ b/Sources/XCTestHTMLReport/Version.swift
@@ -1,1 +1,1 @@
-let version = "3.0.1-pre.69b32fe"
+let version = "4.0.0-pre"

--- a/docs/release-notes/4.0.0.md
+++ b/docs/release-notes/4.0.0.md
@@ -14,26 +14,27 @@ projects. So 4.0.0 is being cut as a series of release candidates —
 `4.0.0rc1`, `4.0.0rc2`, … — rather than one stable tag, and each is published
 as a GitHub **pre-release**. `brew install xctesthtmlreport` and `mint install
 XCTestHTMLReport/XCTestHTMLReport` keep resolving to the 3.x stable line until
-4.0.0 final, so a candidate is always opt-in:
+4.0.0 final, so a candidate is always opt-in — pin the candidate's own tag:
 
 ``` bash
-mint install XCTestHTMLReport/XCTestHTMLReport@4.0.0rc1
+mint install XCTestHTMLReport/XCTestHTMLReport@<candidate-tag>
 ```
 
-Each candidate also attaches a signed, notarized universal binary
-(`xchtmlreport-4.0.0rc1.zip`) to its release page.
+Each candidate's release page names its own tag and attaches a signed,
+notarized universal binary built from it.
 
-**`4.0.0rc1` is the migration plus a conservative refresh.** Everything below
-— the `xcresulttool` migration, the `--json` schema, `--result-reader`, and
-the report changes both readers now share — is in this candidate and is what
-we are asking for soak time on. The report's own markup and styling are
-deliberately left close to 3.x here, so that any regression you hit points at
-the reader rewrite rather than at a redesign landing on top of it.
+**The first candidate is the migration plus a conservative refresh.**
+Everything below — the `xcresulttool` migration, the `--json` schema,
+`--result-reader`, and the report changes both readers now share — is in it,
+and is what we are asking for soak time on. The report's own markup and
+styling are deliberately left close to 3.x there, so that any regression you
+hit points at the reader rewrite rather than at a redesign landing on top of
+it.
 
-**The Xcode-native report redesign lands later in the RC line**, from
-`4.0.0rc2` on, with its own notes appended to this document. The candidate
-line ends when the reader rewrite has gone a full cycle without a parity or
-correctness report against it.
+**The Xcode-native report redesign lands later in the RC line**, with its own
+notes appended to this document as it arrives. The candidate line ends when
+the reader rewrite has gone a full cycle without a parity or correctness
+report against it.
 
 Please file anything you find against
 [the 4.0 milestone](https://github.com/XCTestHTMLReport/XCTestHTMLReport/milestone/2);

--- a/docs/release-notes/4.0.0.md
+++ b/docs/release-notes/4.0.0.md
@@ -3,8 +3,41 @@
 <!--
 Draft for the 4.0.0 GitHub release body. Written alongside #391 (the
 xcresulttool legacy migration); the report-redesign workstream adds its own
-sections before the release ships.
+sections during the release-candidate line.
 -->
+
+## 4.0 ships as a release-candidate line
+
+4.0 rewrites how result bundles are read, and the only way to learn whether
+that rewrite holds against real projects is to put it in front of real
+projects. So 4.0.0 is being cut as a series of release candidates —
+`4.0.0rc1`, `4.0.0rc2`, … — rather than one stable tag, and each is published
+as a GitHub **pre-release**. `brew install xctesthtmlreport` and `mint install
+XCTestHTMLReport/XCTestHTMLReport` keep resolving to the 3.x stable line until
+4.0.0 final, so a candidate is always opt-in:
+
+``` bash
+mint install XCTestHTMLReport/XCTestHTMLReport@4.0.0rc1
+```
+
+Each candidate also attaches a signed, notarized universal binary
+(`xchtmlreport-4.0.0rc1.zip`) to its release page.
+
+**`4.0.0rc1` is the migration plus a conservative refresh.** Everything below
+— the `xcresulttool` migration, the `--json` schema, `--result-reader`, and
+the report changes both readers now share — is in this candidate and is what
+we are asking for soak time on. The report's own markup and styling are
+deliberately left close to 3.x here, so that any regression you hit points at
+the reader rewrite rather than at a redesign landing on top of it.
+
+**The Xcode-native report redesign lands later in the RC line**, from
+`4.0.0rc2` on, with its own notes appended to this document. The candidate
+line ends when the reader rewrite has gone a full cycle without a parity or
+correctness report against it.
+
+Please file anything you find against
+[the 4.0 milestone](https://github.com/XCTestHTMLReport/XCTestHTMLReport/milestone/2);
+a bug found in a candidate is the entire point of the exercise.
 
 ## Why a major release
 
@@ -151,6 +184,42 @@ if one of these four quietly disappears:
 `--json` output additionally carries `testCase.arguments`, which only the
 modern reader can populate (the legacy format has no counterpart) — see the
 contract document.
+
+## Fixes
+
+Independent of the migration, and applying to both readers:
+
+- **A missing `--output` directory is created, not discovered at the end.**
+  `xchtmlreport <bundle> --output /missing/dir` used to parse the bundle,
+  export attachments and render the whole report, then die on the final write
+  with `The file "index.html" doesn't exist.` — a message that named neither
+  the real problem nor anything you could act on, and arrived after the work
+  was already done. The directory (with intermediates) is now created before
+  any work starts. One that genuinely cannot be created is a usage error: it
+  names the path and the reason and exits 64, like the tool's other usage
+  errors (#446).
+- **A run log that resolves to nothing is now a fault.** A log reference that
+  exists in the bundle but yields no content used to leave the report silently
+  short a log and still exit 0. `Summary.validate()` now reports it as
+  `unresolvedLog`, alongside the `unresolvedAttachment` check it already ran.
+  A run that never had a log reference is structural absence and is still
+  never a fault (#386).
+- **A legacy attachment payload whose export fails now reports it.** The
+  `payloadExportFailed` fault existed but the legacy payload path could not
+  reach its own call site, so a failed export degraded the report without
+  saying so (#388).
+- **Attachment filenames are escaped in the report's markup.** An attachment
+  whose name contained HTML or quote characters was interpolated into the page
+  and into inline JavaScript unescaped (#463).
+- **The report passes an axe-core accessibility audit.** Six violations in the
+  generated markup are cleared and the audit is now a CI gate (#462).
+
+For releases themselves, the fixture gate shared by the test workflows now
+asserts that each generated `.xcresult` contains real test data rather than
+merely an `Info.plist`. A vanished simulator could previously leave a stub
+bundle that passed the gate, failed the suite later with a confusing error,
+and came one step from being saved to the fixture cache — where it would have
+poisoned every restore until the key rotated (#454).
 
 ## What is *not* in 4.0
 


### PR DESCRIPTION
4.0 goes out as a **candidate line** rather than one stable tag: the reader rewrite needs real projects pointed at it before it can be called done. This makes the repo ready for a `4.0.0rc1` tag. **It does not tag anything** — the tag is pushed after this merges.

## The tag is `4.0.0rc1`, and the plumbing for it already worked

Worth stating up front, because it is the reason this PR is small. `4.0.0rc1` matches the existing `[0-9]+.[0-9]+.[0-9]+rc[0-9]+` filter, `*rc*` already sets `prerelease=true`, `--prerelease` already keeps a release off "Latest", `bump_version` already skips candidates, and `pages-release.yml` is already stable-only so no demo render is published for an RC. **Tag filters are untouched.**

Moving to v-prefixed semver tags (`v4.0.0-rc.1`) would have meant changing four workflows plus `assemble_site.py`, and an RC release PR is the wrong vehicle for that. Filed as #473 with the full change list.

## What actually changed

### `Version.swift`: `3.0.1-pre.69b32fe` → `4.0.0-pre`

`release.yml` has stamped the tag into this file since the version-reporting fix, so the *released* binary was never wrong. But `brew install --HEAD` and `mint install …@main` builds report this string, and it named the wrong major line.

Deliberately **not** `4.0.0-rc.1`: main is not the candidate, the tag is. Hardcoding a version main has not reached is exactly the lie the stamping step exists to prevent.

### The release body now comes from `docs/release-notes/`

The 4.0 notes have been sitting unread while releases published a bare generated changelog. Now wired in:

- Looked up **per `X.Y.Z`**, so `4.0.0rc1` and `4.0.0` resolve to the same document and cannot drift.
- A version with **no** document falls back to generated notes rather than failing a release that is already built and notarized.
- `--generate-notes` **stays**: `gh` prepends `--notes-file` to it rather than replacing it, so the body reads as the curated document followed by the automatic changelog and contributor list.
- This needs the release job to see the tree, so it gains a **sparse, credential-free** checkout of `docs/release-notes` alone. On a tag push that checkout is the tag, so a release publishes the notes as they stood at the commit it was cut from.

### A candidate announces itself

The pre-release banner is generated **per tag** rather than written into the document — the document is shared with the final release — and it names the real tag and the real asset, so the install line on the page is one that works:

> [!IMPORTANT]
> **4.0.0rc1 is a release candidate**, published as a pre-release.
> `brew install xctesthtmlreport` and `mint install XCTestHTMLReport/XCTestHTMLReport` keep resolving to the latest stable release, so this one is opt-in:
> ```bash
> mint install XCTestHTMLReport/XCTestHTMLReport@4.0.0rc1
> ```
> Or download `xchtmlreport-4.0.0rc1.zip` below: a signed, notarized universal binary.

### Release notes: RC preamble + the fixes that landed after the draft

An RC-cycle preamble explains that `4.0.0rc1` is the migration plus a conservative refresh, and that the Xcode-native redesign lands from `4.0.0rc2` on. Plus the fixes the draft predates: output-directory creation (#446), the unresolved-log and failed-payload faults (#386, #388), attachment filename escaping (#463), and the accessibility pass (#462). The CI fixture gate (#454) is noted as release-integrity rather than user-facing.

README pins no version anywhere, so it needed no change.

## What a `4.0.0rc1` tag push will do

1. Matches `[0-9]+.[0-9]+.[0-9]+rc[0-9]+` → `release.yml` runs. `pages-release.yml` does **not** (stable-only).
2. `version=4.0.0rc1`, `base_version=4.0.0`, `prerelease=true`, `archive_name=xchtmlreport-4.0.0rc1.zip`.
3. Stamps `let version = "4.0.0rc1"`, builds arm64 + x86_64, lipos, and **fails the run** if `--version` does not print `4.0.0rc1`.
4. Signs, verifies, packages, notarizes.
5. Composes the body from `docs/release-notes/4.0.0.md` behind the RC banner.
6. `gh release create 4.0.0rc1 --generate-notes --verify-tag --notes-file release-body.md --prerelease …` → published as a **pre-release**, not Latest.
7. `bump_version` **skips** (`prerelease != 'true'` is false).

## Verification

- `swift test` green **both legs** — `XCHR_RESULT_READER=auto` and `=modern`, 140 tests, 0 failures, 3 skipped each.
- `zizmor --min-severity low .github/workflows/` — **no findings**, run at CI's pinned 1.29.0.
- `actionlint` — one `SC2129` style nit, pre-existing on `main` in the dry-run-summary step, untouched here.
- `swiftformat --lint` / `swiftlint` clean.
- Metadata derivation exercised against `4.0.0rc1`, `4.0.0`, `3.0.1rc1` and the dry-run path; release-body composition executed against the real notes file.
- Built binary reports `4.0.0-pre`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced the 4.0.0 release-candidate series.
  - Added installation and migration guidance for the new release.
  - Documented reporting scope and prerelease usage details.

- **Bug Fixes**
  - Improved output-directory creation and usage error handling.
  - Resolved missing logs and legacy attachment export issues.
  - Improved markup escaping, accessibility auditing, and fixture validation.

- **Documentation**
  - Expanded the 4.0.0 release notes with fixes, migration information, and reporting details.
  - Improved release-note handling for prereleases and releases without curated notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->