### PR TITLE
Give the report a summary header it can be triaged from (refs #439)

### DIFF
--- a/Sources/XCTestHTMLReportCore/Classes/HTMLTemplates.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/HTMLTemplates.swift
@@ -1902,13 +1902,22 @@ struct HTMLTemplates
   ///
   /// It sits inside `<header>`, which is already the banner landmark, so the
   /// section needs no landmark of its own to satisfy axe's `region` rule.
+  ///
+  /// The run duration is written `Duration (5.04s)` — a label, then the value
+  /// parenthesised in its own element. The parentheses are not decoration:
+  /// `(N.NNs)` is the shape the differential's `durations` known-loss rule
+  /// normalises, and this total inherits that loss because a parameterized
+  /// Swift Testing case reports a different duration on each backend. Writing
+  /// it in any other shape would leave a declared divergence unmasked and turn
+  /// the differential red on a slow enough runner. `RunSummaryTests` asserts
+  /// against the masker that this actually holds, rather than assuming it.
   static let runSummary = """
   <section id=\"run-summary\" aria-labelledby=\"run-summary-heading\">
         <div class=\"summary-card\">
           <h2 id=\"run-summary-heading\">
             <span class=\"icon [[OVERALL_STATUS_CLASS]]\"></span>
             Tests
-            <span class=\"summary-meta\">[[SUMMARY_META]]</span>
+            <span class=\"summary-meta\">Duration <span class=\"summary-duration\">([[RUN_DURATION]])</span> &middot; [[DEVICES_LABEL]]</span>
           </h2>
           <div class=\"summary-grid\">
             <div class=\"donut\">

--- a/Sources/XCTestHTMLReportCore/Classes/HTMLTemplates.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/HTMLTemplates.swift
@@ -53,11 +53,44 @@ struct HTMLTemplates
       --status-skipped: #6E6E73;
       --status-unknown: #6E6E73;
       --status-expected: #9A6400;
+      /* Mixed is the one status the tree draws from two tokens rather than
+         one — half passed, half failed, because that is what it means. A
+         14px ring arc and a 10px legend swatch are too small to read a split
+         at, so the summary header (#439, A1) paints mixed in a single hue of
+         its own instead, chosen not to collide with any other status. The
+         tree's split diamond is unchanged; both readings still say "some of
+         each", one by geometry and one by being neither green nor red. */
+      --status-mixed: #8944AB;
 
       /* Colour — surfaces */
       --color-surface: #FFF;
       --color-bg-sidebar: #F2F2F2;
       --color-bg-group-header: #F6F6F6;
+
+      /* Colour — the summary header (#439, A1). A band with cards on it,
+         which is one more surface level than the rest of the report has, so
+         these are their own tokens rather than reuses. Values are Apple's
+         grouped-background pairing; the dark block below is the primary one
+         (this direction is dark-first) and light is its inversion.
+
+         Every text pairing these introduce was computed before it was used;
+         the table is in the PR body. The tightest are muted text on the
+         striped digest row — 6.97:1 light, 5.11:1 dark — and the accent the
+         digest's jump buttons use, 5.33:1 light, 6.50:1 dark. The status
+         fills the ring and the bars paint clear the 3:1 non-text floor
+         against the card by 4.21:1 (passed, light) at worst.
+
+         --color-summary-border and --color-donut-track do not clear 3:1 and
+         are not meant to: a card edge and the ring's empty groove carry no
+         information the arcs and the legend do not already carry in colour
+         *and* in text, and 1.4.11 scopes the floor to graphics you must
+         perceive to understand the content. Raising them to 3:1 would draw
+         the heavy outline the rest of the sheet already avoids. */
+      --color-bg-summary: #ECECEE;
+      --color-summary-card: #FFF;
+      --color-summary-card-alt: #F7F7F9;
+      --color-summary-border: #D2D2D7;
+      --color-donut-track: #E3E3E8;
 
       /* Colour — borders */
       --color-border-strong: #BBB;
@@ -151,10 +184,23 @@ struct HTMLTemplates
         --status-skipped: #9A9AA2;
         --status-unknown: #9A9AA2;
         --status-expected: #D9A038;
+        --status-mixed: #C89AF5;
 
         --color-surface: #161619;
         --color-bg-sidebar: #232327;
         --color-bg-group-header: #202024;
+
+        /* The summary header's own surfaces. The card is the same value as
+           the sidebar, which is deliberate: it is the lightest ground in the
+           dark theme, so every status token was already sized against it and
+           the header inherits those measurements unchanged (5.61 skipped to
+           6.74 expected). The band beneath the cards is darker than the page
+           so the cards read as raised, the way Xcode's do. */
+        --color-bg-summary: #19191C;
+        --color-summary-card: #232327;
+        --color-summary-card-alt: #2A2A2F;
+        --color-summary-border: #3A3A40;
+        --color-donut-track: #3A3A40;
 
         --color-border-strong: #3A3A40;
         --color-border-medium: #33333A;
@@ -208,6 +254,11 @@ struct HTMLTemplates
          two rows never wrap on their own — the pills that do wrap live in
          .tests-header, not here. */
       min-height: 70px;
+      /* A flex item shrinks by default, and #439's summary band made that
+         visible: in a short window the header shrank below its content and
+         `overflow: hidden` on the body clipped the digest. The band caps its
+         own height at 50vh, so refusing to shrink cannot starve the tree. */
+      flex: none;
     }
 
     #info-sections ul {
@@ -845,6 +896,262 @@ struct HTMLTemplates
       color: var(--color-on-accent);
     }
 
+    /* Summary header (#439, redesign A1).
+
+       Everything from here to the media query is new, and nothing below the
+       header was restyled: the tree, the panes and the filter pills are byte
+       for byte what they were. A2 restyles the tree; A3 the filters.
+
+       The band is a flex item of #content, capped at half the viewport so a
+       run with a long failure digest can never push the tree off the screen —
+       the digest scrolls inside itself rather than growing without bound. */
+    #run-summary {
+      background-color: var(--color-bg-summary);
+      border-bottom: 1px solid var(--color-border-strong);
+      padding: var(--space-sm) var(--space-sm) 12px;
+      max-height: 50vh;
+      overflow-y: auto;
+    }
+
+    .summary-card {
+      background-color: var(--color-summary-card);
+      border: 1px solid var(--color-summary-border);
+      border-radius: 10px;
+      /* So the striped digest rows are clipped by the rounded corner rather
+         than squaring it off. */
+      overflow: hidden;
+    }
+
+    .summary-card + .summary-card {
+      margin-top: var(--space-sm);
+    }
+
+    .summary-card > h2 {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      margin: 0;
+      padding: 8px 12px;
+      border-bottom: 1px solid var(--color-summary-border);
+      font-size: var(--font-size-md);
+      font-weight: var(--font-weight-medium);
+    }
+
+    .summary-meta {
+      margin-left: auto;
+      color: var(--color-text-muted);
+      font-size: var(--font-size-sm);
+      font-weight: var(--font-weight-regular);
+    }
+
+    .summary-grid {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 20px;
+      padding: 12px;
+    }
+
+    /* One class per status drives all three readings of it — the ring's arc,
+       the bar's segment and the legend's swatch — by setting `color` and
+       letting `currentColor` do the rest. A stroke, a fill and a background
+       from one declaration, which is also why the dark block has to override
+       nothing here. */
+    .status-tint-succeeded { color: var(--status-passed); }
+    .status-tint-failed { color: var(--status-failed); }
+    .status-tint-skipped { color: var(--status-skipped); }
+    .status-tint-mixed { color: var(--status-mixed); }
+    .status-tint-unknown { color: var(--status-unknown); }
+    .status-tint-expected-failure { color: var(--status-expected); }
+
+    /* The ring and its label share one grid cell, which centres the label
+       without positioning it. */
+    .donut {
+      display: grid;
+      place-items: center;
+      flex: none;
+      width: 108px;
+      height: 108px;
+    }
+
+    .donut > * {
+      grid-area: 1 / 1;
+    }
+
+    .donut-ring {
+      width: 108px;
+      height: 108px;
+    }
+
+    .donut-track {
+      fill: none;
+      stroke: var(--color-donut-track);
+      stroke-width: 12;
+    }
+
+    .donut-seg {
+      fill: none;
+      stroke: currentColor;
+      stroke-width: 12;
+    }
+
+    .donut-center {
+      text-align: center;
+      line-height: 1.15;
+    }
+
+    .donut-center strong {
+      display: block;
+      font-size: var(--font-size-title);
+      font-weight: var(--font-weight-medium);
+    }
+
+    .donut-center small {
+      display: block;
+      font-size: var(--font-size-xs);
+      color: var(--color-text-muted);
+    }
+
+    .summary-legend {
+      flex: 0 1 auto;
+      min-width: 170px;
+      font-size: var(--font-size-sm);
+    }
+
+    .summary-legend li {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 2px 0;
+    }
+
+    .legend-swatch {
+      width: var(--icon-size-sm);
+      height: var(--icon-size-sm);
+      border-radius: var(--radius-sm);
+      background-color: currentColor;
+      flex: none;
+    }
+
+    .legend-count {
+      margin-left: auto;
+      color: var(--color-text-secondary);
+      font-variant-numeric: tabular-nums;
+    }
+
+    .device-bars {
+      flex: 1 1 300px;
+      min-width: 240px;
+    }
+
+    .device-bars-head {
+      color: var(--color-text-muted);
+      font-size: var(--font-size-xs);
+      padding-bottom: 2px;
+      border-bottom: 1px solid var(--color-summary-border);
+    }
+
+    .device-row {
+      padding: 6px 0;
+    }
+
+    .device-row-name {
+      display: block;
+      font-size: var(--font-size-sm);
+      overflow-wrap: anywhere;
+    }
+
+    .device-row-os {
+      color: var(--color-text-muted);
+    }
+
+    /* An SVG rather than nested divs so no width lands in a `style`
+       attribute: the segments are `<rect>`s in a 0-100 user space, which is
+       the same arithmetic the ring's dash lengths use. `border-radius` on the
+       element clips them, and the track shows through wherever a run produced
+       no tests at all. */
+    .segbar {
+      display: block;
+      width: 100%;
+      height: 8px;
+      margin: var(--space-xs) 0 2px;
+      border-radius: var(--radius-sm);
+      overflow: hidden;
+      background-color: var(--color-donut-track);
+    }
+
+    .segbar rect {
+      fill: currentColor;
+    }
+
+    .device-row-tally {
+      color: var(--color-text-muted);
+      font-size: var(--font-size-xs);
+    }
+
+    .failure-digest {
+      font-size: var(--font-size-sm);
+      max-height: 168px;
+      overflow-y: auto;
+    }
+
+    .failure-digest li {
+      display: grid;
+      grid-template-columns: auto 1fr auto;
+      gap: 8px;
+      align-items: baseline;
+      padding: 6px 12px;
+    }
+
+    .failure-digest li:nth-child(even) {
+      background-color: var(--color-summary-card-alt);
+    }
+
+    .failure-digest .icon {
+      margin: 0;
+      align-self: center;
+    }
+
+    .digest-body {
+      min-width: 0;
+    }
+
+    /* A real <button>, so the digest is reachable and operable from the
+       keyboard, wearing a link's clothes. */
+    .digest-jump {
+      display: block;
+      padding: 0;
+      border: 0;
+      background: none;
+      font: inherit;
+      font-weight: var(--font-weight-medium);
+      color: var(--color-accent-text);
+      text-align: left;
+      cursor: pointer;
+      overflow-wrap: anywhere;
+    }
+
+    .digest-jump:hover {
+      text-decoration: underline;
+    }
+
+    .digest-jump:focus-visible {
+      outline: 2px solid var(--color-accent);
+      outline-offset: 2px;
+      border-radius: var(--radius-sm);
+    }
+
+    .digest-message {
+      display: block;
+      color: var(--color-text-muted);
+      overflow-wrap: anywhere;
+    }
+
+    .digest-suite {
+      color: var(--color-text-muted);
+      white-space: nowrap;
+    }
+
     /* Narrow screens (#439).
 
        Everything above this point is the desktop layout, untouched: this
@@ -987,6 +1294,57 @@ struct HTMLTemplates
         max-height: 40vh;
         object-fit: contain;
       }
+
+      /* Summary header, narrow (#439, A1). The three columns of the summary
+         grid stack on their own — `flex-wrap` and the device bars' 300px
+         basis already do that — so this only tightens the spacing and shrinks
+         the ring, which at 108px would otherwise eat a third of a 375px row. */
+      /* 40vh, not the desktop 50: the title band and the Tests/Logs row are a
+         fixed cost, and on an 812px phone a half-viewport band left the tree
+         with less than the summary above it. */
+      #run-summary {
+        padding: 6px;
+        max-height: 40vh;
+      }
+
+      .summary-grid {
+        gap: 12px;
+        padding: var(--space-sm);
+      }
+
+      .donut,
+      .donut-ring {
+        width: 84px;
+        height: 84px;
+      }
+
+      .summary-legend {
+        min-width: 140px;
+      }
+
+      .device-bars {
+        flex-basis: 100%;
+      }
+
+      /* The suite drops under the message rather than off the page: it is the
+         column the mockup deletes at this width, but it is also the only
+         thing telling two same-named tests apart. */
+      .failure-digest li {
+        grid-template-columns: auto 1fr;
+      }
+
+      .failure-digest .digest-suite {
+        grid-column: 2;
+        white-space: normal;
+      }
+
+      /* One scroller, not two. On a phone the band's own cap is always the
+         binding one, so a second scroll region nested inside it would only
+         ever swallow the gesture that was meant for the band. */
+      .failure-digest {
+        max-height: none;
+        overflow-y: visible;
+      }
     }
 
     </style>
@@ -1000,6 +1358,7 @@ struct HTMLTemplates
           <h1>XCTestHTMLReport</h1>
           <div class=\"clear\"></div>
         </div>
+        [[RUN_SUMMARY]]
         <ul id=\"test-log-toolbar\" class=\"toolbar centered-toolbar toggle-toolbar\">
           <li class=\"selected\" onclick=\"showTests(this);\">Tests</li>
           <li onclick=\"showLogs(this);\">Logs</li>
@@ -1456,9 +1815,178 @@ struct HTMLTemplates
     document.querySelectorAll('.device-info')[0].classList.add(\"selected\");
     document.querySelectorAll('.run')[0].classList.add(\"active\");
 
+    // Failure digest (#439, A1). Each row's button carries the failing test's
+    // element id in `data-target`; nothing about the test reaches a script
+    // context, which is the shape #463 left behind.
+    //
+    // The digest lists every run's failures, but only one run is in the
+    // layout at a time, so a jump has four things to undo before the row is
+    // on screen: the Logs tab, a non-active run, a filter that hid the row,
+    // and the collapsed disclosure it sits behind.
+    var digestButtons = document.querySelectorAll('.digest-jump');
+    for (var d = 0; d < digestButtons.length; d++) {
+      digestButtons[d].addEventListener('click', digestJump, false);
+    }
+
+    function digestJump(e) {
+      var uuid = e.currentTarget.getAttribute('data-target'),
+          // A test with one iteration hangs its rows off `activities-`; a
+          // retried one off `iterations-`. Both ids come from the same uuid,
+          // and the outer row is the nearest .test-summary either way.
+          disclosure = document.getElementById('activities-' + uuid)
+                    || document.getElementById('iterations-' + uuid);
+      if (!disclosure) {
+        return;
+      }
+
+      var row = disclosure.closest('.test-summary');
+      if (!row) {
+        return;
+      }
+
+      var testsTab = document.querySelector('#test-log-toolbar li');
+      if (testsTab && !testsTab.classList.contains('selected')) {
+        showTests(testsTab);
+      }
+
+      activateRunContaining(row);
+
+      // The filter writes `display: none` onto the element itself, and its
+      // group as well. Clearing both un-hides this one row without resetting
+      // the filter the reader chose.
+      row.style.display = 'block';
+      var group = row.closest('.test-summary-group');
+      if (group) {
+        group.style.display = 'block';
+      }
+
+      disclosure.style.display = 'block';
+      var chevron = row.querySelector('.drop-down-icon');
+      if (chevron) {
+        chevron.classList.add('dropped');
+      }
+
+      var listItem = row.querySelector('.list-item');
+      if (listItem) {
+        selectListItem(listItem);
+      }
+      row.scrollIntoView({ block: 'start' });
+    }
+
+    // `.run` elements and `.device-info` cards are rendered from one list of
+    // runs, in order, so the nth card selects the nth run. Going through
+    // selectDevice rather than toggling the classes here keeps one definition
+    // of what \"active\" means.
+    function activateRunContaining(el) {
+      var run = el.closest('.run');
+      if (!run || run.classList.contains('active')) {
+        return;
+      }
+      var runs = Array.prototype.slice.call(document.querySelectorAll('.run')),
+          cards = document.querySelectorAll('.device-info'),
+          index = runs.indexOf(run);
+      if (index >= 0 && cards[index]) {
+        selectDevice(run.id.replace('device_', ''), cards[index]);
+      }
+    }
+
     </script>
   </body>
   </html>
+  """
+
+  /// The summary header (#439, A1). Rendered whole by `RunSummary` and
+  /// substituted into the index as `[[RUN_SUMMARY]]`, so the header's markup
+  /// lives beside the templates it is built from rather than inside the
+  /// thousand-line index string.
+  ///
+  /// It sits inside `<header>`, which is already the banner landmark, so the
+  /// section needs no landmark of its own to satisfy axe's `region` rule.
+  static let runSummary = """
+  <section id=\"run-summary\" aria-labelledby=\"run-summary-heading\">
+        <div class=\"summary-card\">
+          <h2 id=\"run-summary-heading\">
+            <span class=\"icon [[OVERALL_STATUS_CLASS]]\"></span>
+            Tests
+            <span class=\"summary-meta\">[[SUMMARY_META]]</span>
+          </h2>
+          <div class=\"summary-grid\">
+            <div class=\"donut\">
+              [[DONUT]]
+              <span class=\"donut-center\"><strong>[[N_OF_TESTS]]</strong><small>[[TESTS_LABEL]]</small></span>
+            </div>
+            <ul class=\"summary-legend\">
+              [[LEGEND]]
+            </ul>
+            <div class=\"device-bars\">
+              <p class=\"device-bars-head\">Devices &amp; Configurations</p>
+              [[DEVICE_BARS]]
+            </div>
+          </div>
+        </div>
+        [[FAILURE_DIGEST]]
+      </section>
+  """
+
+  /// The ring. `aria-hidden` because the legend beside it already states every
+  /// count in text; announcing both would read the same run out twice.
+  static let summaryDonut = """
+  <svg class=\"donut-ring\" viewBox=\"0 0 120 120\" aria-hidden=\"true\" focusable=\"false\">
+                <circle class=\"donut-track\" cx=\"60\" cy=\"60\" r=\"48\"></circle>
+                [[SEGMENTS]]
+              </svg>
+  """
+
+  static let summaryDonutSegment = """
+  <circle class=\"donut-seg status-tint-[[STATUS_CLASS]]\" cx=\"60\" cy=\"60\" r=\"48\" pathLength=\"100\" stroke-dasharray=\"[[DASH]] [[GAP]]\" stroke-dashoffset=\"[[OFFSET]]\" transform=\"rotate(-90 60 60)\"></circle>
+  """
+
+  /// The space before the count is load-bearing for assistive technology and
+  /// free for layout: a whitespace-only text node between flex items is not
+  /// rendered, but without it the row's text content is \"Passed1\".
+  static let summaryLegendRow = """
+  <li><span class=\"legend-swatch status-tint-[[STATUS_CLASS]]\"></span>[[LABEL]] <span class=\"legend-count\">[[COUNT]]</span></li>
+  """
+
+  /// One device row: name, proportional bar, and the same breakdown in words.
+  /// The bar is `aria-hidden` for the reason the ring is — the caption beside
+  /// it is the accessible reading of the identical fact.
+  static let summaryDeviceRow = """
+  <div class=\"device-row\">
+                <span class=\"device-row-name\">[[DEVICE_LABEL]]</span>
+                <svg class=\"segbar\" viewBox=\"0 0 100 8\" preserveAspectRatio=\"none\" aria-hidden=\"true\" focusable=\"false\">[[SEGMENTS]]</svg>
+                <span class=\"device-row-tally\">[[DEVICE_TALLY]]</span>
+              </div>
+  """
+
+  static let summaryBarSegment = """
+  <rect class=\"status-tint-[[STATUS_CLASS]]\" x=\"[[X]]\" y=\"0\" width=\"[[WIDTH]]\" height=\"8\"></rect>
+  """
+
+  /// The failure digest. Omitted entirely when nothing failed.
+  static let summaryFailureDigest = """
+  <div class=\"summary-card\">
+          <h2>Test Failures <span class=\"summary-meta\">[[FAILURES_LABEL]]</span></h2>
+          <ul class=\"failure-digest\">
+            [[FAILURE_ROWS]]
+          </ul>
+        </div>
+  """
+
+  /// `data-target`, not an interpolated `onclick`: #463 took the last report
+  /// datum out of a script context, and the handler is bound from the script
+  /// instead. The value is an `IdentifierPath` digest, so it is hex either
+  /// way — the point is that nothing that follows this pattern can ever put a
+  /// test-author-controlled string into JavaScript.
+  static let summaryFailureRow = """
+  <li>
+              <span class=\"icon failure\"></span>
+              <span class=\"digest-body\">
+                <button type=\"button\" class=\"digest-jump\" data-target=\"[[UUID]]\">[[TEST_NAME]]</button>
+                <span class=\"digest-message\">[[MESSAGE]]</span>
+              </span>
+              <span class=\"digest-suite\">[[SUITE_NAME]]</span>
+            </li>
   """
 
   static let device = """

--- a/Sources/XCTestHTMLReportCore/Classes/Models/RunSummary+HTML.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Models/RunSummary+HTML.swift
@@ -19,7 +19,8 @@ extension RunSummary: HTML {
             "N_OF_TESTS": String(tally.total),
             "TESTS_LABEL": tally.total == 1 ? "Test" : "Tests",
             "OVERALL_STATUS_CLASS": Self.iconClass(for: overallStatus),
-            "SUMMARY_META": metaLine,
+            "RUN_DURATION": duration.formattedSeconds,
+            "DEVICES_LABEL": devices.count == 1 ? "1 device" : "\(devices.count) devices",
             "DONUT": donutHTML,
             "LEGEND": tally.buckets.map(Self.legendRow).joined(),
             "DEVICE_BARS": devices.map(Self.deviceRow).joined(),
@@ -37,12 +38,6 @@ extension RunSummary: HTML {
         case .success: return "success"
         default: return "skip"
         }
-    }
-
-    /// "Ran for 1.19s · 2 devices". No start time: `ParsedRun` has no date.
-    private var metaLine: String {
-        let devicesLabel = devices.count == 1 ? "1 device" : "\(devices.count) devices"
-        return "Ran for \(duration.formattedSeconds) · \(devicesLabel)"
     }
 
     /// "12 passed, 6 failed, 1 skipped" — the device bars' visible caption,

--- a/Sources/XCTestHTMLReportCore/Classes/Models/RunSummary+HTML.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Models/RunSummary+HTML.swift
@@ -1,0 +1,179 @@
+//
+//  RunSummary+HTML.swift
+//  XCTestHTMLReport
+//
+//  Rendering for the summary header (#439, A1). Split from `RunSummary.swift`
+//  so the derivation — which is the part with rules about what may be read —
+//  is not read alongside the string substitution.
+//
+
+import Foundation
+
+extension RunSummary: HTML {
+    var htmlTemplate: String {
+        HTMLTemplates.runSummary
+    }
+
+    var htmlPlaceholderValues: [String: String] {
+        [
+            "N_OF_TESTS": String(tally.total),
+            "TESTS_LABEL": tally.total == 1 ? "Test" : "Tests",
+            "OVERALL_STATUS_CLASS": Self.iconClass(for: overallStatus),
+            "SUMMARY_META": metaLine,
+            "DONUT": donutHTML,
+            "LEGEND": tally.buckets.map(Self.legendRow).joined(),
+            "DEVICE_BARS": devices.map(Self.deviceRow).joined(),
+            "FAILURE_DIGEST": failureDigestHTML,
+        ]
+    }
+
+    /// The class the shared icon rules paint the run-wide glyph from. Those
+    /// rules are named for the outcome, not for the `Status` case (`.skipped`
+    /// draws `.skip`), so the mapping is spelled out rather than reusing
+    /// `cssClass`, which names the row classes instead.
+    private static func iconClass(for status: Status) -> String {
+        switch status {
+        case .failure: return "failure"
+        case .success: return "success"
+        default: return "skip"
+        }
+    }
+
+    /// "Ran for 1.19s · 2 devices". No start time: `ParsedRun` has no date.
+    private var metaLine: String {
+        let devicesLabel = devices.count == 1 ? "1 device" : "\(devices.count) devices"
+        return "Ran for \(duration.formattedSeconds) · \(devicesLabel)"
+    }
+
+    /// "12 passed, 6 failed, 1 skipped" — the device bars' visible caption,
+    /// and the only reading of the bar that assistive technology gets, since
+    /// the bar itself is `aria-hidden`.
+    private static func spokenTally(_ tally: RunSummary.Tally) -> String {
+        guard tally.total > 0 else {
+            return "No tests"
+        }
+        return tally.buckets.map(\.spoken).joined(separator: ", ")
+    }
+
+    private static func legendRow(_ bucket: Bucket) -> String {
+        HTMLTemplates.summaryLegendRow
+            .replacingOccurrences(of: "[[STATUS_CLASS]]", with: bucket.status.cssClass)
+            .replacingOccurrences(
+                of: "[[LABEL]]", with: bucket.label.stringByEscapingXMLChars
+            )
+            .replacingOccurrences(of: "[[COUNT]]", with: String(bucket.count))
+    }
+
+    private static func deviceRow(_ device: DeviceRow) -> String {
+        // The OS version is a secondary span rather than being folded into the
+        // name, because it is the field that tells two otherwise identical
+        // destinations apart in a multi-runtime test plan.
+        let name = device.name.stringByEscapingXMLChars
+        let label = device.osVersion.isEmpty
+            ? name
+            : name + " <span class=\"device-row-os\">"
+            + device.osVersion.stringByEscapingXMLChars + "</span>"
+        return HTMLTemplates.summaryDeviceRow
+            .replacingOccurrences(of: "[[DEVICE_LABEL]]", with: label)
+            .replacingOccurrences(of: "[[SEGMENTS]]", with: barSegments(device.tally))
+            .replacingOccurrences(
+                of: "[[DEVICE_TALLY]]",
+                with: spokenTally(device.tally).stringByEscapingXMLChars
+            )
+    }
+
+    /// The bar's rects, in a 0–100 user-space viewBox so a segment's width is
+    /// its percentage.
+    private static func barSegments(_ tally: Tally) -> String {
+        segments(of: tally).map { segment in
+            HTMLTemplates.summaryBarSegment
+                .replacingOccurrences(of: "[[STATUS_CLASS]]", with: segment.status.cssClass)
+                .replacingOccurrences(of: "[[X]]", with: format(segment.start))
+                .replacingOccurrences(of: "[[WIDTH]]", with: format(segment.length))
+        }.joined()
+    }
+
+    /// The ring, as one stroked circle per non-empty bucket.
+    ///
+    /// `pathLength="100"` rebases the dash units onto the same 0–100 scale the
+    /// bar uses, so both readings share one arithmetic and neither needs π.
+    /// Each arc is a *stroke*: `stroke-dasharray` draws exactly its own share
+    /// and leaves the rest of the circumference as gap, and
+    /// `stroke-dashoffset` rotates that dash to where the previous arc ended.
+    /// `rotate(-90 …)` starts the run at twelve o'clock, as Xcode's does.
+    private var donutHTML: String {
+        let arcs = Self.segments(of: tally).map { segment in
+            HTMLTemplates.summaryDonutSegment
+                .replacingOccurrences(of: "[[STATUS_CLASS]]", with: segment.status.cssClass)
+                .replacingOccurrences(of: "[[DASH]]", with: Self.format(segment.length))
+                .replacingOccurrences(
+                    of: "[[GAP]]", with: Self.format(100 - segment.length)
+                )
+                .replacingOccurrences(of: "[[OFFSET]]", with: Self.format(-segment.start))
+        }.joined()
+        return HTMLTemplates.summaryDonut
+            .replacingOccurrences(of: "[[SEGMENTS]]", with: arcs)
+    }
+
+    private var failureDigestHTML: String {
+        guard !failures.isEmpty else {
+            // No failures, no card. The digest exists to answer "what broke";
+            // an empty one answers nothing and costs a screenful.
+            return ""
+        }
+        let rows = failures.map { failure in
+            HTMLTemplates.summaryFailureRow
+                .replacingOccurrences(of: "[[UUID]]", with: failure.uuid)
+                .replacingOccurrences(
+                    of: "[[TEST_NAME]]", with: failure.testName.stringByEscapingXMLChars
+                )
+                .replacingOccurrences(
+                    of: "[[MESSAGE]]", with: failure.message.stringByEscapingXMLChars
+                )
+                .replacingOccurrences(
+                    of: "[[SUITE_NAME]]", with: failure.suiteName.stringByEscapingXMLChars
+                )
+        }.joined()
+        return HTMLTemplates.summaryFailureDigest
+            .replacingOccurrences(of: "[[FAILURE_ROWS]]", with: rows)
+            .replacingOccurrences(
+                of: "[[FAILURES_LABEL]]",
+                with: failures.count == 1 ? "1 failure" : "\(failures.count) failures"
+            )
+    }
+
+    /// One bucket's share of the ring and of the bar: where it starts and how
+    /// far it runs, on a 0–100 scale.
+    private struct Segment {
+        let status: Status
+        let start: Double
+        let length: Double
+    }
+
+    /// Both ends are computed from the running count rather than by
+    /// accumulating the lengths, so rounding can neither leave a hairline gap
+    /// between two arcs nor let the last one overshoot the circle.
+    private static func segments(of tally: Tally) -> [Segment] {
+        guard tally.total > 0 else {
+            return []
+        }
+        var result: [Segment] = []
+        var consumed = 0
+        for bucket in tally.buckets {
+            let start = 100 * Double(consumed) / Double(tally.total)
+            consumed += bucket.count
+            let end = 100 * Double(consumed) / Double(tally.total)
+            result.append(Segment(status: bucket.status, start: start, length: end - start))
+        }
+        return result
+    }
+
+    /// Fixed precision, so a render is reproducible byte for byte (#430) and
+    /// two backends that agree on the counts agree on the markup.
+    ///
+    /// Zero is normalised first: the first arc's offset is `-0`, which `%.4f`
+    /// writes as `-0.0000`.
+    private static func format(_ value: Double) -> String {
+        String(format: "%.4f", value == 0 ? 0 : value)
+    }
+}

--- a/Sources/XCTestHTMLReportCore/Classes/Models/RunSummary.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Models/RunSummary.swift
@@ -1,0 +1,251 @@
+//
+//  RunSummary.swift
+//  XCTestHTMLReport
+//
+//  The Xcode-native summary header (#439, redesign step A1): the outcome
+//  ring, the per-device bars and the failure digest that sit above the tree.
+//
+//  Everything here is *derived*. No reader was touched to build it, and no
+//  field is read that the legacy and modern backends do not agree on — a
+//  divergence would land straight in `DifferentialTests`, whose allow-list
+//  this step deliberately does not grow. Two derivations were measured
+//  against all three fixtures on both backends before being used:
+//
+//  - **Counts.** `Status` partitions the leaf tests exactly (passed, failed,
+//    skipped, mixed, expected failure, unknown sum to the total on every
+//    fixture), and the differential already pins four of the six per run.
+//  - **Duration.** The sum of *leaf* test durations agrees to the fourth
+//    decimal on all three fixtures (TestResults 1.1882, SanityResults
+//    0.1059, RetryResults 0.6235). The sum of *group* durations does not,
+//    and cannot: `durationInSeconds` is null on every suite node in the
+//    modern format, which is the standing `durations` allow-list entry. So
+//    the header sums leaves, never groups.
+//
+//  `ParsedRun` carries no run date, so the header states a duration and no
+//  start time. Deriving one from the earliest activity timestamp — which the
+//  design mockup did — would be a field the differential does not cover.
+//
+
+import Foundation
+
+/// The header's whole view model: one ring, one row per device, one digest.
+struct RunSummary {
+    let tally: Tally
+    let devices: [DeviceRow]
+    let failures: [FailureRow]
+    let duration: TimeInterval
+    /// The one glyph that speaks for the whole report, by the same rule
+    /// `Summary` already applies to the title bar's icon: a failure anywhere
+    /// wins, then a pass, then skipped. Recomputed here rather than threaded
+    /// through a placeholder so this template renders standalone.
+    let overallStatus: Status
+
+    init(runs: [Run]) {
+        tally = runs.map(\.tally).reduce(.empty, +)
+        devices = runs.map(DeviceRow.init)
+        failures = runs.flatMap(\.failureRows)
+        duration = runs.reduce(0) { $0 + $1.duration }
+        if runs.contains(where: { $0.status == .failure }) {
+            overallStatus = .failure
+        } else if runs.contains(where: { $0.status == .success }) {
+            overallStatus = .success
+        } else {
+            overallStatus = .skipped
+        }
+    }
+}
+
+extension RunSummary {
+    /// How many tests landed in each terminal status.
+    ///
+    /// One field per `Status` case rather than a dictionary keyed by it: the
+    /// ring, the legend and every device bar have to walk the buckets in the
+    /// same order or the three readings of one run disagree, and a dictionary
+    /// has no order to walk.
+    struct Tally {
+        var passed = 0
+        var failed = 0
+        var skipped = 0
+        var mixed = 0
+        var expectedFailure = 0
+        var unknown = 0
+
+        static let empty = Tally()
+
+        var total: Int {
+            passed + failed + skipped + mixed + expectedFailure + unknown
+        }
+
+        /// The buckets, in the fixed order every rendering of them uses, with
+        /// the empty ones dropped.
+        ///
+        /// Dropped, not rendered as zeroes: Xcode's own summary names the
+        /// outcomes a run produced, and a permanent "Mixed 0" row in a report
+        /// that has never retried a test is noise. The ring is unaffected —
+        /// a zero-count bucket draws a zero-length arc either way.
+        var buckets: [Bucket] {
+            [
+                Bucket(status: .success, label: "Passed", count: passed),
+                Bucket(status: .failure, label: "Failed", count: failed),
+                Bucket(status: .skipped, label: "Skipped", count: skipped),
+                Bucket(status: .mixed, label: "Mixed", count: mixed),
+                Bucket(
+                    status: .expectedFailure,
+                    label: "Expected failures",
+                    count: expectedFailure
+                ),
+                Bucket(status: .unknown, label: "Unknown", count: unknown),
+            ].filter { $0.count > 0 }
+        }
+
+        init() {}
+
+        init(tests: [Test]) {
+            for test in tests {
+                switch test.status {
+                case .success: passed += 1
+                case .failure: failed += 1
+                case .skipped: skipped += 1
+                case .mixed: mixed += 1
+                case .expectedFailure: expectedFailure += 1
+                case .unknown: unknown += 1
+                }
+            }
+        }
+
+        static func + (lhs: Tally, rhs: Tally) -> Tally {
+            var sum = Tally()
+            sum.passed = lhs.passed + rhs.passed
+            sum.failed = lhs.failed + rhs.failed
+            sum.skipped = lhs.skipped + rhs.skipped
+            sum.mixed = lhs.mixed + rhs.mixed
+            sum.expectedFailure = lhs.expectedFailure + rhs.expectedFailure
+            sum.unknown = lhs.unknown + rhs.unknown
+            return sum
+        }
+    }
+
+    struct Bucket {
+        let status: Status
+        let label: String
+        let count: Int
+
+        /// How this bucket reads inside a sentence ("1 skipped, 2 expected
+        /// failures"). Five of the six labels are participles and are already
+        /// count-neutral; only the expected-failure one is a noun phrase and
+        /// needs the number agreed with.
+        var spoken: String {
+            guard status == .expectedFailure else {
+                return "\(count) \(label.lowercased())"
+            }
+            return count == 1 ? "1 expected failure" : "\(count) expected failures"
+        }
+    }
+
+    /// One "Devices & Configurations" row.
+    struct DeviceRow {
+        let name: String
+        let osVersion: String
+        let tally: Tally
+
+        init(run: Run) {
+            name = run.runDestination.name
+            osVersion = run.runDestination.targetDevice.osVersion
+            tally = run.tally
+        }
+    }
+
+    /// One line of the failure digest.
+    struct FailureRow {
+        /// The failing test's element id, which is what the digest's jump
+        /// button hands back to the page. Path-derived like every other id
+        /// (#430), so it is stable across renders and normalised away in the
+        /// cross-backend differential.
+        let uuid: String
+        let testName: String
+        /// The owning suite, taken from the *identifier* rather than from the
+        /// parent group's title. The identifier is the one key the
+        /// differential already pins as equal across backends
+        /// (`testStatusesAndCountsMatchAcrossBackends`), whereas the legacy
+        /// tree wraps every suite in "Selected tests" and "<target>.xctest"
+        /// levels the modern tree does not have.
+        let suiteName: String
+        /// The first failing activity's title, which is the assertion message
+        /// the tree shows on the red row. Empty when a test is failed but
+        /// recorded no failure activity.
+        let message: String
+    }
+}
+
+extension Run {
+    var tally: RunSummary.Tally {
+        RunSummary.Tally(tests: allTests)
+    }
+
+    /// Wall time this run's tests account for.
+    ///
+    /// Leaves only — see the note at the top of this file. `allTests` already
+    /// flattens the tree to its leaves, so a group's own duration is never
+    /// added on top of the cases it contains, and the modern format's null
+    /// suite durations cannot reach the total.
+    var duration: TimeInterval {
+        allTests.reduce(0) { $0 + $1.duration }
+    }
+
+    var failureRows: [RunSummary.FailureRow] {
+        allTests
+            .filter { $0.status == .failure }
+            .map { test in
+                RunSummary.FailureRow(
+                    uuid: test.uuid,
+                    testName: test.title,
+                    suiteName: Self.suiteName(of: test.identifier),
+                    message: Self.firstFailureMessage(of: test) ?? ""
+                )
+            }
+    }
+
+    /// `FirstSuite/testTwo()` → `FirstSuite`; a bare identifier → nothing.
+    private static func suiteName(of identifier: String) -> String {
+        let components = identifier.split(separator: "/")
+        guard components.count > 1 else {
+            return ""
+        }
+        return String(components[components.count - 2])
+    }
+
+    /// The assertion message the tree's red row carries, for the digest.
+    ///
+    /// Only `TestCase` holds iterations, and only iterations hold activities;
+    /// `allTests` yields leaves, so anything that is not a `TestCase` — an
+    /// empty group counted as a leaf — simply has no message.
+    private static func firstFailureMessage(of test: Test) -> String? {
+        guard let testCase = test as? TestCase else {
+            return nil
+        }
+        for iteration in testCase.iterations where iteration.status == .failure {
+            if let failure = firstFailure(in: iteration.activities) {
+                return failure.title
+            }
+        }
+        return nil
+    }
+
+    /// Pre-order, so the message is the first failure the tree shows rather
+    /// than whichever one a breadth-first walk happened to reach first.
+    ///
+    /// Not `Activity.failingActivityRecursive`: that returns the outermost
+    /// activity *containing* a failure, whose title is the step's name
+    /// ("Set Up"), not the assertion text.
+    private static func firstFailure(in activities: [Activity]) -> Activity? {
+        for activity in activities {
+            if activity.isFailure {
+                return activity
+            }
+            if let nested = firstFailure(in: activity.subActivities) {
+                return nested
+            }
+        }
+        return nil
+    }
+}

--- a/Sources/XCTestHTMLReportCore/Classes/Models/RunSummary.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Models/RunSummary.swift
@@ -21,23 +21,36 @@
 //    and zero on the other.
 //
 //    Summing leaves does not make the total backend-identical, and this file
-//    does not pretend otherwise. One leaf diverges — a parameterized Swift
-//    Testing case, where legacy sums the argument executions and modern
-//    reports the node's own value (measured on CI's TestResults:
-//    `parameterizedAddition(value:)` at 0.001268s legacy against 0.000423s
-//    modern, carrying a 0.85ms difference into a 5.04s total). That is the
-//    same divergence the `durations` entry already declares, so the total is
-//    rendered `Duration (5.04s)` — parenthesised, in the shape that rule
-//    normalises — rather than in a shape that would leave a declared loss
-//    unmasked and fail the differential intermittently, on whichever runner
-//    happened to be slow enough to cross a rounding boundary.
+//    does not pretend otherwise. Two leaf-level divergences reach it, and they
+//    are different in kind:
 //
-//    The root cause is fixable and predates this header: answer 8 of the
-//    migration design already solved the identical problem for *repetitions*
-//    by summing in the renderer, and nobody applied it to *arguments* when
-//    answer 6 added them. See the follow-up issue named in
-//    `DifferentialTests.testSummaryHeaderNumbersAgreeAcrossBackends`; when it
-//    lands, this paragraph and that test's exclusion both come out.
+//    1. *Structural, and fixable.* A parameterized Swift Testing case, where
+//       legacy sums the argument executions and modern reports the node's own
+//       value (measured on CI's TestResults: `parameterizedAddition(value:)`
+//       at 0.001268s legacy against 0.000423s modern, carrying a 0.85ms
+//       difference into a 5.04s total). This one predates the header: answer 8
+//       of the migration design already solved the identical problem for
+//       *repetitions* by summing in the renderer, and nobody applied it to
+//       *arguments* when answer 6 added them. The follow-up issue named in
+//       `DifferentialTests.testSummaryHeaderNumbersAgreeAcrossBackends` closes
+//       it, and takes that test's by-name exclusion out with it.
+//
+//    2. *Measurement, and permanent.* A leaf the run repeated can differ by
+//       microseconds, because the two formats measure and report the same
+//       repetition independently — 144µs on `RetryTests/testRetryOnFailure()`
+//       in one fixture generation, 0 in another, all of it in a single
+//       repetition. The summing is already common to both readers, so there is
+//       nothing here to converge. The migration spec records it as a measured
+//       format property under Verification.
+//
+//    Either one alone is why the total is rendered `Duration (5.04s)` —
+//    parenthesised, in the shape the `durations` rule normalises — rather than
+//    in a shape that would leave a declared loss unmasked and fail the
+//    differential intermittently, on whichever runner happened to be slow
+//    enough to cross a rounding boundary. Note it follows that closing the
+//    issue in (1) does **not** free the total to be written in any shape: (2)
+//    keeps the masked shape necessary for as long as a repeated test can land
+//    in a report.
 //
 //  `ParsedRun` carries no run date, so the header states a duration and no
 //  start time. Deriving one from the earliest activity timestamp — which the

--- a/Sources/XCTestHTMLReportCore/Classes/Models/RunSummary.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Models/RunSummary.swift
@@ -5,21 +5,39 @@
 //  The Xcode-native summary header (#439, redesign step A1): the outcome
 //  ring, the per-device bars and the failure digest that sit above the tree.
 //
-//  Everything here is *derived*. No reader was touched to build it, and no
-//  field is read that the legacy and modern backends do not agree on — a
-//  divergence would land straight in `DifferentialTests`, whose allow-list
-//  this step deliberately does not grow. Two derivations were measured
-//  against all three fixtures on both backends before being used:
+//  Everything here is *derived*. No reader was touched to build it, and the
+//  differential allow-list is not grown. Two derivations, measured against
+//  all three fixtures on both backends:
 //
 //  - **Counts.** `Status` partitions the leaf tests exactly (passed, failed,
 //    skipped, mixed, expected failure, unknown sum to the total on every
 //    fixture), and the differential already pins four of the six per run.
-//  - **Duration.** The sum of *leaf* test durations agrees to the fourth
-//    decimal on all three fixtures (TestResults 1.1882, SanityResults
-//    0.1059, RetryResults 0.6235). The sum of *group* durations does not,
-//    and cannot: `durationInSeconds` is null on every suite node in the
-//    modern format, which is the standing `durations` allow-list entry. So
-//    the header sums leaves, never groups.
+//    These are compared byte for byte across backends; nothing masks them.
+//
+//  - **Duration.** The sum of *leaf* test durations, never of groups:
+//    `durationInSeconds` is null on every suite node in the modern format,
+//    which is the standing `durations` allow-list entry, so a total that
+//    reached for a group's duration would read a real value on one backend
+//    and zero on the other.
+//
+//    Summing leaves does not make the total backend-identical, and this file
+//    does not pretend otherwise. One leaf diverges — a parameterized Swift
+//    Testing case, where legacy sums the argument executions and modern
+//    reports the node's own value (measured on CI's TestResults:
+//    `parameterizedAddition(value:)` at 0.001268s legacy against 0.000423s
+//    modern, carrying a 0.85ms difference into a 5.04s total). That is the
+//    same divergence the `durations` entry already declares, so the total is
+//    rendered `Duration (5.04s)` — parenthesised, in the shape that rule
+//    normalises — rather than in a shape that would leave a declared loss
+//    unmasked and fail the differential intermittently, on whichever runner
+//    happened to be slow enough to cross a rounding boundary.
+//
+//    The root cause is fixable and predates this header: answer 8 of the
+//    migration design already solved the identical problem for *repetitions*
+//    by summing in the renderer, and nobody applied it to *arguments* when
+//    answer 6 added them. See the follow-up issue named in
+//    `DifferentialTests.testSummaryHeaderNumbersAgreeAcrossBackends`; when it
+//    lands, this paragraph and that test's exclusion both come out.
 //
 //  `ParsedRun` carries no run date, so the header states a duration and no
 //  start time. Deriving one from the earliest activity timestamp — which the

--- a/Sources/XCTestHTMLReportCore/Classes/Models/Summary.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Models/Summary.swift
@@ -305,6 +305,12 @@ extension Summary: HTML {
         return [
             "DEVICES": runs.map(\.runDestination.html).joined(),
             "RESULT_CLASS": resultClass,
+            // Fully rendered before it gets here, so the header's own
+            // placeholders are gone by the time this dictionary is applied.
+            // That matters because the substitution walks an unordered
+            // dictionary: a value still carrying `[[N_OF_TESTS]]` would be
+            // filled or not depending on iteration order.
+            "RUN_SUMMARY": RunSummary(runs: runs).html,
             "RUNS": runs.map(\.html).joined(),
             "TITLE": title.stringByEscapingXMLChars,
         ]

--- a/Tests/XCTestHTMLReportTests/CoreTests.swift
+++ b/Tests/XCTestHTMLReportTests/CoreTests.swift
@@ -100,8 +100,12 @@ final class CoreTests: XCTestCase {
                 all - skipped - 2,
                 "Every remaining test lands in exactly one bucket, except the " +
                     "two `Expected Failure` cases (testExpectedFailure and " +
-                    "knownIssue) — `Status` folds them to `.unknown`, so today " +
-                    "they are counted in no header bucket at all; see #439"
+                    "knownIssue). These are the per-run *filter pills*, which " +
+                    "#439's A1 did not touch: they still offer five buckets " +
+                    "and an expected failure matches none of them. The summary " +
+                    "header added by A1 does count them — see " +
+                    "`testSummaryHeaderAccountsForExpectedFailures` below — so " +
+                    "the two readings disagree until A3 rebuilds the filters"
             )
             XCTAssertGreaterThanOrEqual(
                 failed, 6,
@@ -109,6 +113,48 @@ final class CoreTests: XCTestCase {
                     "a lower count means failures are being lost"
             )
         }
+    }
+
+    /// The summary header's counts, on the real fixture rather than the
+    /// synthetic one `RunSummaryTests` pins exactly.
+    ///
+    /// The split cannot be asserted — the bundles are regenerated on every run
+    /// — but two properties can: the buckets partition the tests, and the two
+    /// deliberate `Expected Failure` cases land in a bucket rather than
+    /// nowhere. Before #439 they landed nowhere, which is the gap this
+    /// header closes.
+    func testSummaryHeaderAccountsForExpectedFailures() throws {
+        let testResultsUrl = try XCTUnwrap(testResultsUrl)
+        let summary = Summary(
+            resultPaths: [testResultsUrl.path],
+            renderingMode: .linking,
+            downsizeImagesEnabled: false,
+            downsizeScaleFactor: 0.5
+        )
+
+        let document = try SwiftSoup.parse(summary.html)
+        let legend = try document.select("ul.summary-legend li").array()
+        var counted = 0
+        var expected = 0
+        for row in legend {
+            let count = try Int(row.select(".legend-count").text()) ?? 0
+            counted += count
+            if try row.text().hasPrefix("Expected failures") {
+                expected = count
+            }
+        }
+
+        let total = try Int(document.select(".donut-center strong").text())
+        XCTAssertEqual(
+            counted, total,
+            "the legend's buckets must add up to the run's test count"
+        )
+        XCTAssertEqual(
+            expected, 2,
+            "testExpectedFailure and knownIssue are the sample sources' two "
+                + "deliberate expected failures; before #439 they were counted "
+                + "in no bucket at all"
+        )
     }
 
     /// Swift Testing (`import Testing`, `@Test`) results are recorded

--- a/Tests/XCTestHTMLReportTests/DifferentialSummaryHeaderTests.swift
+++ b/Tests/XCTestHTMLReportTests/DifferentialSummaryHeaderTests.swift
@@ -1,0 +1,89 @@
+//
+//  DifferentialSummaryHeaderTests.swift
+//
+//  The cross-backend assertions for #439's summary header, in an extension
+//  rather than in `DifferentialTests` itself: that file was already at its
+//  length limit, and these share its cached summaries, which is what keeps a
+//  suite dominated by `xcresulttool` subprocess time from doubling.
+//
+
+import XCTest
+@testable import XCTestHTMLReportCore
+
+extension DifferentialTests {
+    /// The one leaf duration the summary header's total is allowed to inherit
+    /// a divergence from (#477).
+    ///
+    /// Legacy merges a parameterized Swift Testing case's argument executions
+    /// into iterations and so sums their durations; the modern reader reports
+    /// the node's own value. Measured on CI's `TestResults`: 0.001268s against
+    /// 0.000423s, three argument sets. Every other leaf agrees exactly.
+    ///
+    /// Narrower than `testXCTestCaseDurationsAgreeAcrossBackends`'s blanket
+    /// `SwiftTestingSuite/` filter on purpose — the non-parameterized Swift
+    /// Testing cases do agree, and this pins them. Delete this constant, and
+    /// the `filter` that reads it, when #477 lands.
+    private static let divergentDurationIdentifier =
+        "SwiftTestingSuite/parameterizedAddition"
+
+    /// What the summary header derives, asserted on the model rather than
+    /// through the render — the same reason
+    /// `testXCTestCaseDurationsAgreeAcrossBackends` exists.
+    ///
+    /// The header's *total* is deliberately not compared here: it sums leaves,
+    /// and one leaf diverges (#477), so the total inherits that divergence.
+    /// The header therefore writes its total in the parenthesised `(N.NNs)`
+    /// shape the `durations` known-loss rule already normalises, and
+    /// `RunSummaryTests.testTheHeadersDurationIsWrittenInAMaskedShape` proves
+    /// that against the masker.
+    ///
+    /// What is asserted instead is stronger and does not rot: every leaf
+    /// duration except that one identifier must agree *exactly*, and every
+    /// status bucket must match. When #477 converges the two backends the
+    /// exclusion becomes unnecessary, and the constant above says so.
+    func testSummaryHeaderNumbersAgreeAcrossBackends() throws {
+        try requireBothBackends()
+        for fixture in Self.fixtures {
+            let legacy = try summary(fixture, .legacy)
+            let modern = try summary(fixture, .modern)
+
+            func leafDurations(_ summary: Summary) -> [String: TimeInterval] {
+                Dictionary(
+                    summary.runs.flatMap(\.allTests)
+                        .filter { !$0.identifier.hasPrefix(Self.divergentDurationIdentifier) }
+                        .map { ($0.identifier, $0.duration) },
+                    uniquingKeysWith: { first, _ in first }
+                )
+            }
+            let legacyLeaves = leafDurations(legacy)
+            XCTAssertFalse(
+                legacyLeaves.isEmpty,
+                "\(fixture): no leaves left to compare — the exclusion is too broad"
+            )
+            // Exact, not within a tolerance. A tolerance here is what let the
+            // #477 divergence through in the first place: it was 0.85ms, well
+            // inside any accuracy anyone would have picked.
+            XCTAssertEqual(
+                legacyLeaves, leafDurations(modern),
+                "\(fixture): a leaf duration outside the one declared divergence "
+                    + "differs between backends"
+            )
+
+            let legacyHeader = RunSummary(runs: legacy.runs)
+            let modernHeader = RunSummary(runs: modern.runs)
+            XCTAssertGreaterThan(
+                legacyHeader.duration, 0,
+                "\(fixture): a zero total would make the header vacuous"
+            )
+            XCTAssertEqual(
+                legacyHeader.tally.buckets.map { "\($0.label) \($0.count)" },
+                modernHeader.tally.buckets.map { "\($0.label) \($0.count)" },
+                "\(fixture): the header's status buckets differ between backends"
+            )
+            XCTAssertEqual(
+                legacyHeader.tally.total, legacy.runs.flatMap(\.allTests).count,
+                "\(fixture): the buckets must account for every test"
+            )
+        }
+    }
+}

--- a/Tests/XCTestHTMLReportTests/DifferentialSummaryHeaderTests.swift
+++ b/Tests/XCTestHTMLReportTests/DifferentialSummaryHeaderTests.swift
@@ -17,7 +17,10 @@ extension DifferentialTests {
     /// Legacy merges a parameterized Swift Testing case's argument executions
     /// into iterations and so sums their durations; the modern reader reports
     /// the node's own value. Measured on CI's `TestResults`: 0.001268s against
-    /// 0.000423s, three argument sets. Every other leaf agrees exactly.
+    /// 0.000423s, three argument sets. This one is *structural* — the two
+    /// readers assemble the number differently, so one of them can be changed
+    /// to match, which is what #477 is for. Contrast the repetition case
+    /// below, which is not structural and has no fix.
     ///
     /// Narrower than `testXCTestCaseDurationsAgreeAcrossBackends`'s blanket
     /// `SwiftTestingSuite/` filter on purpose — the non-parameterized Swift
@@ -25,6 +28,50 @@ extension DifferentialTests {
     /// the `filter` that reads it, when #477 lands.
     private static let divergentDurationIdentifier =
         "SwiftTestingSuite/parameterizedAddition"
+
+    /// How far apart a *repeated* leaf's two durations may sit, per repetition.
+    ///
+    /// This is not the same phenomenon as #477 and is not a bug to be fixed.
+    /// Both backends already sum repetitions by construction (design answer 8),
+    /// so there is no structural divergence left to close: what remains is that
+    /// the two formats *measure and report the same repetition independently*,
+    /// each rounding to its own microsecond-scale value. Exact equality is not
+    /// something either format promises for a repetition duration, and no
+    /// renderer-side change can make it true.
+    ///
+    /// Measured on `RetryTests/testRetryOnFailure()`, two repetitions, across
+    /// three `prepareTestResults.sh` generations of `RetryResults`:
+    ///
+    /// | generation | legacy | modern | Δ |
+    /// | --- | --- | --- | --- |
+    /// | review's | 0.14027798s | 0.14065396s | 376µs |
+    /// | 2026-08-14 01:21 | 0.60440397s | 0.60440397s | 0 |
+    /// | 2026-08-14 11:43 | 0.18024814s | 0.18039226s | 144µs |
+    ///
+    /// So it is generation-dependent, not constant — which is why an exact
+    /// assertion here passed on CI and in development until a reviewer
+    /// regenerated the bundle. The 11:43 generation also localises it: the
+    /// gap is entirely in repetition 0 (0.12885606s against 0.12900018s) while
+    /// repetition 1 is bit-identical. That is a per-repetition reporting
+    /// difference, not an error in summing them — the sum is already common to
+    /// both backends.
+    ///
+    /// The bound is set roughly five times the largest divergence anyone has
+    /// measured (188µs per repetition) rather than snugly above it, because a
+    /// bound has to survive that generation-to-generation variance to be worth
+    /// asserting at all. Scaled per repetition because the leaf's duration is
+    /// a sum: an N-times repeated case accumulates N independent
+    /// measurements, so its worst case grows with N. Deliberately *not* a
+    /// blanket tolerance — every leaf the run did not repeat is still compared
+    /// exactly, below.
+    ///
+    /// Note the pre-existing `testXCTestCaseDurationsAgreeAcrossBackends`
+    /// holds the same leaves to a flat `accuracy: 0.0005`, which is tighter
+    /// than this for anything repeated twice. That is left alone deliberately:
+    /// it is the older, blanket gate, and if a generation ever exceeds it, the
+    /// right response is to give *that* assertion the same per-repetition
+    /// treatment, not to loosen either one further.
+    private static let repetitionDurationTolerancePerIteration: TimeInterval = 0.001
 
     /// What the summary header derives, asserted on the model rather than
     /// through the render — the same reason
@@ -38,35 +85,20 @@ extension DifferentialTests {
     /// that against the masker.
     ///
     /// What is asserted instead is stronger and does not rot: every leaf
-    /// duration except that one identifier must agree *exactly*, and every
-    /// status bucket must match. When #477 converges the two backends the
-    /// exclusion becomes unnecessary, and the constant above says so.
+    /// duration except that one identifier must agree *exactly* — unless the
+    /// run repeated the leaf, in which case it must agree within the bound
+    /// above, for the reason stated there — and every status bucket must
+    /// match. When #477 converges the two backends the exclusion becomes
+    /// unnecessary, and the constant above says so.
     func testSummaryHeaderNumbersAgreeAcrossBackends() throws {
         try requireBothBackends()
+        var repeatedLeavesCompared = 0
         for fixture in Self.fixtures {
             let legacy = try summary(fixture, .legacy)
             let modern = try summary(fixture, .modern)
 
-            func leafDurations(_ summary: Summary) -> [String: TimeInterval] {
-                Dictionary(
-                    summary.runs.flatMap(\.allTests)
-                        .filter { !$0.identifier.hasPrefix(Self.divergentDurationIdentifier) }
-                        .map { ($0.identifier, $0.duration) },
-                    uniquingKeysWith: { first, _ in first }
-                )
-            }
-            let legacyLeaves = leafDurations(legacy)
-            XCTAssertFalse(
-                legacyLeaves.isEmpty,
-                "\(fixture): no leaves left to compare — the exclusion is too broad"
-            )
-            // Exact, not within a tolerance. A tolerance here is what let the
-            // #477 divergence through in the first place: it was 0.85ms, well
-            // inside any accuracy anyone would have picked.
-            XCTAssertEqual(
-                legacyLeaves, leafDurations(modern),
-                "\(fixture): a leaf duration outside the one declared divergence "
-                    + "differs between backends"
+            repeatedLeavesCompared += assertLeafDurationsAgree(
+                fixture: fixture, legacy: legacy, modern: modern
             )
 
             let legacyHeader = RunSummary(runs: legacy.runs)
@@ -85,5 +117,96 @@ extension DifferentialTests {
                 "\(fixture): the buckets must account for every test"
             )
         }
+        // `RetryResults` is generated with `-test-iterations 2
+        // -retry-tests-on-failure`, so the tolerance branch above must have
+        // run. If it did not, either that fixture stopped repeating anything
+        // or both readers stopped reporting repetitions — and the weaker of
+        // the two comparisons would have quietly become dead code.
+        XCTAssertGreaterThan(
+            repeatedLeavesCompared, 0,
+            "no repeated leaf was compared — the fixtures no longer exercise "
+                + "repetitions, so the per-repetition tolerance is unproven"
+        )
+    }
+
+    /// Compares one fixture's leaf durations across the two backends and
+    /// answers how many of them the run had repeated.
+    ///
+    /// Split out of the test above only to keep that method inside the length
+    /// the linter enforces; it carries no assertions of its own beyond the
+    /// duration comparison.
+    private func assertLeafDurationsAgree(
+        fixture: String, legacy: Summary, modern: Summary
+    ) -> Int {
+        let legacyLeaves = comparableLeaves(of: legacy)
+        let modernLeaves = comparableLeaves(of: modern)
+        XCTAssertFalse(
+            legacyLeaves.isEmpty,
+            "\(fixture): no leaves left to compare — the exclusion is too broad"
+        )
+        XCTAssertEqual(
+            Set(legacyLeaves.keys), Set(modernLeaves.keys),
+            "\(fixture): the backends disagree on which leaves exist, so "
+                + "comparing their durations would compare different sets"
+        )
+
+        var repeatedLeaves = 0
+        var exactLegacy: [String: TimeInterval] = [:]
+        var exactModern: [String: TimeInterval] = [:]
+        for (identifier, legacyLeaf) in legacyLeaves {
+            guard let modernLeaf = modernLeaves[identifier] else {
+                continue // Already failed on the key sets above.
+            }
+            // The repetition *count* is structural and must match exactly: it
+            // is what makes the duration a sum of N measurements, and a backend
+            // that dropped a repetition would otherwise hide inside the
+            // tolerance that same count is used to size.
+            let count = repetitions(of: legacyLeaf)
+            XCTAssertEqual(
+                count, repetitions(of: modernLeaf),
+                "\(fixture): \(identifier) has a different number of "
+                    + "repetitions on each backend"
+            )
+            guard count > 1 else {
+                exactLegacy[identifier] = legacyLeaf.duration
+                exactModern[identifier] = modernLeaf.duration
+                continue
+            }
+            repeatedLeaves += 1
+            XCTAssertEqual(
+                legacyLeaf.duration, modernLeaf.duration,
+                accuracy: Self.repetitionDurationTolerancePerIteration * Double(count),
+                "\(fixture): \(identifier) repeated \(count) times and its two "
+                    + "durations are further apart than independent measurement "
+                    + "of the same repetitions explains"
+            )
+        }
+        // Exact, not within a tolerance, for everything the run ran once. A
+        // tolerance here is what let the #477 divergence through in the first
+        // place: it was 0.85ms, well inside any accuracy anyone would have
+        // picked.
+        XCTAssertEqual(
+            exactLegacy, exactModern,
+            "\(fixture): a single-run leaf duration outside the one declared "
+                + "divergence differs between backends"
+        )
+        return repeatedLeaves
+    }
+
+    /// Every leaf whose duration the two backends are expected to agree on,
+    /// keyed by identifier — so, all of them but #477's.
+    private func comparableLeaves(of summary: Summary) -> [String: Test] {
+        Dictionary(
+            summary.runs.flatMap(\.allTests)
+                .filter { !$0.identifier.hasPrefix(Self.divergentDurationIdentifier) }
+                .map { ($0.identifier, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+    }
+
+    /// Only `TestCase` carries repetitions; a leaf that is not one — an empty
+    /// group — is a single measurement by definition.
+    private func repetitions(of leaf: Test) -> Int {
+        (leaf as? TestCase)?.iterations.count ?? 1
     }
 }

--- a/Tests/XCTestHTMLReportTests/DifferentialSummaryHeaderTests.swift
+++ b/Tests/XCTestHTMLReportTests/DifferentialSummaryHeaderTests.swift
@@ -138,8 +138,8 @@ extension DifferentialTests {
     private func assertLeafDurationsAgree(
         fixture: String, legacy: Summary, modern: Summary
     ) -> Int {
-        let legacyLeaves = comparableLeaves(of: legacy)
-        let modernLeaves = comparableLeaves(of: modern)
+        let legacyLeaves = keyedByIdentifier(comparableLeaves(of: legacy), fixture)
+        let modernLeaves = keyedByIdentifier(comparableLeaves(of: modern), fixture)
         XCTAssertFalse(
             legacyLeaves.isEmpty,
             "\(fixture): no leaves left to compare — the exclusion is too broad"
@@ -193,15 +193,34 @@ extension DifferentialTests {
         return repeatedLeaves
     }
 
-    /// Every leaf whose duration the two backends are expected to agree on,
-    /// keyed by identifier — so, all of them but #477's.
-    private func comparableLeaves(of summary: Summary) -> [String: Test] {
-        Dictionary(
-            summary.runs.flatMap(\.allTests)
-                .filter { !$0.identifier.hasPrefix(Self.divergentDurationIdentifier) }
-                .map { ($0.identifier, $0) },
-            uniquingKeysWith: { first, _ in first }
+    /// Every leaf whose duration the two backends are expected to agree on —
+    /// so, all of them but #477's.
+    private func comparableLeaves(of summary: Summary) -> [Test] {
+        summary.runs.flatMap(\.allTests)
+            .filter { !$0.identifier.hasPrefix(Self.divergentDurationIdentifier) }
+    }
+
+    /// The same leaves keyed for comparison, failing rather than dropping if
+    /// two of them share an identifier.
+    ///
+    /// They cannot today: every fixture is one test plan on one destination,
+    /// so `runs` has one element. The moment that stops being true — the same
+    /// plan run on two devices — the identifier alone stops being unique, and
+    /// a `uniquingKeysWith` that keeps the first would quietly compare one of
+    /// the two and report parity for both. That is the class of vacuous
+    /// assertion this whole test exists to avoid, so it is asserted rather
+    /// than assumed: a multi-run fixture will fail here and whoever adds it
+    /// puts the run into the key.
+    private func keyedByIdentifier(_ leaves: [Test], _ fixture: String) -> [String: Test] {
+        let keyed = Dictionary(
+            leaves.map { ($0.identifier, $0) }, uniquingKeysWith: { first, _ in first }
         )
+        XCTAssertEqual(
+            keyed.count, leaves.count,
+            "\(fixture): two leaves share an identifier, so keying on it "
+                + "compares only one of them — put the run in the key"
+        )
+        return keyed
     }
 
     /// Only `TestCase` carries repetitions; a leaf that is not one — an empty

--- a/Tests/XCTestHTMLReportTests/DifferentialTests.swift
+++ b/Tests/XCTestHTMLReportTests/DifferentialTests.swift
@@ -295,6 +295,54 @@ final class DifferentialTests: XCTestCase {
         }
     }
 
+    /// The summary header's two derived numbers, on the model rather than
+    /// through the render — the same reason
+    /// `testXCTestCaseDurationsAgreeAcrossBackends` exists.
+    ///
+    /// The duration sits one regex away from the `durations` mask, which
+    /// normalises the parenthesised `(1.23s)` form the tree uses: a header
+    /// that ever adopted that form would have its divergence masked away
+    /// silently. It sums *leaf* tests, which agree. Groups do not and cannot
+    /// — `durationInSeconds` is null on every suite node in the modern
+    /// format, which is exactly what that allow-list entry declares.
+    func testSummaryHeaderNumbersAgreeAcrossBackends() throws {
+        try requireBothBackends()
+        for fixture in Self.fixtures {
+            let legacy = try summary(fixture, .legacy)
+            let modern = try summary(fixture, .modern)
+
+            let legacyHeader = RunSummary(runs: legacy.runs)
+            let modernHeader = RunSummary(runs: modern.runs)
+
+            XCTAssertGreaterThan(
+                legacyHeader.duration, 0,
+                "\(fixture): a zero total would make the comparison vacuous"
+            )
+            XCTAssertEqual(
+                legacyHeader.duration, modernHeader.duration, accuracy: 0.0005,
+                "\(fixture): the header's run duration differs between backends"
+            )
+
+            // Rendered, not field by field: it is the two-decimal string that
+            // reaches the page, and it is the string the differential holds.
+            XCTAssertEqual(
+                legacyHeader.duration.formattedSeconds,
+                modernHeader.duration.formattedSeconds,
+                "\(fixture): the header's rendered duration differs between backends"
+            )
+
+            XCTAssertEqual(
+                legacyHeader.tally.buckets.map { "\($0.label) \($0.count)" },
+                modernHeader.tally.buckets.map { "\($0.label) \($0.count)" },
+                "\(fixture): the header's status buckets differ between backends"
+            )
+            XCTAssertEqual(
+                legacyHeader.tally.total, legacy.runs.flatMap(\.allTests).count,
+                "\(fixture): the buckets must account for every test"
+            )
+        }
+    }
+
     func testAttachmentPayloadsAreByteIdenticalAcrossBackends() throws {
         try requireBothBackends()
 

--- a/Tests/XCTestHTMLReportTests/DifferentialTests.swift
+++ b/Tests/XCTestHTMLReportTests/DifferentialTests.swift
@@ -10,7 +10,7 @@ import XCTest
 @testable import XCTestHTMLReportCore
 
 final class DifferentialTests: XCTestCase {
-    private static let fixtures = ["TestResults", "SanityResults", "RetryResults"]
+    static let fixtures = ["TestResults", "SanityResults", "RetryResults"]
 
     /// Linking-mode summaries and their normalized renders, one per
     /// fixture-and-backend. Rendering is deterministic for a given backend
@@ -39,7 +39,7 @@ final class DifferentialTests: XCTestCase {
         return try JSONDecoder().decode(AllowList.self, from: Data(contentsOf: url))
     }
 
-    private func summary(_ resource: String, _ backend: ResultBackend) throws -> Summary {
+    func summary(_ resource: String, _ backend: ResultBackend) throws -> Summary {
         let key = "\(resource)|\(backend.rawValue)"
         if let cached = Self.summaries[key] {
             return cached
@@ -82,7 +82,7 @@ final class DifferentialTests: XCTestCase {
     /// modern reader: the differential would then compare the modern backend
     /// against itself and report parity. `resolve()` returns
     /// `.legacyUnavailable` instead of substituting, and this asserts on that.
-    private func requireBothBackends() throws {
+    func requireBothBackends() throws {
         switch ResultBackend.legacy.resolve() {
         case .legacyUnavailable:
             throw XCTSkip(
@@ -292,54 +292,6 @@ final class DifferentialTests: XCTestCase {
                     "\(fixture): \(identifier) duration differs between backends"
                 )
             }
-        }
-    }
-
-    /// The summary header's two derived numbers, on the model rather than
-    /// through the render — the same reason
-    /// `testXCTestCaseDurationsAgreeAcrossBackends` exists.
-    ///
-    /// The duration sits one regex away from the `durations` mask, which
-    /// normalises the parenthesised `(1.23s)` form the tree uses: a header
-    /// that ever adopted that form would have its divergence masked away
-    /// silently. It sums *leaf* tests, which agree. Groups do not and cannot
-    /// — `durationInSeconds` is null on every suite node in the modern
-    /// format, which is exactly what that allow-list entry declares.
-    func testSummaryHeaderNumbersAgreeAcrossBackends() throws {
-        try requireBothBackends()
-        for fixture in Self.fixtures {
-            let legacy = try summary(fixture, .legacy)
-            let modern = try summary(fixture, .modern)
-
-            let legacyHeader = RunSummary(runs: legacy.runs)
-            let modernHeader = RunSummary(runs: modern.runs)
-
-            XCTAssertGreaterThan(
-                legacyHeader.duration, 0,
-                "\(fixture): a zero total would make the comparison vacuous"
-            )
-            XCTAssertEqual(
-                legacyHeader.duration, modernHeader.duration, accuracy: 0.0005,
-                "\(fixture): the header's run duration differs between backends"
-            )
-
-            // Rendered, not field by field: it is the two-decimal string that
-            // reaches the page, and it is the string the differential holds.
-            XCTAssertEqual(
-                legacyHeader.duration.formattedSeconds,
-                modernHeader.duration.formattedSeconds,
-                "\(fixture): the header's rendered duration differs between backends"
-            )
-
-            XCTAssertEqual(
-                legacyHeader.tally.buckets.map { "\($0.label) \($0.count)" },
-                modernHeader.tally.buckets.map { "\($0.label) \($0.count)" },
-                "\(fixture): the header's status buckets differ between backends"
-            )
-            XCTAssertEqual(
-                legacyHeader.tally.total, legacy.runs.flatMap(\.allTests).count,
-                "\(fixture): the buckets must account for every test"
-            )
         }
     }
 

--- a/Tests/XCTestHTMLReportTests/HTMLEscapingTests.swift
+++ b/Tests/XCTestHTMLReportTests/HTMLEscapingTests.swift
@@ -165,6 +165,110 @@ final class HTMLEscapingTests: XCTestCase {
         )
     }
 
+    /// The summary header (#439, A1) is a second place every hostile leaf
+    /// string reaches markup: the digest carries a test name and an assertion
+    /// message, the device row a destination name and an OS version.
+    ///
+    /// Scoped to `#run-summary` rather than to the whole document on purpose.
+    /// The tree below renders the same strings escaped, so a document-wide
+    /// "contains the escaped form" assertion would pass even if the header
+    /// emitted a raw copy — the very failure mode #463 fixed elsewhere.
+    func testTheSummaryHeaderEscapesEveryHostileValue() throws {
+        let hostile = "\"'<>&"
+        let escaped = "&quot;&apos;&lt;&gt;&amp;"
+        let header = try summaryHeader(in: hostileFailingRunHTML())
+
+        XCTAssertFalse(
+            header.contains(hostile),
+            "a raw hostile string reached the summary header"
+        )
+        for value in ["testHostile\(escaped)()", "Device\(escaped)", "1.0\(escaped)",
+                      "Suite\(escaped)", "assertion\(escaped) failed"]
+        {
+            XCTAssertTrue(
+                header.contains(value),
+                "the header must render '\(value)' — escaped, but present"
+            )
+        }
+    }
+
+    /// The digest hands the page an element id through `data-target` rather
+    /// than through an interpolated `onclick`, so it is not covered by
+    /// `testEveryIdentifierReachingAScriptHandlerIsAHexDigest`. What makes it
+    /// safe is the same property, and it is worth the same tripwire: the
+    /// script looks the value up with `getElementById`, so a name reaching it
+    /// would be a selector built from test-author-controlled text.
+    func testEveryDigestJumpTargetIsAHexDigest() throws {
+        let targets = try attributeValues(named: "data-target", in: hostileFailingRunHTML())
+        XCTAssertFalse(targets.isEmpty, "the fixture must render a failure digest")
+
+        let digest = try NSRegularExpression(pattern: "^[0-9a-f]{32}$")
+        let offenders = targets.filter { value in
+            digest.firstMatch(in: value, range: NSRange(location: 0, length: value.utf16.count))
+                == nil
+        }
+        XCTAssertEqual(offenders, [], "only opaque digests may address a row from the digest")
+    }
+
+    /// The `<section id="run-summary">` element's source, which holds no
+    /// nested `<section>`, so the first close tag after it is its own.
+    private func summaryHeader(in html: String) throws -> String {
+        let open = try XCTUnwrap(
+            html.range(of: "<section id=\"run-summary\""),
+            "the report must render a summary header"
+        )
+        let close = try XCTUnwrap(
+            html.range(of: "</section>", range: open.upperBound ..< html.endIndex)
+        )
+        return String(html[open.lowerBound ..< close.upperBound])
+    }
+
+    /// `hostileRunHTML`'s test passes, so it renders no digest. This is the
+    /// same run with the test failed and its assertion message hostile too.
+    private func hostileFailingRunHTML() -> String {
+        let hostile = "\"'<>&"
+        let failure = ParsedActivity(
+            title: "assertion\(hostile) failed",
+            isFailure: true,
+            start: Date(timeIntervalSince1970: 0),
+            attachments: [],
+            subActivities: []
+        )
+        let group = ParsedGroup(
+            name: "Suite\(hostile)",
+            identifier: "Suite\(hostile)",
+            duration: 1,
+            children: [.testCase(ParsedTestCase(
+                name: "testHostile\(hostile)()",
+                identifier: "Suite\(hostile)/testHostile\(hostile)()",
+                arguments: [],
+                iterations: [SyntheticResult.iteration(
+                    number: nil,
+                    status: .failed,
+                    activities: [failure]
+                )]
+            ))]
+        )
+        let run = ParsedRun(
+            destination: ParsedDestination(
+                displayName: "Device\(hostile)",
+                deviceIdentifier: "identifier\(hostile)",
+                modelName: "Model\(hostile)",
+                operatingSystemVersion: "1.0\(hostile)"
+            ),
+            logReference: SyntheticResult.logReference,
+            testables: [ParsedTestable(targetName: "HostileTests", groups: [group])]
+        )
+        return Summary(
+            parsedRuns: [run],
+            payloads: SyntheticResult.payloads,
+            renderingMode: .linking,
+            downsizeImagesEnabled: false,
+            downsizeScaleFactor: 0.5,
+            bundleNames: ["Synthetic"]
+        ).generatedHtmlReport()
+    }
+
     /// The guard against over-correcting: values that are already rendered
     /// HTML must pass through the seam untouched, or the whole report
     /// collapses into escaped source text.

--- a/Tests/XCTestHTMLReportTests/RunSummaryTests.swift
+++ b/Tests/XCTestHTMLReportTests/RunSummaryTests.swift
@@ -78,10 +78,34 @@ final class RunSummaryTests: XCTestCase {
     /// and 0s on the other.
     func testDurationSumsLeafTestsAndNotGroups() throws {
         let meta = try document().select("#run-summary-heading .summary-meta").text()
-        XCTAssertEqual(meta, "Ran for 9.00s · 1 device")
+        XCTAssertEqual(meta, "Duration (9.00s) · 1 device")
 
         let group = SyntheticResult.parsedRun.testables[0].groups[0]
         XCTAssertEqual(group.duration, 6, "the fixture's group must disagree with its leaves")
+    }
+
+    /// The header's total inherits a declared divergence — a parameterized
+    /// Swift Testing case reports a different duration on each backend (#477)
+    /// — so it has to be written in a shape the differential's `durations`
+    /// known-loss rule normalises, or the cross-backend comparison goes red on
+    /// whichever runner is slow enough to cross a rounding boundary.
+    ///
+    /// Asserted against `KnownLossMasker` itself rather than by reading the
+    /// regex and believing it. That distinction is the whole point: the shape
+    /// is `(N.NNs)`, and a copy edit that dropped the parentheses — which look
+    /// like styling — would silently uncover the divergence. This fails the
+    /// moment that happens.
+    func testTheHeadersDurationIsWrittenInAMaskedShape() throws {
+        let rendered = summary().generatedHtmlReport()
+        try XCTAssertContains(rendered, "<span class=\"summary-duration\">(9.00s)</span>")
+
+        let masked = KnownLossMasker.mask(rendered, rules: ["durations"])
+        XCTAssertFalse(
+            masked.contains("(9.00s)"),
+            "the durations rule must normalise the header's total, as it does "
+                + "every duration in the tree"
+        )
+        try XCTAssertContains(masked, "(DURATION)")
     }
 
     /// The ring covers the full circle and each arc starts where the last one

--- a/Tests/XCTestHTMLReportTests/RunSummaryTests.swift
+++ b/Tests/XCTestHTMLReportTests/RunSummaryTests.swift
@@ -1,0 +1,215 @@
+//
+//  RunSummaryTests.swift
+//
+//  The summary header (#439, A1). Driven by the synthetic fixture, which is
+//  the only one whose numbers are constants — the generated .xcresult bundles
+//  are regenerated on every run, so nothing there can be pinned exactly.
+//
+
+import SwiftSoup
+import XCTest
+@testable import XCTestHTMLReportCore
+
+final class RunSummaryTests: XCTestCase {
+    private func summary(_ run: ParsedRun = SyntheticResult.parsedRun) -> Summary {
+        Summary(
+            parsedRuns: [run],
+            payloads: SyntheticResult.payloads,
+            renderingMode: .linking,
+            downsizeImagesEnabled: false,
+            downsizeScaleFactor: 0.5,
+            bundleNames: ["Synthetic"]
+        )
+    }
+
+    private func document(_ run: ParsedRun = SyntheticResult.parsedRun) throws -> Document {
+        try SwiftSoup.parse(summary(run).generatedHtmlReport())
+    }
+
+    /// The six statuses partition the tests, so the ring is a whole circle
+    /// rather than a circle with a gap in it.
+    ///
+    /// The fixture puts exactly one test in each of five buckets, which is
+    /// also what makes the legend below assertable: any bucket that stopped
+    /// being counted would drop a row rather than change a number.
+    func testLegendCountsEveryStatusTheFixtureProduces() throws {
+        let rows = try document().select("ul.summary-legend li").array()
+        XCTAssertEqual(
+            try rows.map { try $0.text() },
+            [
+                "Passed 1",
+                "Failed 1",
+                "Skipped 1",
+                "Mixed 1",
+                "Expected failures 1",
+            ],
+            "the legend must name every bucket the fixture fills, and only those"
+        )
+
+        let total = try document().select(".donut-center strong").text()
+        XCTAssertEqual(total, "5", "the ring's centre states the run's test count")
+    }
+
+    /// The bucket `Status` folds nowhere else: before #439 an expected failure
+    /// landed in no header count at all, so a run of nothing but expected
+    /// failures reported zero tests in every bucket. It is surfaced from the
+    /// model both readers already populate, so this holds on either backend.
+    func testExpectedFailuresAreCountedRatherThanDropped() {
+        let tally = RunSummary(runs: summary().runs).tally
+        XCTAssertEqual(tally.expectedFailure, 1)
+        XCTAssertEqual(
+            tally.total,
+            tally.passed + tally.failed + tally.skipped
+                + tally.mixed + tally.expectedFailure + tally.unknown,
+            "every test must land in exactly one bucket"
+        )
+        XCTAssertEqual(tally.total, summary().runs.flatMap(\.allTests).count)
+    }
+
+    /// The header's duration is the sum of the *leaf* tests, never of the
+    /// groups. The fixture makes the two answers different on purpose: its
+    /// group declares 6s while its five test cases add up to 9s (four at 1.5s
+    /// plus a retried one with two 1.5s iterations).
+    ///
+    /// This is the assertion that keeps the cross-backend differential green
+    /// without an allow-list entry. `durationInSeconds` is null on every suite
+    /// node in the modern format — the standing `durations` known loss — so a
+    /// total that reached for a group's duration would read 6s on one backend
+    /// and 0s on the other.
+    func testDurationSumsLeafTestsAndNotGroups() throws {
+        let meta = try document().select("#run-summary-heading .summary-meta").text()
+        XCTAssertEqual(meta, "Ran for 9.00s · 1 device")
+
+        let group = SyntheticResult.parsedRun.testables[0].groups[0]
+        XCTAssertEqual(group.duration, 6, "the fixture's group must disagree with its leaves")
+    }
+
+    /// The ring covers the full circle and each arc starts where the last one
+    /// ended, which is what makes it readable as proportions at all.
+    func testRingArcsTileTheWholeCircle() throws {
+        let arcs = try document().select("circle.donut-seg").array()
+        XCTAssertEqual(arcs.count, 5, "one arc per non-empty bucket")
+
+        var expectedStart = 0.0
+        var covered = 0.0
+        for arc in arcs {
+            let dash = try XCTUnwrap(
+                Double(arc.attr("stroke-dasharray").split(separator: " ")[0])
+            )
+            // The offset is negative: it rotates the dash pattern forward by
+            // everything already drawn.
+            let offset = try XCTUnwrap(Double(arc.attr("stroke-dashoffset")))
+            let arcName = try arc.className()
+            XCTAssertEqual(
+                -offset, expectedStart, accuracy: 0.001,
+                "arc \(arcName) does not start where the previous one ended"
+            )
+            expectedStart += dash
+            covered += dash
+        }
+        XCTAssertEqual(covered, 100, accuracy: 0.001, "the arcs must tile the circle")
+    }
+
+    /// The digest is the direction's strongest claim — failures readable
+    /// without expanding anything — so it has to carry the message, not just
+    /// the name.
+    func testFailureDigestCarriesTheAssertionMessage() throws {
+        let rows = try document().select("ul.failure-digest li").array()
+        XCTAssertEqual(rows.count, 1, "the fixture has exactly one failed test")
+
+        let row = try XCTUnwrap(rows.first)
+        XCTAssertEqual(try row.select(".digest-jump").text(), "testFails()")
+        XCTAssertEqual(
+            try row.select(".digest-message").text(),
+            "Synthetic.swift:42: assertion failed",
+            "the message is the failing activity's title, which is what the "
+                + "tree's red row shows"
+        )
+        XCTAssertEqual(
+            try row.select(".digest-suite").text(), "Synthetic",
+            "the suite comes from the test identifier, the one key the "
+                + "differential pins as equal across backends"
+        )
+    }
+
+    /// A jump button whose target is not in the document is a dead link, and
+    /// nothing else in the suite would notice: the id it points at is built
+    /// from a different path than the digest walks.
+    func testEveryDigestJumpTargetsAnElementInTheDocument() throws {
+        let page = try document()
+        let buttons = try page.select("button.digest-jump").array()
+        XCTAssertFalse(buttons.isEmpty, "the fixture must produce a digest to check")
+
+        for button in buttons {
+            let uuid = try button.attr("data-target")
+            XCTAssertFalse(uuid.isEmpty, "a jump button with no target is inert")
+            let disclosure = try page.getElementById("activities-\(uuid)")
+                ?? page.getElementById("iterations-\(uuid)")
+            XCTAssertNotNil(
+                disclosure,
+                "no element for \(uuid): the digest points at a row the page "
+                    + "does not contain"
+            )
+            let owningRow = try disclosure?.parent()
+            XCTAssertNotNil(
+                owningRow,
+                "the disclosure must sit inside the row the script scrolls to"
+            )
+            XCTAssertTrue(
+                owningRow?.hasClass("test-summary") == true,
+                "the script walks up to the nearest .test-summary; \(uuid)'s "
+                    + "disclosure is not inside one"
+            )
+        }
+    }
+
+    /// No failures, no card. An empty digest answers nothing and costs a
+    /// screenful of the space the header is already spending.
+    func testDigestIsOmittedWhenNothingFailed() throws {
+        let passing = ParsedRun(
+            destination: SyntheticResult.parsedRun.destination,
+            logReference: SyntheticResult.logReference,
+            testables: [ParsedTestable(
+                targetName: "SyntheticTests",
+                groups: [ParsedGroup(
+                    name: "SyntheticSuite",
+                    identifier: "SyntheticSuite",
+                    duration: 1,
+                    children: [.testCase(SyntheticResult.testCase(
+                        name: "testPasses()",
+                        iterations: [SyntheticResult.iteration(
+                            number: nil, status: .passed, activities: []
+                        )]
+                    ))]
+                )]
+            )]
+        )
+        let page = try document(passing)
+        XCTAssertTrue(
+            try page.select("ul.failure-digest").isEmpty(),
+            "a clean run must not render an empty failure digest"
+        )
+        XCTAssertFalse(
+            try page.select("ul.summary-legend li").isEmpty(),
+            "the rest of the header still renders"
+        )
+    }
+
+    /// One row per run, whatever the run count, because the ring only ever
+    /// speaks for the whole report.
+    func testOneDeviceRowPerRun() throws {
+        let page = try document()
+        let rows = try page.select(".device-row").array()
+        XCTAssertEqual(rows.count, 1)
+        XCTAssertEqual(
+            try XCTUnwrap(rows.first).select(".device-row-name").text(),
+            "Synthetic Device 1.0"
+        )
+        XCTAssertEqual(
+            try XCTUnwrap(rows.first).select(".device-row-tally").text(),
+            "1 passed, 1 failed, 1 skipped, 1 mixed, 1 expected failure",
+            "the bar is aria-hidden, so this caption is the only accessible "
+                + "reading of the proportions it draws"
+        )
+    }
+}

--- a/Tests/XCTestHTMLReportTests/Snapshots/index-inline.html
+++ b/Tests/XCTestHTMLReportTests/Snapshots/index-inline.html
@@ -1356,7 +1356,7 @@
         <h2 id="run-summary-heading">
           <span class="icon failure"></span>
           Tests
-          <span class="summary-meta">Ran for 9.00s · 1 device</span>
+          <span class="summary-meta">Duration <span class="summary-duration">(9.00s)</span> &middot; 1 device</span>
         </h2>
         <div class="summary-grid">
           <div class="donut">

--- a/Tests/XCTestHTMLReportTests/Snapshots/index-inline.html
+++ b/Tests/XCTestHTMLReportTests/Snapshots/index-inline.html
@@ -46,11 +46,44 @@
     --status-skipped: #6E6E73;
     --status-unknown: #6E6E73;
     --status-expected: #9A6400;
+    /* Mixed is the one status the tree draws from two tokens rather than
+       one — half passed, half failed, because that is what it means. A
+       14px ring arc and a 10px legend swatch are too small to read a split
+       at, so the summary header (#439, A1) paints mixed in a single hue of
+       its own instead, chosen not to collide with any other status. The
+       tree's split diamond is unchanged; both readings still say "some of
+       each", one by geometry and one by being neither green nor red. */
+    --status-mixed: #8944AB;
 
     /* Colour — surfaces */
     --color-surface: #FFF;
     --color-bg-sidebar: #F2F2F2;
     --color-bg-group-header: #F6F6F6;
+
+    /* Colour — the summary header (#439, A1). A band with cards on it,
+       which is one more surface level than the rest of the report has, so
+       these are their own tokens rather than reuses. Values are Apple's
+       grouped-background pairing; the dark block below is the primary one
+       (this direction is dark-first) and light is its inversion.
+
+       Every text pairing these introduce was computed before it was used;
+       the table is in the PR body. The tightest are muted text on the
+       striped digest row — 6.97:1 light, 5.11:1 dark — and the accent the
+       digest's jump buttons use, 5.33:1 light, 6.50:1 dark. The status
+       fills the ring and the bars paint clear the 3:1 non-text floor
+       against the card by 4.21:1 (passed, light) at worst.
+
+       --color-summary-border and --color-donut-track do not clear 3:1 and
+       are not meant to: a card edge and the ring's empty groove carry no
+       information the arcs and the legend do not already carry in colour
+       *and* in text, and 1.4.11 scopes the floor to graphics you must
+       perceive to understand the content. Raising them to 3:1 would draw
+       the heavy outline the rest of the sheet already avoids. */
+    --color-bg-summary: #ECECEE;
+    --color-summary-card: #FFF;
+    --color-summary-card-alt: #F7F7F9;
+    --color-summary-border: #D2D2D7;
+    --color-donut-track: #E3E3E8;
 
     /* Colour — borders */
     --color-border-strong: #BBB;
@@ -144,10 +177,23 @@
       --status-skipped: #9A9AA2;
       --status-unknown: #9A9AA2;
       --status-expected: #D9A038;
+      --status-mixed: #C89AF5;
 
       --color-surface: #161619;
       --color-bg-sidebar: #232327;
       --color-bg-group-header: #202024;
+
+      /* The summary header's own surfaces. The card is the same value as
+         the sidebar, which is deliberate: it is the lightest ground in the
+         dark theme, so every status token was already sized against it and
+         the header inherits those measurements unchanged (5.61 skipped to
+         6.74 expected). The band beneath the cards is darker than the page
+         so the cards read as raised, the way Xcode's do. */
+      --color-bg-summary: #19191C;
+      --color-summary-card: #232327;
+      --color-summary-card-alt: #2A2A2F;
+      --color-summary-border: #3A3A40;
+      --color-donut-track: #3A3A40;
 
       --color-border-strong: #3A3A40;
       --color-border-medium: #33333A;
@@ -201,6 +247,11 @@
        two rows never wrap on their own — the pills that do wrap live in
        .tests-header, not here. */
     min-height: 70px;
+    /* A flex item shrinks by default, and #439's summary band made that
+       visible: in a short window the header shrank below its content and
+       `overflow: hidden` on the body clipped the digest. The band caps its
+       own height at 50vh, so refusing to shrink cannot starve the tree. */
+    flex: none;
   }
 
   #info-sections ul {
@@ -838,6 +889,262 @@
     color: var(--color-on-accent);
   }
 
+  /* Summary header (#439, redesign A1).
+
+     Everything from here to the media query is new, and nothing below the
+     header was restyled: the tree, the panes and the filter pills are byte
+     for byte what they were. A2 restyles the tree; A3 the filters.
+
+     The band is a flex item of #content, capped at half the viewport so a
+     run with a long failure digest can never push the tree off the screen —
+     the digest scrolls inside itself rather than growing without bound. */
+  #run-summary {
+    background-color: var(--color-bg-summary);
+    border-bottom: 1px solid var(--color-border-strong);
+    padding: var(--space-sm) var(--space-sm) 12px;
+    max-height: 50vh;
+    overflow-y: auto;
+  }
+
+  .summary-card {
+    background-color: var(--color-summary-card);
+    border: 1px solid var(--color-summary-border);
+    border-radius: 10px;
+    /* So the striped digest rows are clipped by the rounded corner rather
+       than squaring it off. */
+    overflow: hidden;
+  }
+
+  .summary-card + .summary-card {
+    margin-top: var(--space-sm);
+  }
+
+  .summary-card > h2 {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin: 0;
+    padding: 8px 12px;
+    border-bottom: 1px solid var(--color-summary-border);
+    font-size: var(--font-size-md);
+    font-weight: var(--font-weight-medium);
+  }
+
+  .summary-meta {
+    margin-left: auto;
+    color: var(--color-text-muted);
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-regular);
+  }
+
+  .summary-grid {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 20px;
+    padding: 12px;
+  }
+
+  /* One class per status drives all three readings of it — the ring's arc,
+     the bar's segment and the legend's swatch — by setting `color` and
+     letting `currentColor` do the rest. A stroke, a fill and a background
+     from one declaration, which is also why the dark block has to override
+     nothing here. */
+  .status-tint-succeeded { color: var(--status-passed); }
+  .status-tint-failed { color: var(--status-failed); }
+  .status-tint-skipped { color: var(--status-skipped); }
+  .status-tint-mixed { color: var(--status-mixed); }
+  .status-tint-unknown { color: var(--status-unknown); }
+  .status-tint-expected-failure { color: var(--status-expected); }
+
+  /* The ring and its label share one grid cell, which centres the label
+     without positioning it. */
+  .donut {
+    display: grid;
+    place-items: center;
+    flex: none;
+    width: 108px;
+    height: 108px;
+  }
+
+  .donut > * {
+    grid-area: 1 / 1;
+  }
+
+  .donut-ring {
+    width: 108px;
+    height: 108px;
+  }
+
+  .donut-track {
+    fill: none;
+    stroke: var(--color-donut-track);
+    stroke-width: 12;
+  }
+
+  .donut-seg {
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 12;
+  }
+
+  .donut-center {
+    text-align: center;
+    line-height: 1.15;
+  }
+
+  .donut-center strong {
+    display: block;
+    font-size: var(--font-size-title);
+    font-weight: var(--font-weight-medium);
+  }
+
+  .donut-center small {
+    display: block;
+    font-size: var(--font-size-xs);
+    color: var(--color-text-muted);
+  }
+
+  .summary-legend {
+    flex: 0 1 auto;
+    min-width: 170px;
+    font-size: var(--font-size-sm);
+  }
+
+  .summary-legend li {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 2px 0;
+  }
+
+  .legend-swatch {
+    width: var(--icon-size-sm);
+    height: var(--icon-size-sm);
+    border-radius: var(--radius-sm);
+    background-color: currentColor;
+    flex: none;
+  }
+
+  .legend-count {
+    margin-left: auto;
+    color: var(--color-text-secondary);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .device-bars {
+    flex: 1 1 300px;
+    min-width: 240px;
+  }
+
+  .device-bars-head {
+    color: var(--color-text-muted);
+    font-size: var(--font-size-xs);
+    padding-bottom: 2px;
+    border-bottom: 1px solid var(--color-summary-border);
+  }
+
+  .device-row {
+    padding: 6px 0;
+  }
+
+  .device-row-name {
+    display: block;
+    font-size: var(--font-size-sm);
+    overflow-wrap: anywhere;
+  }
+
+  .device-row-os {
+    color: var(--color-text-muted);
+  }
+
+  /* An SVG rather than nested divs so no width lands in a `style`
+     attribute: the segments are `<rect>`s in a 0-100 user space, which is
+     the same arithmetic the ring's dash lengths use. `border-radius` on the
+     element clips them, and the track shows through wherever a run produced
+     no tests at all. */
+  .segbar {
+    display: block;
+    width: 100%;
+    height: 8px;
+    margin: var(--space-xs) 0 2px;
+    border-radius: var(--radius-sm);
+    overflow: hidden;
+    background-color: var(--color-donut-track);
+  }
+
+  .segbar rect {
+    fill: currentColor;
+  }
+
+  .device-row-tally {
+    color: var(--color-text-muted);
+    font-size: var(--font-size-xs);
+  }
+
+  .failure-digest {
+    font-size: var(--font-size-sm);
+    max-height: 168px;
+    overflow-y: auto;
+  }
+
+  .failure-digest li {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    gap: 8px;
+    align-items: baseline;
+    padding: 6px 12px;
+  }
+
+  .failure-digest li:nth-child(even) {
+    background-color: var(--color-summary-card-alt);
+  }
+
+  .failure-digest .icon {
+    margin: 0;
+    align-self: center;
+  }
+
+  .digest-body {
+    min-width: 0;
+  }
+
+  /* A real <button>, so the digest is reachable and operable from the
+     keyboard, wearing a link's clothes. */
+  .digest-jump {
+    display: block;
+    padding: 0;
+    border: 0;
+    background: none;
+    font: inherit;
+    font-weight: var(--font-weight-medium);
+    color: var(--color-accent-text);
+    text-align: left;
+    cursor: pointer;
+    overflow-wrap: anywhere;
+  }
+
+  .digest-jump:hover {
+    text-decoration: underline;
+  }
+
+  .digest-jump:focus-visible {
+    outline: 2px solid var(--color-accent);
+    outline-offset: 2px;
+    border-radius: var(--radius-sm);
+  }
+
+  .digest-message {
+    display: block;
+    color: var(--color-text-muted);
+    overflow-wrap: anywhere;
+  }
+
+  .digest-suite {
+    color: var(--color-text-muted);
+    white-space: nowrap;
+  }
+
   /* Narrow screens (#439).
 
      Everything above this point is the desktop layout, untouched: this
@@ -980,6 +1287,57 @@
       max-height: 40vh;
       object-fit: contain;
     }
+
+    /* Summary header, narrow (#439, A1). The three columns of the summary
+       grid stack on their own — `flex-wrap` and the device bars' 300px
+       basis already do that — so this only tightens the spacing and shrinks
+       the ring, which at 108px would otherwise eat a third of a 375px row. */
+    /* 40vh, not the desktop 50: the title band and the Tests/Logs row are a
+       fixed cost, and on an 812px phone a half-viewport band left the tree
+       with less than the summary above it. */
+    #run-summary {
+      padding: 6px;
+      max-height: 40vh;
+    }
+
+    .summary-grid {
+      gap: 12px;
+      padding: var(--space-sm);
+    }
+
+    .donut,
+    .donut-ring {
+      width: 84px;
+      height: 84px;
+    }
+
+    .summary-legend {
+      min-width: 140px;
+    }
+
+    .device-bars {
+      flex-basis: 100%;
+    }
+
+    /* The suite drops under the message rather than off the page: it is the
+       column the mockup deletes at this width, but it is also the only
+       thing telling two same-named tests apart. */
+    .failure-digest li {
+      grid-template-columns: auto 1fr;
+    }
+
+    .failure-digest .digest-suite {
+      grid-column: 2;
+      white-space: normal;
+    }
+
+    /* One scroller, not two. On a phone the band's own cap is always the
+       binding one, so a second scroll region nested inside it would only
+       ever swallow the gesture that was meant for the band. */
+    .failure-digest {
+      max-height: none;
+      overflow-y: visible;
+    }
   }
 
   </style>
@@ -993,6 +1351,48 @@
         <h1>XCTestHTMLReport</h1>
         <div class="clear"></div>
       </div>
+      <section id="run-summary" aria-labelledby="run-summary-heading">
+      <div class="summary-card">
+        <h2 id="run-summary-heading">
+          <span class="icon failure"></span>
+          Tests
+          <span class="summary-meta">Ran for 9.00s · 1 device</span>
+        </h2>
+        <div class="summary-grid">
+          <div class="donut">
+            <svg class="donut-ring" viewBox="0 0 120 120" aria-hidden="true" focusable="false">
+              <circle class="donut-track" cx="60" cy="60" r="48"></circle>
+              <circle class="donut-seg status-tint-succeeded" cx="60" cy="60" r="48" pathLength="100" stroke-dasharray="20.0000 80.0000" stroke-dashoffset="0.0000" transform="rotate(-90 60 60)"></circle><circle class="donut-seg status-tint-failed" cx="60" cy="60" r="48" pathLength="100" stroke-dasharray="20.0000 80.0000" stroke-dashoffset="-20.0000" transform="rotate(-90 60 60)"></circle><circle class="donut-seg status-tint-skipped" cx="60" cy="60" r="48" pathLength="100" stroke-dasharray="20.0000 80.0000" stroke-dashoffset="-40.0000" transform="rotate(-90 60 60)"></circle><circle class="donut-seg status-tint-mixed" cx="60" cy="60" r="48" pathLength="100" stroke-dasharray="20.0000 80.0000" stroke-dashoffset="-60.0000" transform="rotate(-90 60 60)"></circle><circle class="donut-seg status-tint-expected-failure" cx="60" cy="60" r="48" pathLength="100" stroke-dasharray="20.0000 80.0000" stroke-dashoffset="-80.0000" transform="rotate(-90 60 60)"></circle>
+            </svg>
+            <span class="donut-center"><strong>5</strong><small>Tests</small></span>
+          </div>
+          <ul class="summary-legend">
+            <li><span class="legend-swatch status-tint-succeeded"></span>Passed <span class="legend-count">1</span></li><li><span class="legend-swatch status-tint-failed"></span>Failed <span class="legend-count">1</span></li><li><span class="legend-swatch status-tint-skipped"></span>Skipped <span class="legend-count">1</span></li><li><span class="legend-swatch status-tint-mixed"></span>Mixed <span class="legend-count">1</span></li><li><span class="legend-swatch status-tint-expected-failure"></span>Expected failures <span class="legend-count">1</span></li>
+          </ul>
+          <div class="device-bars">
+            <p class="device-bars-head">Devices &amp; Configurations</p>
+            <div class="device-row">
+              <span class="device-row-name">Synthetic Device <span class="device-row-os">1.0</span></span>
+              <svg class="segbar" viewBox="0 0 100 8" preserveAspectRatio="none" aria-hidden="true" focusable="false"><rect class="status-tint-succeeded" x="0.0000" y="0" width="20.0000" height="8"></rect><rect class="status-tint-failed" x="20.0000" y="0" width="20.0000" height="8"></rect><rect class="status-tint-skipped" x="40.0000" y="0" width="20.0000" height="8"></rect><rect class="status-tint-mixed" x="60.0000" y="0" width="20.0000" height="8"></rect><rect class="status-tint-expected-failure" x="80.0000" y="0" width="20.0000" height="8"></rect></svg>
+              <span class="device-row-tally">1 passed, 1 failed, 1 skipped, 1 mixed, 1 expected failure</span>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="summary-card">
+        <h2>Test Failures <span class="summary-meta">1 failure</span></h2>
+        <ul class="failure-digest">
+          <li>
+            <span class="icon failure"></span>
+            <span class="digest-body">
+              <button type="button" class="digest-jump" data-target="4abdbdaebf10baf0f23017525cf4a9be">testFails()</button>
+              <span class="digest-message">Synthetic.swift:42: assertion failed</span>
+            </span>
+            <span class="digest-suite">Synthetic</span>
+          </li>
+        </ul>
+      </div>
+    </section>
       <ul id="test-log-toolbar" class="toolbar centered-toolbar toggle-toolbar">
         <li class="selected" onclick="showTests(this);">Tests</li>
         <li onclick="showLogs(this);">Logs</li>
@@ -1805,6 +2205,81 @@
 
   document.querySelectorAll('.device-info')[0].classList.add("selected");
   document.querySelectorAll('.run')[0].classList.add("active");
+
+  // Failure digest (#439, A1). Each row's button carries the failing test's
+  // element id in `data-target`; nothing about the test reaches a script
+  // context, which is the shape #463 left behind.
+  //
+  // The digest lists every run's failures, but only one run is in the
+  // layout at a time, so a jump has four things to undo before the row is
+  // on screen: the Logs tab, a non-active run, a filter that hid the row,
+  // and the collapsed disclosure it sits behind.
+  var digestButtons = document.querySelectorAll('.digest-jump');
+  for (var d = 0; d < digestButtons.length; d++) {
+    digestButtons[d].addEventListener('click', digestJump, false);
+  }
+
+  function digestJump(e) {
+    var uuid = e.currentTarget.getAttribute('data-target'),
+        // A test with one iteration hangs its rows off `activities-`; a
+        // retried one off `iterations-`. Both ids come from the same uuid,
+        // and the outer row is the nearest .test-summary either way.
+        disclosure = document.getElementById('activities-' + uuid)
+                  || document.getElementById('iterations-' + uuid);
+    if (!disclosure) {
+      return;
+    }
+
+    var row = disclosure.closest('.test-summary');
+    if (!row) {
+      return;
+    }
+
+    var testsTab = document.querySelector('#test-log-toolbar li');
+    if (testsTab && !testsTab.classList.contains('selected')) {
+      showTests(testsTab);
+    }
+
+    activateRunContaining(row);
+
+    // The filter writes `display: none` onto the element itself, and its
+    // group as well. Clearing both un-hides this one row without resetting
+    // the filter the reader chose.
+    row.style.display = 'block';
+    var group = row.closest('.test-summary-group');
+    if (group) {
+      group.style.display = 'block';
+    }
+
+    disclosure.style.display = 'block';
+    var chevron = row.querySelector('.drop-down-icon');
+    if (chevron) {
+      chevron.classList.add('dropped');
+    }
+
+    var listItem = row.querySelector('.list-item');
+    if (listItem) {
+      selectListItem(listItem);
+    }
+    row.scrollIntoView({ block: 'start' });
+  }
+
+  // `.run` elements and `.device-info` cards are rendered from one list of
+  // runs, in order, so the nth card selects the nth run. Going through
+  // selectDevice rather than toggling the classes here keeps one definition
+  // of what "active" means.
+  function activateRunContaining(el) {
+    var run = el.closest('.run');
+    if (!run || run.classList.contains('active')) {
+      return;
+    }
+    var runs = Array.prototype.slice.call(document.querySelectorAll('.run')),
+        cards = document.querySelectorAll('.device-info'),
+        index = runs.indexOf(run);
+    if (index >= 0 && cards[index]) {
+      selectDevice(run.id.replace('device_', ''), cards[index]);
+    }
+  }
 
   </script>
 </body>

--- a/Tests/XCTestHTMLReportTests/Snapshots/index.html
+++ b/Tests/XCTestHTMLReportTests/Snapshots/index.html
@@ -1356,7 +1356,7 @@
         <h2 id="run-summary-heading">
           <span class="icon failure"></span>
           Tests
-          <span class="summary-meta">Ran for 9.00s · 1 device</span>
+          <span class="summary-meta">Duration <span class="summary-duration">(9.00s)</span> &middot; 1 device</span>
         </h2>
         <div class="summary-grid">
           <div class="donut">

--- a/Tests/XCTestHTMLReportTests/Snapshots/index.html
+++ b/Tests/XCTestHTMLReportTests/Snapshots/index.html
@@ -46,11 +46,44 @@
     --status-skipped: #6E6E73;
     --status-unknown: #6E6E73;
     --status-expected: #9A6400;
+    /* Mixed is the one status the tree draws from two tokens rather than
+       one — half passed, half failed, because that is what it means. A
+       14px ring arc and a 10px legend swatch are too small to read a split
+       at, so the summary header (#439, A1) paints mixed in a single hue of
+       its own instead, chosen not to collide with any other status. The
+       tree's split diamond is unchanged; both readings still say "some of
+       each", one by geometry and one by being neither green nor red. */
+    --status-mixed: #8944AB;
 
     /* Colour — surfaces */
     --color-surface: #FFF;
     --color-bg-sidebar: #F2F2F2;
     --color-bg-group-header: #F6F6F6;
+
+    /* Colour — the summary header (#439, A1). A band with cards on it,
+       which is one more surface level than the rest of the report has, so
+       these are their own tokens rather than reuses. Values are Apple's
+       grouped-background pairing; the dark block below is the primary one
+       (this direction is dark-first) and light is its inversion.
+
+       Every text pairing these introduce was computed before it was used;
+       the table is in the PR body. The tightest are muted text on the
+       striped digest row — 6.97:1 light, 5.11:1 dark — and the accent the
+       digest's jump buttons use, 5.33:1 light, 6.50:1 dark. The status
+       fills the ring and the bars paint clear the 3:1 non-text floor
+       against the card by 4.21:1 (passed, light) at worst.
+
+       --color-summary-border and --color-donut-track do not clear 3:1 and
+       are not meant to: a card edge and the ring's empty groove carry no
+       information the arcs and the legend do not already carry in colour
+       *and* in text, and 1.4.11 scopes the floor to graphics you must
+       perceive to understand the content. Raising them to 3:1 would draw
+       the heavy outline the rest of the sheet already avoids. */
+    --color-bg-summary: #ECECEE;
+    --color-summary-card: #FFF;
+    --color-summary-card-alt: #F7F7F9;
+    --color-summary-border: #D2D2D7;
+    --color-donut-track: #E3E3E8;
 
     /* Colour — borders */
     --color-border-strong: #BBB;
@@ -144,10 +177,23 @@
       --status-skipped: #9A9AA2;
       --status-unknown: #9A9AA2;
       --status-expected: #D9A038;
+      --status-mixed: #C89AF5;
 
       --color-surface: #161619;
       --color-bg-sidebar: #232327;
       --color-bg-group-header: #202024;
+
+      /* The summary header's own surfaces. The card is the same value as
+         the sidebar, which is deliberate: it is the lightest ground in the
+         dark theme, so every status token was already sized against it and
+         the header inherits those measurements unchanged (5.61 skipped to
+         6.74 expected). The band beneath the cards is darker than the page
+         so the cards read as raised, the way Xcode's do. */
+      --color-bg-summary: #19191C;
+      --color-summary-card: #232327;
+      --color-summary-card-alt: #2A2A2F;
+      --color-summary-border: #3A3A40;
+      --color-donut-track: #3A3A40;
 
       --color-border-strong: #3A3A40;
       --color-border-medium: #33333A;
@@ -201,6 +247,11 @@
        two rows never wrap on their own — the pills that do wrap live in
        .tests-header, not here. */
     min-height: 70px;
+    /* A flex item shrinks by default, and #439's summary band made that
+       visible: in a short window the header shrank below its content and
+       `overflow: hidden` on the body clipped the digest. The band caps its
+       own height at 50vh, so refusing to shrink cannot starve the tree. */
+    flex: none;
   }
 
   #info-sections ul {
@@ -838,6 +889,262 @@
     color: var(--color-on-accent);
   }
 
+  /* Summary header (#439, redesign A1).
+
+     Everything from here to the media query is new, and nothing below the
+     header was restyled: the tree, the panes and the filter pills are byte
+     for byte what they were. A2 restyles the tree; A3 the filters.
+
+     The band is a flex item of #content, capped at half the viewport so a
+     run with a long failure digest can never push the tree off the screen —
+     the digest scrolls inside itself rather than growing without bound. */
+  #run-summary {
+    background-color: var(--color-bg-summary);
+    border-bottom: 1px solid var(--color-border-strong);
+    padding: var(--space-sm) var(--space-sm) 12px;
+    max-height: 50vh;
+    overflow-y: auto;
+  }
+
+  .summary-card {
+    background-color: var(--color-summary-card);
+    border: 1px solid var(--color-summary-border);
+    border-radius: 10px;
+    /* So the striped digest rows are clipped by the rounded corner rather
+       than squaring it off. */
+    overflow: hidden;
+  }
+
+  .summary-card + .summary-card {
+    margin-top: var(--space-sm);
+  }
+
+  .summary-card > h2 {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin: 0;
+    padding: 8px 12px;
+    border-bottom: 1px solid var(--color-summary-border);
+    font-size: var(--font-size-md);
+    font-weight: var(--font-weight-medium);
+  }
+
+  .summary-meta {
+    margin-left: auto;
+    color: var(--color-text-muted);
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-regular);
+  }
+
+  .summary-grid {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 20px;
+    padding: 12px;
+  }
+
+  /* One class per status drives all three readings of it — the ring's arc,
+     the bar's segment and the legend's swatch — by setting `color` and
+     letting `currentColor` do the rest. A stroke, a fill and a background
+     from one declaration, which is also why the dark block has to override
+     nothing here. */
+  .status-tint-succeeded { color: var(--status-passed); }
+  .status-tint-failed { color: var(--status-failed); }
+  .status-tint-skipped { color: var(--status-skipped); }
+  .status-tint-mixed { color: var(--status-mixed); }
+  .status-tint-unknown { color: var(--status-unknown); }
+  .status-tint-expected-failure { color: var(--status-expected); }
+
+  /* The ring and its label share one grid cell, which centres the label
+     without positioning it. */
+  .donut {
+    display: grid;
+    place-items: center;
+    flex: none;
+    width: 108px;
+    height: 108px;
+  }
+
+  .donut > * {
+    grid-area: 1 / 1;
+  }
+
+  .donut-ring {
+    width: 108px;
+    height: 108px;
+  }
+
+  .donut-track {
+    fill: none;
+    stroke: var(--color-donut-track);
+    stroke-width: 12;
+  }
+
+  .donut-seg {
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 12;
+  }
+
+  .donut-center {
+    text-align: center;
+    line-height: 1.15;
+  }
+
+  .donut-center strong {
+    display: block;
+    font-size: var(--font-size-title);
+    font-weight: var(--font-weight-medium);
+  }
+
+  .donut-center small {
+    display: block;
+    font-size: var(--font-size-xs);
+    color: var(--color-text-muted);
+  }
+
+  .summary-legend {
+    flex: 0 1 auto;
+    min-width: 170px;
+    font-size: var(--font-size-sm);
+  }
+
+  .summary-legend li {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 2px 0;
+  }
+
+  .legend-swatch {
+    width: var(--icon-size-sm);
+    height: var(--icon-size-sm);
+    border-radius: var(--radius-sm);
+    background-color: currentColor;
+    flex: none;
+  }
+
+  .legend-count {
+    margin-left: auto;
+    color: var(--color-text-secondary);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .device-bars {
+    flex: 1 1 300px;
+    min-width: 240px;
+  }
+
+  .device-bars-head {
+    color: var(--color-text-muted);
+    font-size: var(--font-size-xs);
+    padding-bottom: 2px;
+    border-bottom: 1px solid var(--color-summary-border);
+  }
+
+  .device-row {
+    padding: 6px 0;
+  }
+
+  .device-row-name {
+    display: block;
+    font-size: var(--font-size-sm);
+    overflow-wrap: anywhere;
+  }
+
+  .device-row-os {
+    color: var(--color-text-muted);
+  }
+
+  /* An SVG rather than nested divs so no width lands in a `style`
+     attribute: the segments are `<rect>`s in a 0-100 user space, which is
+     the same arithmetic the ring's dash lengths use. `border-radius` on the
+     element clips them, and the track shows through wherever a run produced
+     no tests at all. */
+  .segbar {
+    display: block;
+    width: 100%;
+    height: 8px;
+    margin: var(--space-xs) 0 2px;
+    border-radius: var(--radius-sm);
+    overflow: hidden;
+    background-color: var(--color-donut-track);
+  }
+
+  .segbar rect {
+    fill: currentColor;
+  }
+
+  .device-row-tally {
+    color: var(--color-text-muted);
+    font-size: var(--font-size-xs);
+  }
+
+  .failure-digest {
+    font-size: var(--font-size-sm);
+    max-height: 168px;
+    overflow-y: auto;
+  }
+
+  .failure-digest li {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    gap: 8px;
+    align-items: baseline;
+    padding: 6px 12px;
+  }
+
+  .failure-digest li:nth-child(even) {
+    background-color: var(--color-summary-card-alt);
+  }
+
+  .failure-digest .icon {
+    margin: 0;
+    align-self: center;
+  }
+
+  .digest-body {
+    min-width: 0;
+  }
+
+  /* A real <button>, so the digest is reachable and operable from the
+     keyboard, wearing a link's clothes. */
+  .digest-jump {
+    display: block;
+    padding: 0;
+    border: 0;
+    background: none;
+    font: inherit;
+    font-weight: var(--font-weight-medium);
+    color: var(--color-accent-text);
+    text-align: left;
+    cursor: pointer;
+    overflow-wrap: anywhere;
+  }
+
+  .digest-jump:hover {
+    text-decoration: underline;
+  }
+
+  .digest-jump:focus-visible {
+    outline: 2px solid var(--color-accent);
+    outline-offset: 2px;
+    border-radius: var(--radius-sm);
+  }
+
+  .digest-message {
+    display: block;
+    color: var(--color-text-muted);
+    overflow-wrap: anywhere;
+  }
+
+  .digest-suite {
+    color: var(--color-text-muted);
+    white-space: nowrap;
+  }
+
   /* Narrow screens (#439).
 
      Everything above this point is the desktop layout, untouched: this
@@ -980,6 +1287,57 @@
       max-height: 40vh;
       object-fit: contain;
     }
+
+    /* Summary header, narrow (#439, A1). The three columns of the summary
+       grid stack on their own — `flex-wrap` and the device bars' 300px
+       basis already do that — so this only tightens the spacing and shrinks
+       the ring, which at 108px would otherwise eat a third of a 375px row. */
+    /* 40vh, not the desktop 50: the title band and the Tests/Logs row are a
+       fixed cost, and on an 812px phone a half-viewport band left the tree
+       with less than the summary above it. */
+    #run-summary {
+      padding: 6px;
+      max-height: 40vh;
+    }
+
+    .summary-grid {
+      gap: 12px;
+      padding: var(--space-sm);
+    }
+
+    .donut,
+    .donut-ring {
+      width: 84px;
+      height: 84px;
+    }
+
+    .summary-legend {
+      min-width: 140px;
+    }
+
+    .device-bars {
+      flex-basis: 100%;
+    }
+
+    /* The suite drops under the message rather than off the page: it is the
+       column the mockup deletes at this width, but it is also the only
+       thing telling two same-named tests apart. */
+    .failure-digest li {
+      grid-template-columns: auto 1fr;
+    }
+
+    .failure-digest .digest-suite {
+      grid-column: 2;
+      white-space: normal;
+    }
+
+    /* One scroller, not two. On a phone the band's own cap is always the
+       binding one, so a second scroll region nested inside it would only
+       ever swallow the gesture that was meant for the band. */
+    .failure-digest {
+      max-height: none;
+      overflow-y: visible;
+    }
   }
 
   </style>
@@ -993,6 +1351,48 @@
         <h1>XCTestHTMLReport</h1>
         <div class="clear"></div>
       </div>
+      <section id="run-summary" aria-labelledby="run-summary-heading">
+      <div class="summary-card">
+        <h2 id="run-summary-heading">
+          <span class="icon failure"></span>
+          Tests
+          <span class="summary-meta">Ran for 9.00s · 1 device</span>
+        </h2>
+        <div class="summary-grid">
+          <div class="donut">
+            <svg class="donut-ring" viewBox="0 0 120 120" aria-hidden="true" focusable="false">
+              <circle class="donut-track" cx="60" cy="60" r="48"></circle>
+              <circle class="donut-seg status-tint-succeeded" cx="60" cy="60" r="48" pathLength="100" stroke-dasharray="20.0000 80.0000" stroke-dashoffset="0.0000" transform="rotate(-90 60 60)"></circle><circle class="donut-seg status-tint-failed" cx="60" cy="60" r="48" pathLength="100" stroke-dasharray="20.0000 80.0000" stroke-dashoffset="-20.0000" transform="rotate(-90 60 60)"></circle><circle class="donut-seg status-tint-skipped" cx="60" cy="60" r="48" pathLength="100" stroke-dasharray="20.0000 80.0000" stroke-dashoffset="-40.0000" transform="rotate(-90 60 60)"></circle><circle class="donut-seg status-tint-mixed" cx="60" cy="60" r="48" pathLength="100" stroke-dasharray="20.0000 80.0000" stroke-dashoffset="-60.0000" transform="rotate(-90 60 60)"></circle><circle class="donut-seg status-tint-expected-failure" cx="60" cy="60" r="48" pathLength="100" stroke-dasharray="20.0000 80.0000" stroke-dashoffset="-80.0000" transform="rotate(-90 60 60)"></circle>
+            </svg>
+            <span class="donut-center"><strong>5</strong><small>Tests</small></span>
+          </div>
+          <ul class="summary-legend">
+            <li><span class="legend-swatch status-tint-succeeded"></span>Passed <span class="legend-count">1</span></li><li><span class="legend-swatch status-tint-failed"></span>Failed <span class="legend-count">1</span></li><li><span class="legend-swatch status-tint-skipped"></span>Skipped <span class="legend-count">1</span></li><li><span class="legend-swatch status-tint-mixed"></span>Mixed <span class="legend-count">1</span></li><li><span class="legend-swatch status-tint-expected-failure"></span>Expected failures <span class="legend-count">1</span></li>
+          </ul>
+          <div class="device-bars">
+            <p class="device-bars-head">Devices &amp; Configurations</p>
+            <div class="device-row">
+              <span class="device-row-name">Synthetic Device <span class="device-row-os">1.0</span></span>
+              <svg class="segbar" viewBox="0 0 100 8" preserveAspectRatio="none" aria-hidden="true" focusable="false"><rect class="status-tint-succeeded" x="0.0000" y="0" width="20.0000" height="8"></rect><rect class="status-tint-failed" x="20.0000" y="0" width="20.0000" height="8"></rect><rect class="status-tint-skipped" x="40.0000" y="0" width="20.0000" height="8"></rect><rect class="status-tint-mixed" x="60.0000" y="0" width="20.0000" height="8"></rect><rect class="status-tint-expected-failure" x="80.0000" y="0" width="20.0000" height="8"></rect></svg>
+              <span class="device-row-tally">1 passed, 1 failed, 1 skipped, 1 mixed, 1 expected failure</span>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="summary-card">
+        <h2>Test Failures <span class="summary-meta">1 failure</span></h2>
+        <ul class="failure-digest">
+          <li>
+            <span class="icon failure"></span>
+            <span class="digest-body">
+              <button type="button" class="digest-jump" data-target="4abdbdaebf10baf0f23017525cf4a9be">testFails()</button>
+              <span class="digest-message">Synthetic.swift:42: assertion failed</span>
+            </span>
+            <span class="digest-suite">Synthetic</span>
+          </li>
+        </ul>
+      </div>
+    </section>
       <ul id="test-log-toolbar" class="toolbar centered-toolbar toggle-toolbar">
         <li class="selected" onclick="showTests(this);">Tests</li>
         <li onclick="showLogs(this);">Logs</li>
@@ -1805,6 +2205,81 @@
 
   document.querySelectorAll('.device-info')[0].classList.add("selected");
   document.querySelectorAll('.run')[0].classList.add("active");
+
+  // Failure digest (#439, A1). Each row's button carries the failing test's
+  // element id in `data-target`; nothing about the test reaches a script
+  // context, which is the shape #463 left behind.
+  //
+  // The digest lists every run's failures, but only one run is in the
+  // layout at a time, so a jump has four things to undo before the row is
+  // on screen: the Logs tab, a non-active run, a filter that hid the row,
+  // and the collapsed disclosure it sits behind.
+  var digestButtons = document.querySelectorAll('.digest-jump');
+  for (var d = 0; d < digestButtons.length; d++) {
+    digestButtons[d].addEventListener('click', digestJump, false);
+  }
+
+  function digestJump(e) {
+    var uuid = e.currentTarget.getAttribute('data-target'),
+        // A test with one iteration hangs its rows off `activities-`; a
+        // retried one off `iterations-`. Both ids come from the same uuid,
+        // and the outer row is the nearest .test-summary either way.
+        disclosure = document.getElementById('activities-' + uuid)
+                  || document.getElementById('iterations-' + uuid);
+    if (!disclosure) {
+      return;
+    }
+
+    var row = disclosure.closest('.test-summary');
+    if (!row) {
+      return;
+    }
+
+    var testsTab = document.querySelector('#test-log-toolbar li');
+    if (testsTab && !testsTab.classList.contains('selected')) {
+      showTests(testsTab);
+    }
+
+    activateRunContaining(row);
+
+    // The filter writes `display: none` onto the element itself, and its
+    // group as well. Clearing both un-hides this one row without resetting
+    // the filter the reader chose.
+    row.style.display = 'block';
+    var group = row.closest('.test-summary-group');
+    if (group) {
+      group.style.display = 'block';
+    }
+
+    disclosure.style.display = 'block';
+    var chevron = row.querySelector('.drop-down-icon');
+    if (chevron) {
+      chevron.classList.add('dropped');
+    }
+
+    var listItem = row.querySelector('.list-item');
+    if (listItem) {
+      selectListItem(listItem);
+    }
+    row.scrollIntoView({ block: 'start' });
+  }
+
+  // `.run` elements and `.device-info` cards are rendered from one list of
+  // runs, in order, so the nth card selects the nth run. Going through
+  // selectDevice rather than toggling the classes here keeps one definition
+  // of what "active" means.
+  function activateRunContaining(el) {
+    var run = el.closest('.run');
+    if (!run || run.classList.contains('active')) {
+      return;
+    }
+    var runs = Array.prototype.slice.call(document.querySelectorAll('.run')),
+        cards = document.querySelectorAll('.device-info'),
+        index = runs.indexOf(run);
+    if (index >= 0 && cards[index]) {
+      selectDevice(run.id.replace('device_', ''), cards[index]);
+    }
+  }
 
   </script>
 </body>

--- a/docs/superpowers/specs/2026-08-10-xcresulttool-legacy-migration-design.md
+++ b/docs/superpowers/specs/2026-08-10-xcresulttool-legacy-migration-design.md
@@ -701,6 +701,45 @@ still normalizes — against the hex-digest pattern, not the UUID one. A regex
 written for RFC-4122 silently matches nothing after #430 and the differential
 degrades to comparing raw identifiers, which fails on every run.
 
+### Repetition durations are measured independently — measured (2026-08-14)
+
+Answer 8 converges *summing*: `TestCase.duration` sums its iterations under
+both readers, so neither backend can disagree about how a repeated case's
+total is assembled. It does not — and cannot — converge the inputs. The two
+formats report the same repetition from their own measurement, at microsecond
+scale, and those values are not always the same number.
+
+`RetryTests/testRetryOnFailure()` (two repetitions), across three
+`prepareTestResults.sh` generations of `RetryResults.xcresult`:
+
+| generation | legacy | modern | Δ |
+| --- | --- | --- | --- |
+| #476's review | 0.14027798s | 0.14065396s | 376µs |
+| 2026-08-14 01:21 | 0.60440397s | 0.60440397s | 0 |
+| 2026-08-14 11:43 | 0.18024814s | 0.18039226s | 144µs |
+
+The last generation localises it: the whole gap sits in repetition 0
+(0.12885606s legacy against 0.12900018s modern) while repetition 1 is
+bit-identical. Sibling leaves in the same bundle — `testJustPass()`,
+`testJustFail()`, `testInUnknownState()` — agree exactly in every generation.
+
+**This is a property of the formats, not a bug, and it is not #477.** #477 is
+structural and closable: legacy sums a parameterized case's argument
+executions and modern does not, so one of the two can be changed to match.
+Here there is nothing to change — the arithmetic already agrees, and a
+renderer cannot make two independent measurements of the same repetition
+round to the same microsecond. Exact equality is not something either format
+promises for a repetition duration, so the differential must not assert it.
+
+Consequence for the harness: cross-backend duration comparison is exact for
+leaves the run executed once, and holds repeated leaves to a per-repetition
+tolerance instead — 1ms per repetition in
+`DifferentialTests.testSummaryHeaderNumbersAgreeAcrossBackends`, about five
+times the largest per-repetition divergence measured above, since a bound
+that only clears one generation's number is not a bound. The repetition
+*count* stays an exact assertion, so a dropped repetition cannot hide inside
+the tolerance that count sizes.
+
 ### The differential test
 
 `Tests/XCTestHTMLReportTests/DifferentialTests.swift`, for each of

--- a/visual/tests/behaviour.spec.ts
+++ b/visual/tests/behaviour.spec.ts
@@ -19,6 +19,47 @@ test('the failed filter hides passing tests', async ({ page }) => {
   expect(failed, 'the fixture has failing tests, so some rows must remain').toBeGreaterThan(0);
 });
 
+// The failure digest (#439, A1). Its jump is the one piece of the summary
+// header that is behaviour rather than markup, and it has four things to undo
+// before the row is on screen — none of which a rendered-HTML assertion can
+// see.
+test('a digest jump expands the failing test it names', async ({ page }) => {
+  await page.goto(reportURL);
+
+  const jump = page.locator('.digest-jump').first();
+  const name = (await jump.textContent())?.trim();
+  expect(name, 'the fixture must render a failure digest').toBeTruthy();
+
+  const uuid = await jump.getAttribute('data-target');
+  const disclosure = page.locator(`#activities-${uuid}, #iterations-${uuid}`).first();
+  await expect(disclosure, 'the test starts collapsed').toBeHidden();
+
+  await jump.click();
+
+  await expect(disclosure, 'the jump must expand the test').toBeVisible();
+  await expect(
+    page.locator('.run.active .list-item.selected').first(),
+    'the jump must select the row it scrolled to',
+  ).toContainText(name!);
+});
+
+// A digest row for a test the active filter has hidden still has to reach it.
+test('a digest jump reveals a row the filter has hidden', async ({ page }) => {
+  await page.goto(reportURL);
+
+  // "Passed" hides every failing row, which is every row the digest lists.
+  await page.locator('li', { hasText: /^Passed \(\d+\)$/ }).click();
+
+  const jump = page.locator('.digest-jump').first();
+  const uuid = await jump.getAttribute('data-target');
+  const row = page.locator(`#activities-${uuid}, #iterations-${uuid}`).first()
+    .locator('xpath=ancestor::div[contains(@class,"test-summary")][1]');
+  await expect(row, 'the Passed filter must have hidden the failing row').toBeHidden();
+
+  await jump.click();
+  await expect(row, 'the jump must reveal it anyway').toBeVisible();
+});
+
 test('arrow keys move the selection', async ({ page }) => {
   await page.goto(reportURL);
 


### PR DESCRIPTION
Refs #439. First of three serial PRs implementing **Option A — Xcode-native**, the
direction chosen from `DIRECTION-PACKAGE-2026-08-12.md`. This one is the **summary
header only**: the outcome ring, the per-device bars and the failure digest that sit
above the tree. A2 restyles the tree and rows; A3 does the filters and #460. Neither is
started here.

## What lands

- **Run summary** — a ring showing every outcome's share, a legend with the counts, the
  total, and the run duration. All six `Status` cases are counted, so the buckets
  partition the run rather than leaving tests uncounted.
- **Failure digest** — one row per failed test with its assertion message and its suite,
  readable without expanding anything (the audit's finding 2). The test name is a
  `<button>`: clicking it activates the owning run, clears whatever the filter hid,
  expands the disclosure, selects the row and scrolls to it.
- **Device bars** — one row per run, a proportional bar and the same breakdown in words.
- **Dark-first Apple palette** for the header, as five new surface tokens plus
  `--status-mixed`, on the existing `:root` layer.
- **The ring is inline SVG** — one stroked `<circle>` per bucket, `pathLength="100"` so
  the dash arithmetic is percentages. No canvas, no fetch, no external anything; it works
  identically in `--rendering-mode inline` and `linking`.

## The two derived numbers, and why the differential stays green

`DifferentialTests` renders every fixture through both readers and requires byte equality
after masking the four declared losses. **No allow-list entry was added**, and
`differential-allowlist.json` is not in this diff.

**Counts** are backend-identical and are compared as such. `Status` partitions the leaf
tests exactly, and the header asserts that the buckets add up to the run's test count on
both backends.

**Duration** is the sum of *leaf* test durations, never of groups — `durationInSeconds` is
null on every suite node in the modern format, which is the standing `durations` entry, so
a total that reached for a group's duration would read a real value on one backend and
zero on the other.

That sum is **not** backend-identical, and this PR does not pretend otherwise. The first
revision claimed it was, on the strength of three local fixtures where the leaf sums
matched to the last bit. CI disagreed, and CI was right. Downloading the failing run's
bundles and re-running against them isolates one divergent leaf on those bundles — a
second, unrelated one turned up in review and is covered below:

| | legacy | modern |
|---|---|---|
| `SwiftTestingSuite/parameterizedAddition(value:)` | 0.001268s | 0.000423s |
| run total | 5.0396610s | 5.0388156s |

Legacy is ~3× modern and the test has three argument sets: legacy merges the argument
executions and sums them, modern reports the node's own value.

Both totals still render `5.04s`, so the byte comparison passed; only a tight model-level
assertion caught it. That is luck, not safety. Legacy = 3 × modern means a slower runner
where modern reports 0.003s makes legacy 0.009s — a 6ms gap that crosses a 2-decimal
rounding boundary and turns the differential red intermittently. Loosening the tolerance
would have buried precisely the thing that breaks CI later.

So the header writes its total in the shape the **existing** `durations` rule already
normalises:

```html
<span class="summary-meta">Duration <span class="summary-duration">(5.04s)</span> · 1 device</span>
```

Rendered copy: **`Duration (5.04s) · 1 device`**. The parentheses are not styling — `(N.NNs)`
is literally what `KnownLossMasker`'s `durations` rule matches, so the header's total
inherits the loss that entry already declares instead of leaving it uncovered.
`RunSummaryTests.testTheHeadersDurationIsWrittenInAMaskedShape` proves that against the
masker rather than by reading the regex and believing it, so a copy edit that dropped the
parentheses fails immediately.

### The second divergence, found in review — a format property, not a bug

This PR previously went on to claim every *other* leaf was exact. Review disproved that by
regenerating the fixtures: a leaf the run **repeated** can differ too, by microseconds.
Measured on `RetryTests/testRetryOnFailure()` (two repetitions), across three
`prepareTestResults.sh` generations of `RetryResults.xcresult`:

| generation | legacy | modern | Δ |
|---|---|---|---|
| review's | 0.14027798s | 0.14065396s | **376µs** |
| 2026-08-14 01:21 | 0.60440397s | 0.60440397s | 0 |
| 2026-08-14 11:43 (fresh, this revision) | 0.18024814s | 0.18039226s | **144µs** |

So it is generation-dependent, which is why an exact assertion passed on CI and in
development until someone rebuilt the bundle. The 11:43 generation localises it: the whole
gap sits in **repetition 0** (0.12885606s legacy against 0.12900018s modern) while
repetition 1 is bit-identical, and the three sibling leaves in the same bundle agree
exactly in every generation.

**This is not #477 and should not be filed under it.** #477 is structural and closable —
legacy sums a parameterized case's argument executions and modern does not, so one side
can be changed to match. Here the arithmetic *already* agrees: design answer 8 has both
readers summing repetitions, so there is nothing left to converge. What remains is the two
formats measuring and reporting the same repetition independently at microsecond
precision, and no renderer-side change can make two independent measurements round to the
same microsecond. Exact equality is not something either format promises for a repetition
duration, so the differential must stop asserting it. It is recorded as a measured format
property in the migration spec's Verification section, amended in this PR — not left open
as a bug with no fix.

One consequence worth flagging, because it corrects something #477's own issue body says:
closing #477 will **not** free the header's total to be written in any shape. The
repetition property above reaches the same total by the same route, so the parenthesised,
`durations`-masked form stays necessary for as long as a repeated test can land in a
report. The comment in `RunSummary.swift` now names both divergences and says which is
which.

### How the assertion is structured

The model-level assertion was not deleted, and the two divergences are handled
differently because they are different things:

| leaf | comparison | why |
|---|---|---|
| ran once | **exact**, no tolerance | provably bit-identical on every fixture and every generation; this also pins the non-parameterized Swift Testing cases that `testXCTestCaseDurationsAgreeAcrossBackends` skips wholesale |
| repeated N times | within **1ms × N** | the per-repetition measurement property above; the bound is ~5× the largest per-repetition divergence measured (188µs), because a bound that only clears one generation's number is not a bound |
| `SwiftTestingSuite/parameterizedAddition` | excluded by name | structural, closable, owned by #477 |

The repetition *count* itself stays an exact assertion, so a backend that dropped a
repetition cannot hide inside the tolerance that same count is used to size. A guard
after the fixture loop fails if no repeated leaf was compared at all, so the weaker of
the two comparisons cannot quietly become dead code. Verified both ways on the fresh
generation: the previous exact-only assertion is **red** on it (144µs on
`testRetryOnFailure()`), the restructured one is green on that generation *and* on the
01:21 bundles.

One more vacuity hole closed on review feedback: keying leaves by identifier used
`uniquingKeysWith` and would silently drop the second of a duplicated pair, reporting
parity for a leaf it never compared. Identifiers are unique today because every fixture
is one plan on one destination; the moment a multi-run fixture lands they are not. The
uniqueness is now asserted rather than assumed, with a message naming the fix (put the
run in the key). Widening the key pre-emptively was rejected: it would buy coverage no
fixture exercises at the price of assuming both backends order `runs` identically, which
nothing pins. Mutation-verified — duplicating the leaf list fails it on every fixture.

Note `testXCTestCaseDurationsAgreeAcrossBackends` still holds those same leaves to a flat
`accuracy: 0.0005`, tighter than 1ms × 2 for anything repeated twice. That is left alone
deliberately — it is the older blanket gate, and if a generation ever exceeds it the right
response is to give *it* the same per-repetition treatment, not to loosen either.

**The root cause has an issue: #477.** The migration design's answer 8 already solved the
identical problem for *repetitions* by summing in the renderer; answer 6 added `arguments`
at the same time as an *"unexercised by fixtures"* slot, and nobody applied answer 8 to it.
The fix is to converge the backends by construction rather than by mask, per the spec's
own "an unmasked diff proves more than a masked one". #477 names the two things that come
out when it lands: the exclusion in the differential and the paragraph in
`RunSummary.swift`. This divergence predates this PR — it has been living under the
`durations` mask in the tree since the parameterized fixture landed — but the header is
the first place it aggregates into one number, which is what made it visible.

`ParsedRun` carries no run date, so the header states a duration and no start time. The
mockup derived one from the earliest activity timestamp; that is a field the differential
does not cover, so it is not read here.

## Contrast

Every pairing below is the *resolved* one, read out of the live cascade in Chromium at
1440px rather than from a hand-written matrix. Text floor 4.5:1, non-text (WCAG 1.4.11)
floor 3:1. `visual/tests/tokens.spec.ts` enforces the text column automatically in both
themes and passes.

### Text — light / dark

| Element | light fg on bg | ratio | dark fg on bg | ratio |
|---|---|---|---|---|
| `h2`, `.donut-center strong`, `.device-row-name` | `#111111` on `#FFFFFF` | 18.88 | `#E8E8EA` on `#232327` | 12.80 |
| `.summary-meta`, `.donut-center small`, `.device-bars-head`, `.device-row-os`, `.device-row-tally` | `#555555` on `#FFFFFF` | 7.46 | `#9A9AA2` on `#232327` | 5.61 |
| `.legend-count` | `#333333` on `#FFFFFF` | 12.63 | `#C9C9CE` on `#232327` | 9.49 |
| `.digest-jump` (odd row) | `#1163CC` on `#FFFFFF` | 5.71 | `#7FB0FF` on `#232327` | 7.13 |
| `.digest-jump` (even/striped row) | `#1163CC` on `#F7F7F9` | 5.33 | `#7FB0FF` on `#2A2A2F` | 6.50 |
| `.digest-message`, `.digest-suite` (odd row) | `#555555` on `#FFFFFF` | 7.46 | `#9A9AA2` on `#232327` | 5.61 |
| `.digest-message`, `.digest-suite` (even/striped row) | `#555555` on `#F7F7F9` | 6.97 | `#9A9AA2` on `#2A2A2F` | **5.11** |

Tightest pairing in the header: 5.11:1, against a 4.5 floor.

### Non-text — ring arcs, bar segments and legend swatches, against the card

| Status | light fg on bg | ratio | dark fg on bg | ratio |
|---|---|---|---|---|
| passed | `#1E8E3E` on `#FFFFFF` | **4.21** | `#4FBF6B` on `#232327` | 6.71 |
| failed | `#D70015` on `#FFFFFF` | 5.38 | `#FF6E6A` on `#232327` | 5.73 |
| skipped / unknown | `#6E6E73` on `#FFFFFF` | 5.07 | `#9A9AA2` on `#232327` | 5.61 |
| expected failure | `#9A6400` on `#FFFFFF` | 5.00 | `#D9A038` on `#232327` | 6.74 |
| mixed *(new token)* | `#8944AB` on `#FFFFFF` | 6.04 | `#C89AF5` on `#232327` | 7.01 |

Tightest: 4.21:1, against a 3:1 floor. The status values are the existing #439 tokens,
unchanged — in dark the header's card is the same `#232327` those tokens were already
sized against, so it inherits their measurements exactly.

### Deliberately below 3:1

`--color-summary-border` (1.51 light / 1.39 dark) and `--color-donut-track` (1.28 / 1.39).
Both are decorative: a card edge and the ring's empty groove carry nothing the arcs and
the legend do not already carry in colour *and* in text, and 1.4.11 scopes the floor to
graphics you must perceive to understand the content. Raising them to 3:1 would draw the
heavy outline the rest of the sheet already avoids.

## Deviations from the mockup, and why

1. **No counts printed inside the bars.** The mockup puts white numerals on the segments.
   Measured: white on its `--green` is **3.13:1** light / **2.02:1** dark, on `--gray`
   3.26 / 2.87, on `--red` 4.23 / 3.41 — all under the 4.5 floor for 11px text. The
   counts moved out into the caption beside the bar, and the bar became a pure graphic
   held to the 3:1 non-text floor. This is the C-refresh discipline applied to the
   mockup's own errors, as directed.
2. **Corrected palette, not the mockup's.** The status colours are C's contrast-vetted
   tokens, not the mockup's raw Apple values (`#34c759`, `#ff453a`, `#ffd60a`). Only
   surfaces and `--status-mixed` are new.
3. **No run start time** — `ParsedRun` has no date; see above.
4. **Duration is the leaf sum, written `Duration (5.04s)`**, not the mockup's
   "Selected tests ran for 27.51 s" — see above. The parenthesised form is what keeps a
   declared known loss covered.
5. **The ring is a stroked SVG, not `conic-gradient`.** The direction package proposed
   CSS; inline SVG was specified for this PR, and it is the better fit anyway: a ring
   drawn with `conic-gradient` needs a second element to punch the hole, and the dash
   arithmetic here is computed in Swift at fixed precision, which is what keeps the golden
   files byte-stable.
6. **Mixed gets a solid hue** rather than the tree's split-diamond treatment. A 12px ring
   arc and a 10px legend swatch are too small to read a split at. The tree's glyph is
   unchanged.
7. **The device bar spans its column** instead of the mockup's fixed 220px. The mockup
   capped its `main` at 1100px; the report is a full-width app shell with no centred
   document column, and pinning the bar would leave it stranded at 1440.
8. **The suite label comes from the test identifier**, not from the parent group's title:
   the identifier is the one key the differential already pins as equal across backends,
   while the legacy tree wraps every suite in "Selected tests" and "&lt;target&gt;.xctest"
   levels the modern tree does not have.
9. **The header lives inside `<header>`**, the existing banner landmark, rather than as a
   new top-level section — a section outside every landmark would regress axe's `region`
   rule, closed in #462.
10. **At 375px the suite drops under the message** instead of being hidden. The mockup
    deletes that column at ≤480px, but it is the only thing telling two same-named tests
    apart (`testOne()` appears in both SecondSuite and ThirdSuite in the fixture).
11. **The band scrolls** — capped at 50vh, 40vh narrow — so a run with many failures can
    never push the tree off the screen. The digest card disappears entirely when nothing
    failed.
12. **The ring carries no accessible name of its own.** The mockup gives the donut
    `role="img"` with `aria-label="16 tests: 9 passed, 6 failed, 1 skipped"`. The SVG here
    is `aria-hidden="true"` instead, because that sentence is already in the document
    twice — as the `.donut-center` text and as the legend rows — and a `role="img"` name
    would make a screen reader read the same tally three times. Explained in the template
    comment; listed here because it is still a deviation.
13. **The device-bars head keeps only its left-hand label.** The mockup's head is two
    spans, `Devices & Configurations` and `Passed / Failed / Skipped`. The right-hand one
    is dropped: deviation 1 moved the counts out of the bars and into a per-row caption
    that names each number in words, so a column header over a column that no longer
    exists would point at nothing.
14. **Digest meta reads `6 failures`**, not the mockup's `6 total failures`. "Total" adds
    nothing when the digest is the complete list by construction.

## Byte regions touched

`HTMLTemplates.swift` is **insertion-only**: every one of its ten hunks is `-N,0`. Not a
single existing line of the stylesheet, the markup or the script was modified or deleted.

| Region | Change | A2/A3 scope |
|---|---|---|
| `:root` / dark block | +`--status-mixed`, +5 summary surface tokens | — |
| `header { … }` | +`flex: none` (one line) | — |
| stylesheet, before the media query | +new `#run-summary` block | A2 restyles the tree below it |
| `@media (max-width: 700px)` | +new summary rules at the end | A2 |
| `<header>` markup | +`[[RUN_SUMMARY]]`, one line | — |
| `<script>` | +`digestJump` / `activateRunContaining`, appended | A3 rewrites the filter scripts |
| new templates | `runSummary`, `summaryDonut(+Segment)`, `summaryLegendRow`, `summaryDeviceRow`, `summaryBarSegment`, `summaryFailureDigest`, `summaryFailureRow` | — |

Untouched, deliberately: `run`, `testSummary`, `testCase`, `testCaseWithIterations`,
`testGroup`, `iteration`, `activity`, and every attachment template; the three-pane
layout; the filter pills; the resizers; the attachment pane. The digest's jump reaches its
target through the ids those templates *already* emit (`activities-<uuid>` /
`iterations-<uuid>`), which is why none of them needed an `id` added.

`Summary.swift` gains six lines (the `RUN_SUMMARY` placeholder and its comment).
`RunSummary.swift` and `RunSummary+HTML.swift` are new. No reader was touched.

## Test-pin changes

- **`CoreTests.testResultStatusCount`** — comment only, two lines. It said the two
  `Expected Failure` cases "are counted in no header bucket at all". That is still true of
  the *per-run filter pills* it asserts on, which A1 did not touch, but no longer true of
  the report, so the comment now says which of the two readings it means and that they
  disagree until A3 rebuilds the filters. No assertion changed.
- **`CoreTests.testSummaryHeaderAccountsForExpectedFailures`** — new. On the real fixture,
  where the pass/fail split cannot be pinned, it asserts the two properties that can be:
  the legend's buckets add up to the run's test count, and the sample sources' two
  deliberate expected failures land in a bucket rather than nowhere.
- **`DifferentialTests.testSummaryHeaderNumbersAgreeAcrossBackends`** — new, per the
  section above. It lives in `DifferentialSummaryHeaderTests.swift`, an extension on the
  same class, so it shares the cached summaries (a fresh class would double a suite already
  dominated by `xcresulttool` subprocess time) without pushing `DifferentialTests.swift`
  past the 400-line lint threshold. Net swiftlint warnings introduced by this PR: zero.
- **`HTMLEscapingTests`** — two new tests. The header is a second place every hostile
  leaf string reaches markup, and it needed its own coverage: the existing assertions are
  document-wide, so a raw copy in the header would hide behind the escaped copy the tree
  already renders. One asserts on the `#run-summary` subtree specifically (verified by
  mutation — removing the escaping fails it), the other that every digest `data-target` is
  a hex digest, the same tripwire the `onclick` handlers have.
- **`RunSummaryTests`** — new, 9 tests on the synthetic fixture (the only one whose
  numbers are constants). Notably `testDurationSumsLeafTestsAndNotGroups`, which works
  because the fixture's group declares 6s while its leaves add to 9s, and
  `testEveryDigestJumpTargetsAnElementInTheDocument`, which catches a digest pointing at a
  row the page does not contain.
- **`visual/tests/behaviour.spec.ts`** — two new browser tests. The jump is the only part
  of this PR that is behaviour rather than markup, and rendered-HTML assertions cannot see
  it: one asserts it expands and selects the test it names, the other that it reveals a
  row the active filter has hidden.
- **Goldens** — `Snapshots/index.html` and `index-inline.html`, +475 lines each, **zero
  deletions**, which is the same insertion-only property as the template.

## Verification

- `swift test`, both CI legs (`XCHR_RESULT_READER=auto` and `=modern`): **153 tests, 3
  skipped, 0 failures** on each. The three skips are the standing environment-gated ones
  (`BaselineCaptureTests`, `testRetryFunctionalityJunit` per #378,
  `VisualFixtureDumpTests`) and are unrelated to this PR
- Run against **two independent fixture generations**, not one: the local bundles and a
  set freshly rebuilt with `prepareTestResults.sh` afterwards. That second generation is
  the one carrying the repetition divergence above, so it is the generation on which the
  previous exact-only assertion is red — green on both is the claim, and the red one was
  reproduced first to prove the new assertion is doing work
- Run against **CI's own fixtures**, downloaded from the failing run, not just the local
  ones — those are the bundles that actually exercise the #477 divergence
- `DifferentialTests`: green, **allow-list unchanged** (`differential-allowlist.json` is
  not in this diff)
- `visual/`: 13/13, including axe-core (no critical or serious violations) and the
  automated **text** contrast gate in both themes. Stated precisely, because an earlier
  revision of this section overstated it: `tokens.spec.ts` walks text nodes and holds each
  to 4.5:1, dropping to 3:1 only where WCAG's large-text exemption applies (≥24px, or
  ≥18.66px bold) — that 3:1 is the large-text floor, not the 1.4.11 non-text floor. No
  automated non-text gate exists; axe's `color-contrast` rule is text-only as well. The
  non-text table above (ring arcs, bar segments, legend swatches) is computed by hand from
  the resolved cascade. The *Contrast* section already said this; these two now agree.
- 375px overflow probe on both the synthetic and the real rendered report, both themes:
  the page does not scroll sideways, nothing crosses the viewport edge outside an
  intentional scroll container, and nothing in `#run-summary` crosses it at all
- swiftformat clean; swiftlint clean

## Known limitations

- **The digest has no device column.** `RunSummary.FailureRow` carries `uuid`, `testName`,
  `suiteName` and `message`, and `failures = runs.flatMap(\.failureRows)`, so one test plan
  run on two devices renders two rows that read identically and differ only in their
  `data-target`. The jump itself is correct — it activates the owning run, verified on a
  synthesized two-run report — so this is legibility, not correctness. **Deferred to A2**,
  which is where the per-run presentation is being reworked anyway; adding a column here
  would be undone by that pass.

## Screenshots

Real report (`TestResults.xcresult`, 21 tests / 6 failures / 2 expected failures) and the
synthetic fixture, which is the only one that exercises all five buckets at once.

Sixteen shots — full page and header-only, at 1440 and 375, light and dark, for both fixtures — are in `orca-artifacts/track3-a1-summary/`, alongside the same crops of the mockup for comparison.

To look at it live rather than as a picture: the Test workflow renders the sample report on both legs and uploads it, so `report-auto` / `report-modern` on this PR's run open in a browser with every attachment inlined.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a responsive run summary with test totals, duration, status donut, legends, and device breakdowns.
  * Added a failure digest for quickly locating failed tests.
  * Failure digest links now switch to Tests, reveal filtered or collapsed results, select the test, and scroll it into view.
  * Added light and dark themes, mobile layouts, and keyboard-accessible navigation.
* **Bug Fixes**
  * Improved expected-failure counts and duration reporting.
  * Prevented summary content from shrinking or becoming hidden.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
