### PR TITLE
Make beta runs measure reality: UIScene, a partial-bundle gate, a truncation fault and its canary, drift artifacts (refs #478)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -80,6 +80,7 @@ jobs:
           Tests/XCTestHTMLReportTests/Resources/TestResults.xcresult
           Tests/XCTestHTMLReportTests/Resources/SanityResults.xcresult
           Tests/XCTestHTMLReportTests/Resources/RetryResults.xcresult
+          Tests/XCTestHTMLReportTests/Resources/CrashResults.xcresult
         key: ${{ steps.fixture-key.outputs.key }}
 
     - name: Generate test fixtures

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,6 +56,7 @@ jobs:
           Tests/XCTestHTMLReportTests/Resources/TestResults.xcresult
           Tests/XCTestHTMLReportTests/Resources/SanityResults.xcresult
           Tests/XCTestHTMLReportTests/Resources/RetryResults.xcresult
+          Tests/XCTestHTMLReportTests/Resources/CrashResults.xcresult
         key: ${{ steps.fixture-key.outputs.key }}
 
     - name: Generate test fixtures

--- a/.github/workflows/toolchain-drift.yml
+++ b/.github/workflows/toolchain-drift.yml
@@ -331,6 +331,50 @@ jobs:
           Tests/XCTestHTMLReportTests/Resources/RetryResults.xcresult
         key: ${{ steps.fixture-key.outputs.key }}
 
+    # The bundles themselves, whenever this leg found anything wrong.
+    #
+    # #478 is the argument for this step. A beta run produced a `TestResults`
+    # bundle missing 12 of its 21 tests; `toolchain-drift.yml` uploaded nothing,
+    # so triaging it meant reading two job logs and inferring the bundle's shape
+    # from which assertions failed — and the one question that mattered most
+    # (whether XCTest stopped recording `file:line` in failure titles, or
+    # xcresulttool stopped emitting it) could not be answered at all without a
+    # bundle to interrogate. `gh run download` on that run reported "no valid
+    # artifacts found". Fifty megabytes is a cheap price for the next triage
+    # starting from evidence.
+    #
+    # Named per leg, the convention #470 established for `test.yml`:
+    # upload-artifact v4+ rejects duplicate names, so a run where both legs
+    # failed would otherwise lose the second upload. Five days rather than the
+    # 7-14 elsewhere, because these are ~50 MB each and this workflow runs twice
+    # a week — a triage that has not started by the next scheduled run will be
+    # working from that run's bundles instead.
+    #
+    # Placed before the report step, not after: `Report drift` exits 1 on the
+    # stable leg, and a step after a failed step does not run unless it says so.
+    #
+    # The condition enumerates the signals rather than saying `failure()`,
+    # because a bare `failure()` would never fire here — every signal above is
+    # continue-on-error, so a failing one leaves the job itself successful.
+    # `!cancelled()` is what still covers the case where a step that is *not*
+    # continue-on-error (the cache save) failed first. Generation failing
+    # outright can leave no bundle at all, so the upload tolerates finding
+    # nothing rather than adding a red step of its own.
+    - name: Upload fixtures on drift
+      if: >-
+        ${{ !cancelled() && (steps.legacy.outcome == 'failure'
+        || steps.build.outcome == 'failure'
+        || steps.fixtures.outcome == 'failure'
+        || steps.verify.outcome == 'failure'
+        || steps.tests.outcome == 'failure'
+        || steps.tool.outcome == 'failure') }}
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: xcresult-fixtures-${{ matrix.channel }}
+        path: Tests/XCTestHTMLReportTests/Resources
+        retention-days: 5
+        if-no-files-found: ignore
+
     # Turns step outcomes into a filed issue, so a broken scheduled run cannot
     # rot unseen in the Actions tab. One open issue per label collects repeat
     # failures as comments; a later green run comments on it too, so the
@@ -468,6 +512,12 @@ jobs:
           done
           echo
           cat "$RUNNER_TEMP/summary.md"
+          echo
+          # The pointer matters as much as the upload: #478 was triaged from
+          # logs because nobody knew there was nothing to download.
+          echo "The \`.xcresult\` bundles this leg generated are attached to the run as"
+          echo "\`xcresult-fixtures-${CHANNEL}\` (5-day retention) — interrogate those rather than"
+          echo "these logs. Nothing is attached if generation failed before writing a bundle."
           echo
           echo "_Filed automatically by the \`toolchain-drift\` workflow (#392). While this issue stays open, later failing runs append comments here instead of filing duplicates._"
         } > "$RUNNER_TEMP/issue.md"

--- a/.github/workflows/toolchain-drift.yml
+++ b/.github/workflows/toolchain-drift.yml
@@ -329,6 +329,7 @@ jobs:
           Tests/XCTestHTMLReportTests/Resources/TestResults.xcresult
           Tests/XCTestHTMLReportTests/Resources/SanityResults.xcresult
           Tests/XCTestHTMLReportTests/Resources/RetryResults.xcresult
+          Tests/XCTestHTMLReportTests/Resources/CrashResults.xcresult
         key: ${{ steps.fixture-key.outputs.key }}
 
     # The bundles themselves, whenever this leg found anything wrong.
@@ -360,6 +361,13 @@ jobs:
     # continue-on-error (the cache save) failed first. Generation failing
     # outright can leave no bundle at all, so the upload tolerates finding
     # nothing rather than adding a red step of its own.
+    #
+    # Same six steps `Report drift` reads, but only their `failure` outcome —
+    # a narrower set than the one that files an issue, which also treats a
+    # `skipped` legacy probe or fixture step as a fault worth reporting. That
+    # difference is deliberate: those outcomes mean the step never ran, so
+    # there is no bundle behind them to attach. Widening this to match would
+    # only ever upload a stale or empty directory.
     - name: Upload fixtures on drift
       if: >-
         ${{ !cancelled() && (steps.legacy.outcome == 'failure'

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 TestResults*.xcresult
 RetryResults*.xcresult
 SanityResults*.xcresult
+CrashResults*.xcresult
 .DS_Store
 /.build
 /XCTestHTMLReportSampleApp/Build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,10 +60,18 @@ full of tests, just not the ones hosted in the app.
 ./scripts/verify_fixtures.sh   # asserts each bundle holds its expected test count
 ```
 
-It knows the shape of each of the three fixtures (21, 1 and 4 tests), so a
-bundle that generated partially is rejected by name and count rather than
-waved through. Adding or removing sample-app tests moves those numbers: update
-the table at the top of the script in the same commit.
+It knows the shape of each fixture (21, 1 and 4 tests for the three healthy
+ones), so a bundle that generated partially is rejected by name and count
+rather than waved through. Adding or removing sample-app tests moves those
+numbers: update the table at the top of the script in the same commit.
+
+The fourth bundle, `CrashResults.xcresult`, is a broken run on purpose: the
+script sets `XCHR_TRAP_AT_LAUNCH`, the sample app traps in
+`didFinishLaunchingWithOptions`, and `SampleAppUnitTests` — hosted in that app
+— dies with it. `SystemFailureCanaryTests` reads it to check that Apple still
+calls the resulting group `System Failures`, which is the only handle the
+`systemFailure` fault has. Expect one failing `xcodebuild` invocation during
+generation; that is the fixture being made, not a problem.
 
 Regenerate fixtures after upgrading Xcode; `.xcresult` contents change between
 Xcode versions.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,12 +52,18 @@ No credentials or secrets are required for this part.
 
 If a simulator goes away mid-run, `xcodebuild` can leave an `.xcresult` behind
 that looks complete but holds no tests, and the suite then fails with a
-confusing error. `scripts/verify_fixtures.sh` — the same gate CI runs — catches
-that in a second:
+confusing error. A host-app launch failure does something subtler: the bundle is
+full of tests, just not the ones hosted in the app.
+`scripts/verify_fixtures.sh` — the same gate CI runs — catches both in a second:
 
 ```bash
-./scripts/verify_fixtures.sh   # asserts each bundle actually contains tests
+./scripts/verify_fixtures.sh   # asserts each bundle holds its expected test count
 ```
+
+It knows the shape of each of the three fixtures (21, 1 and 4 tests), so a
+bundle that generated partially is rejected by name and count rather than
+waved through. Adding or removing sample-app tests moves those numbers: update
+the table at the top of the script in the same commit.
 
 Regenerate fixtures after upgrading Xcode; `.xcresult` contents change between
 Xcode versions.

--- a/Package.swift
+++ b/Package.swift
@@ -38,6 +38,12 @@ let package = Package(
                 .process("Resources/TestResults.xcresult"),
                 .process("Resources/RetryResults.xcresult"),
                 .process("Resources/SanityResults.xcresult"),
+                // A deliberately broken run — a host app that traps at launch.
+                // SystemFailureCanaryTests reads it to re-measure the group
+                // name `systemFailure` keys on against the live toolchain
+                // (#478); prepareTestResults.sh generates it alongside the
+                // three healthy bundles.
+                .process("Resources/CrashResults.xcresult"),
                 .process("Resources/differential-allowlist.json"),
             ]
         ),

--- a/Sources/XCTestHTMLReportCore/Classes/Helpers/FaultCollector.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Helpers/FaultCollector.swift
@@ -42,6 +42,18 @@ public struct Fault: Equatable {
         /// the modern reader instead, which is a different reader than the
         /// caller asked for.
         case legacyReaderUnavailable
+        /// A test target is present in the bundle with no test rows beneath
+        /// it: it was planned, it was meant to run, and it produced nothing.
+        /// The run stopped early, and the report is missing everything that
+        /// target would have contributed (#478). A bundle that carries no
+        /// testable for a target at all is structural absence — the usual
+        /// result of `-only-testing` — and is never flagged, the same rule
+        /// `unresolvedLog` and `unresolvedAttachment` follow.
+        case emptyPlannedTestable
+        /// A host-application or system failure row, which both formats file
+        /// under a group Apple names `System Failures`. Direct evidence the
+        /// run did not complete, whatever else survived into the report.
+        case systemFailure
     }
 
     public let kind: Kind

--- a/Sources/XCTestHTMLReportCore/Classes/Helpers/FaultCollector.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Helpers/FaultCollector.swift
@@ -42,17 +42,18 @@ public struct Fault: Equatable {
         /// the modern reader instead, which is a different reader than the
         /// caller asked for.
         case legacyReaderUnavailable
-        /// A test target is present in the bundle with no test rows beneath
-        /// it: it was planned, it was meant to run, and it produced nothing.
-        /// The run stopped early, and the report is missing everything that
-        /// target would have contributed (#478). A bundle that carries no
-        /// testable for a target at all is structural absence — the usual
-        /// result of `-only-testing` — and is never flagged, the same rule
-        /// `unresolvedLog` and `unresolvedAttachment` follow.
-        case emptyPlannedTestable
         /// A host-application or system failure row, which both formats file
         /// under a group Apple names `System Failures`. Direct evidence the
-        /// run did not complete, whatever else survived into the report.
+        /// run did not complete, whatever else survived into the report (#478).
+        ///
+        /// This is the whole of the in-tool truncation signal. A second kind
+        /// that flagged a *selected* target holding zero test rows was written
+        /// and withdrawn: only the legacy reader can observe that shape — the
+        /// modern node tree prunes the emptied bundle node instead — and on
+        /// legacy an ordinary suite-granular `-skip-testing` produces it, so
+        /// the kind faulted healthy runs on the default reader. Bundles missing
+        /// whole targets are caught outside the tool instead, by the per-bundle
+        /// floors in `scripts/verify_fixtures.sh`.
         case systemFailure
     }
 

--- a/Sources/XCTestHTMLReportCore/Classes/Models/Summary.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Models/Summary.swift
@@ -268,6 +268,63 @@ public struct Summary {
             }
             faultCollector.record(.unresolvedLog, run.logFaultDescription)
         }
+
+        validateTruncation(recorded: recorded)
+    }
+
+    /// Records the two signals that a run stopped early (#478).
+    ///
+    /// Both read `parsedRuns` — the model *both* readers produce — rather than
+    /// the rendered tree or either backend's document, so one implementation
+    /// serves both and they cannot drift apart. That matters more here than
+    /// elsewhere: this fault exists because a beta toolchain broke fixture
+    /// generation, and a rule that keyed on the toolchain, or on one reader's
+    /// vocabulary, would be measuring a proxy for the loss rather than the loss.
+    ///
+    /// The two are deliberately independent, and neither knows the other's
+    /// business: the count check never looks at a name, the bucket check never
+    /// looks at a count. A truncated target usually trips exactly one of them —
+    /// a testable emptied outright trips the first, one left holding only a
+    /// crash row trips the second.
+    ///
+    /// Deduped and idempotent on the same terms as the loops above, so the CLI
+    /// and a library caller that validates twice see the same fault set.
+    private func validateTruncation(recorded: [Fault]) {
+        var flaggedTestables = Set(
+            recorded.filter { $0.kind == .emptyPlannedTestable }.map(\.detail)
+        )
+        var flaggedSystemFailures = Set(
+            recorded.filter { $0.kind == .systemFailure }.map(\.detail)
+        )
+
+        for run in parsedRuns {
+            // No loop body for a run with no testables at all: that is
+            // structural absence — `-only-testing` prunes unselected targets
+            // out of the document on both backends — and absence is never a
+            // fault. Only a target that IS here and produced nothing is.
+            for testable in run.testables {
+                if testable.allTestCases.isEmpty,
+                   flaggedTestables.insert(testable.targetName).inserted
+                {
+                    faultCollector.record(.emptyPlannedTestable, testable.targetName)
+                }
+
+                for group in testable.systemFailureGroups {
+                    // The bucket's presence is the signal; its rows only name
+                    // it. An empty bucket is still a system failure, so fall
+                    // back to the group's own name rather than recording
+                    // nothing.
+                    let rows = group.allTestCases.map(\.name)
+                    for row in rows.isEmpty ? [group.name] : rows {
+                        let detail = "\(testable.targetName): \(row)"
+                        guard flaggedSystemFailures.insert(detail).inserted else {
+                            continue
+                        }
+                        faultCollector.record(.systemFailure, detail)
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/Sources/XCTestHTMLReportCore/Classes/Models/Summary.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Models/Summary.swift
@@ -269,46 +269,40 @@ public struct Summary {
             faultCollector.record(.unresolvedLog, run.logFaultDescription)
         }
 
-        validateTruncation(recorded: recorded)
+        validateSystemFailures(recorded: recorded)
     }
 
-    /// Records the two signals that a run stopped early (#478).
+    /// Records the signal that a run stopped early (#478).
     ///
-    /// Both read `parsedRuns` — the model *both* readers produce — rather than
-    /// the rendered tree or either backend's document, so one implementation
-    /// serves both and they cannot drift apart. That matters more here than
-    /// elsewhere: this fault exists because a beta toolchain broke fixture
-    /// generation, and a rule that keyed on the toolchain, or on one reader's
-    /// vocabulary, would be measuring a proxy for the loss rather than the loss.
+    /// Reads `parsedRuns` — the model *both* readers produce — rather than the
+    /// rendered tree or either backend's document, so one implementation serves
+    /// both. That matters more here than elsewhere: this fault exists because a
+    /// beta toolchain broke fixture generation, and a rule that keyed on the
+    /// toolchain, or on one reader's vocabulary, would be measuring a proxy for
+    /// the loss rather than the loss.
     ///
-    /// The two are deliberately independent, and neither knows the other's
-    /// business: the count check never looks at a name, the bucket check never
-    /// looks at a count. A truncated target usually trips exactly one of them —
-    /// a testable emptied outright trips the first, one left holding only a
-    /// crash row trips the second.
+    /// Sharing the implementation is necessary but not sufficient, and the
+    /// distinction cost this file a second fault kind. A rule that flagged a
+    /// *selected* target holding zero test rows was written here, read the same
+    /// shared model, and still fired on one backend only: legacy keeps a
+    /// zero-row `ActionTestableSummary` where the modern node tree prunes the
+    /// bundle node outright, so the same code saw different input and — worse —
+    /// faulted a healthy suite-granular `-skip-testing`, which is ordinary CI
+    /// practice. It was withdrawn. What survives is keyed on a node both
+    /// readers demonstrably produce for the same bundle, checked by
+    /// `SystemFailureCanaryTests` against a bundle the current toolchain just
+    /// generated. Bundles missing whole targets are caught before the tool
+    /// sees them, by the per-bundle floors in `scripts/verify_fixtures.sh`.
     ///
     /// Deduped and idempotent on the same terms as the loops above, so the CLI
     /// and a library caller that validates twice see the same fault set.
-    private func validateTruncation(recorded: [Fault]) {
-        var flaggedTestables = Set(
-            recorded.filter { $0.kind == .emptyPlannedTestable }.map(\.detail)
-        )
+    private func validateSystemFailures(recorded: [Fault]) {
         var flaggedSystemFailures = Set(
             recorded.filter { $0.kind == .systemFailure }.map(\.detail)
         )
 
         for run in parsedRuns {
-            // No loop body for a run with no testables at all: that is
-            // structural absence — `-only-testing` prunes unselected targets
-            // out of the document on both backends — and absence is never a
-            // fault. Only a target that IS here and produced nothing is.
             for testable in run.testables {
-                if testable.allTestCases.isEmpty,
-                   flaggedTestables.insert(testable.targetName).inserted
-                {
-                    faultCollector.record(.emptyPlannedTestable, testable.targetName)
-                }
-
                 for group in testable.systemFailureGroups {
                     // The bucket's presence is the signal; its rows only name
                     // it. An empty bucket is still a system failure, so fall

--- a/Sources/XCTestHTMLReportCore/Classes/ResultReading/ParsedResult.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/ResultReading/ParsedResult.swift
@@ -56,6 +56,72 @@ public struct ParsedGroup {
     public let children: [ParsedNode]
 }
 
+/// The truncation signals `Summary.validate()` reads (#478). They live here,
+/// on the shared model, rather than in either reader: one implementation over
+/// the structure both backends produce is what makes the two agree by
+/// construction instead of by allow-list — the same argument
+/// `ParsedActivity.interleavingFailureRows` makes for failure-row ordering.
+extension ParsedGroup {
+    /// The group Apple files host-app and system failures under.
+    ///
+    /// Not a heuristic reading of a message: it is the node's own name, and
+    /// both formats spell it identically at the same position in the tree.
+    /// Measured, not assumed — a crash bundle was reproduced on Xcode 26.2 by
+    /// trapping in the host app's `didFinishLaunchingWithOptions`, and both
+    /// readers put out a group whose `name` and `identifier` are
+    /// `System Failures`, directly under the testable.
+    ///
+    /// The group is the marker rather than its rows precisely because the rows
+    /// are where the two backends stop agreeing: modern carries the crash row
+    /// (`SampleApp (<pid>) encountered an error`, with the bootstrap failure as
+    /// its failure activity), while XCResultKit drops it — the node is an
+    /// `ActionTestSummary`, not one of the `ActionTestMetadata` entries
+    /// `subtests` decodes — so legacy sees the bucket empty. Keying on the
+    /// bucket makes the rule fire on both; keying on the row would have made it
+    /// fire only on modern.
+    static let systemFailureName = "System Failures"
+
+    /// Every test row in this group's subtree, at any depth.
+    var allTestCases: [ParsedTestCase] {
+        children.flatMap { child -> [ParsedTestCase] in
+            switch child {
+            case let .testCase(testCase):
+                return [testCase]
+            case let .group(group):
+                return group.allTestCases
+            }
+        }
+    }
+
+    /// Every `System Failures` group in this subtree, including this one.
+    ///
+    /// Recursive, though both backends put the bucket directly under the
+    /// testable today: the name is Apple's, so a nested one is still a system
+    /// failure, and for a fault whose whole job is catching a run that stopped
+    /// early, missing a relocated bucket is the worse way to be wrong.
+    var systemFailureGroups: [ParsedGroup] {
+        let nested = children
+            .compactMap { child -> ParsedGroup? in
+                guard case let .group(group) = child else {
+                    return nil
+                }
+                return group
+            }
+            .flatMap(\.systemFailureGroups)
+        return (name == Self.systemFailureName ? [self] : []) + nested
+    }
+}
+
+extension ParsedTestable {
+    var allTestCases: [ParsedTestCase] {
+        groups.flatMap(\.allTestCases)
+    }
+
+    var systemFailureGroups: [ParsedGroup] {
+        groups.flatMap(\.systemFailureGroups)
+    }
+}
+
 /// A test method. Carries one entry per repetition; a non-repeated test has
 /// exactly one.
 public struct ParsedTestCase {

--- a/Sources/XCTestHTMLReportCore/Classes/ResultReading/ParsedResult.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/ResultReading/ParsedResult.swift
@@ -56,20 +56,27 @@ public struct ParsedGroup {
     public let children: [ParsedNode]
 }
 
-/// The truncation signals `Summary.validate()` reads (#478). They live here,
-/// on the shared model, rather than in either reader: one implementation over
-/// the structure both backends produce is what makes the two agree by
-/// construction instead of by allow-list — the same argument
+/// The truncation signal `Summary.validate()` reads (#478). It lives here, on
+/// the shared model, rather than in either reader, so there is one
+/// implementation rather than two to keep in step — the same argument
 /// `ParsedActivity.interleavingFailureRows` makes for failure-row ordering.
+///
+/// One implementation is not by itself a guarantee that both backends behave
+/// alike: shared code over unequal input still diverges, which is how the
+/// withdrawn `emptyPlannedTestable` managed to fire on legacy only. What makes
+/// this one agree is that the node it keys on was measured on both readers,
+/// from the same bundle, and is re-measured on every toolchain by
+/// `SystemFailureCanaryTests`.
 extension ParsedGroup {
     /// The group Apple files host-app and system failures under.
     ///
     /// Not a heuristic reading of a message: it is the node's own name, and
     /// both formats spell it identically at the same position in the tree.
-    /// Measured, not assumed — a crash bundle was reproduced on Xcode 26.2 by
-    /// trapping in the host app's `didFinishLaunchingWithOptions`, and both
-    /// readers put out a group whose `name` and `identifier` are
-    /// `System Failures`, directly under the testable.
+    /// Measured, not assumed — `prepareTestResults.sh` generates
+    /// `CrashResults.xcresult` by trapping in the host app's
+    /// `didFinishLaunchingWithOptions`, and both readers put out a group whose
+    /// `name` and `identifier` are `System Failures`, directly under the
+    /// testable.
     ///
     /// The group is the marker rather than its rows precisely because the rows
     /// are where the two backends stop agreeing: modern carries the crash row
@@ -79,6 +86,27 @@ extension ParsedGroup {
     /// `subtests` decodes — so legacy sees the bucket empty. Keying on the
     /// bucket makes the rule fire on both; keying on the row would have made it
     /// fire only on modern.
+    ///
+    /// Two consequences of keying on a display name, both accepted knowingly:
+    ///
+    /// - **A rename disarms the rule silently.** The bucket is a plain test
+    ///   suite on both surfaces — modern's node is
+    ///   `{"name": "System Failures", "nodeType": "Test Suite"}`, legacy's an
+    ///   ordinary `ActionTestSummaryGroup` — so nothing structural
+    ///   distinguishes it from a user's own suite, and there is no other
+    ///   surface to detect it on today. If Apple renames it, healthy fixtures
+    ///   go on passing and nothing reddens. That is what
+    ///   `SystemFailureCanaryTests` is for: it asserts a freshly generated
+    ///   crash bundle still contains this literal, on both readers, so the
+    ///   rename fails the suite on the toolchain that introduces it — and the
+    ///   `toolchain-drift` beta leg reaches that toolchain before a release
+    ///   does. The literal appears in no binary and no `.strings` table under
+    ///   `Xcode.app`; it is written into the bundle at run time, which is weak
+    ///   evidence it is not localized, and no evidence at all that it is
+    ///   permanent.
+    /// - **A user suite named `System Failures` faults.** Contrived, and it
+    ///   costs that user one `--lenient` run, which is the cheaper side of the
+    ///   trade against missing a real crash.
     static let systemFailureName = "System Failures"
 
     /// Every test row in this group's subtree, at any depth.
@@ -113,10 +141,6 @@ extension ParsedGroup {
 }
 
 extension ParsedTestable {
-    var allTestCases: [ParsedTestCase] {
-        groups.flatMap(\.allTestCases)
-    }
-
     var systemFailureGroups: [ParsedGroup] {
         groups.flatMap(\.systemFailureGroups)
     }

--- a/Tests/XCTestHTMLReportTests/SystemFailureCanaryTests.swift
+++ b/Tests/XCTestHTMLReportTests/SystemFailureCanaryTests.swift
@@ -1,0 +1,156 @@
+//
+//  SystemFailureCanaryTests.swift
+//
+//  A canary for the one literal `systemFailure` depends on (#478).
+//
+//  `ParsedGroup.systemFailureName` is a display name. Nothing structural
+//  distinguishes Apple's crash bucket from a user's own suite on either
+//  surface — modern renders it as `{"name": "System Failures", "nodeType":
+//  "Test Suite"}`, legacy as an ordinary `ActionTestSummaryGroup` — so the name
+//  is the only handle there is. That makes the rule fail *open*: rename the
+//  group in some future Xcode and `systemFailure` stops firing, every healthy
+//  fixture keeps passing, and nothing in the suite goes red. The report would
+//  quietly go back to exiting 0 on a run that never finished, which is the bug
+//  #478 was filed about.
+//
+//  So the literal is re-measured rather than assumed. `prepareTestResults.sh`
+//  generates `CrashResults.xcresult` with the toolchain in front of it, by
+//  setting `XCHR_TRAP_AT_LAUNCH` so the sample app traps in
+//  `didFinishLaunchingWithOptions` and `SampleAppUnitTests` — which is hosted
+//  in it — dies with it. That is the #478 failure reproduced, not simulated.
+//  These tests then assert both readers still find the bucket by name in it.
+//
+//  The canary reaches the next Xcode before a release does: `toolchain-drift`
+//  regenerates fixtures and runs this suite against the beta on its own leg
+//  (#392), so a rename lands as a drift issue rather than as a silent
+//  regression in the field.
+//
+
+import XCTest
+@testable import XCTestHTMLReportCore
+
+final class SystemFailureCanaryTests: XCTestCase {
+    private static let fixture = "CrashResults"
+
+    private func crashBundleURL() throws -> URL {
+        try XCTUnwrap(
+            Bundle.testBundle.url(forResource: Self.fixture, withExtension: "xcresult"),
+            "\(Self.fixture).xcresult is missing — run ./prepareTestResults.sh"
+        )
+    }
+
+    /// Every group name in the parsed tree, at any depth, in tree order.
+    private func groupNames(in result: ParsedResult) -> [String] {
+        func walk(_ group: ParsedGroup) -> [String] {
+            [group.name] + group.children.flatMap { child -> [String] in
+                guard case let .group(nested) = child else {
+                    return []
+                }
+                return walk(nested)
+            }
+        }
+        return result.runs.flatMap(\.testables).flatMap(\.groups).flatMap(walk)
+    }
+
+    /// Names every group the reader did produce, so a failure says what the
+    /// bucket is called *now* instead of only that it is not called what it
+    /// was. The second sentence is there because the other way this assertion
+    /// fails is a trap that stopped firing, and the two are indistinguishable
+    /// from the assertion alone.
+    private func assertBucketIsPresent(
+        in result: ParsedResult,
+        reader: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let names = groupNames(in: result)
+        XCTAssertTrue(
+            names.contains(ParsedGroup.systemFailureName),
+            """
+            The \(reader) reader found no group named \
+            "\(ParsedGroup.systemFailureName)" in a crash bundle this toolchain \
+            just generated, so `systemFailure` is disarmed here. Groups found: \
+            \(names). Either Apple renamed the bucket — update \
+            ParsedGroup.systemFailureName and this fixture's expectations — or \
+            XCHR_TRAP_AT_LAUNCH no longer trapping the sample app means \
+            CrashResults.xcresult is not a crash bundle at all.
+            """,
+            file: file,
+            line: line
+        )
+    }
+
+    // MARK: The literal, per reader
+
+    func testModernReaderStillNamesTheBucketSystemFailures() throws {
+        let url = try crashBundleURL()
+        let reader = ModernResultReader(
+            client: XCResultToolClient(bundleURL: url),
+            payloadStore: nil,
+            faultCollector: FaultCollector()
+        )
+
+        try assertBucketIsPresent(in: XCTUnwrap(reader.read()), reader: "modern")
+    }
+
+    func testLegacyReaderStillNamesTheBucketSystemFailures() throws {
+        // Skipped rather than failed once the toolchain drops the legacy
+        // commands: at that point there is no legacy reader to disarm. The
+        // modern half of the canary carries on alone, which is the direction
+        // 4.0 is heading anyway.
+        guard case .use(.legacy) = ResultBackend.legacy.resolve() else {
+            throw XCTSkip("This toolchain no longer provides the legacy xcresulttool commands")
+        }
+
+        let file = try ResultFile(url: crashBundleURL(), faultCollector: FaultCollector())
+
+        try assertBucketIsPresent(
+            in: XCTUnwrap(LegacyResultReader(file: file).read()), reader: "legacy"
+        )
+    }
+
+    // MARK: The fault the literal drives
+
+    /// End to end, on every backend this toolchain can run: the bundle that
+    /// used to render, print "Report successfully created" and exit 0 now
+    /// records a fault.
+    ///
+    /// The detail differs by reader and that is not drift — modern names the
+    /// crash row it decoded, legacy names the bucket, because legacy does not
+    /// decode the row. Each is truthful about the document its reader saw, so
+    /// this asserts the target and the count, not the wording.
+    func testCrashBundleFaultsOnEveryAvailableBackend() throws {
+        var backends: [ResultBackend] = [.modern]
+        if case .use(.legacy) = ResultBackend.legacy.resolve() {
+            backends.append(.legacy)
+        }
+
+        let url = try crashBundleURL()
+
+        for backend in backends {
+            let summary = Summary(
+                resultPaths: [url.path],
+                renderingMode: .linking,
+                downsizeImagesEnabled: false,
+                downsizeScaleFactor: 0.25,
+                faultCollector: FaultCollector(),
+                backend: backend
+            )
+            summary.validate()
+
+            let details = summary.faults.filter { $0.kind == .systemFailure }.map(\.detail)
+
+            XCTAssertEqual(
+                details.count, 1,
+                "\(backend.rawValue): expected exactly one system failure, got \(details)"
+            )
+            XCTAssertTrue(
+                details.allSatisfy { $0.hasPrefix("SampleAppUnitTests: ") },
+                """
+                \(backend.rawValue): the fault must name the target that died \
+                with the host app, got \(details)
+                """
+            )
+        }
+    }
+}

--- a/Tests/XCTestHTMLReportTests/TruncationFaultTests.swift
+++ b/Tests/XCTestHTMLReportTests/TruncationFaultTests.swift
@@ -1,0 +1,271 @@
+//
+//  TruncationFaultTests.swift
+//
+//  The two faults that catch a run which stopped early (#478).
+//
+//  On the Xcode 27 beta the sample app trapped at launch, `SampleAppUnitTests`
+//  never ran, and `xchtmlreport` rendered 10 of 21 tests, printed "Report
+//  successfully created", and exited 0. A report that claims completeness while
+//  silently dropping 57% of the suite is precisely what the fault machinery
+//  exists to prevent.
+//
+//  Both signals are read off `ParsedResult`, the model *both* readers produce,
+//  so there is one implementation and it cannot drift between backends — the
+//  same seam `unresolvedLog` uses. The shapes were not guessed: the crash was
+//  reproduced on Xcode 26.2 stable by trapping in the host app's
+//  `didFinishLaunchingWithOptions`, and both backends were dumped. They agree
+//  exactly, which is what makes a name-keyed rule defensible here:
+//
+//    legacy  ActionTestSummaryGroup name='System Failures'
+//              └ ActionTestSummary  name='SampleApp (43043) encountered an error'
+//    modern  Test Suite            name='System Failures'
+//              └ Test Case         name='SampleApp (43043) encountered an error'
+//
+
+import XCTest
+@testable import XCTestHTMLReportCore
+
+final class TruncationFaultTests: XCTestCase {
+    // MARK: Synthetic model builders
+
+    private func run(testables: [ParsedTestable]) -> ParsedRun {
+        ParsedRun(
+            destination: ParsedDestination(
+                displayName: "Synthetic Device",
+                deviceIdentifier: "00000000-0000-0000-0000-000000000000",
+                modelName: "Synthetic Model",
+                operatingSystemVersion: "1.0"
+            ),
+            // No log reference: a run that never had one resolves to `.none`
+            // by construction and records no `unresolvedLog`, so the fault sets
+            // below hold only what these tests are about.
+            logReference: nil,
+            testables: testables
+        )
+    }
+
+    private func testCase(_ name: String) -> ParsedNode {
+        .testCase(ParsedTestCase(
+            name: name,
+            identifier: "Synthetic/\(name)",
+            arguments: [],
+            iterations: [ParsedIteration(
+                iterationNumber: nil, status: .passed, duration: 1, activities: []
+            )]
+        ))
+    }
+
+    private func group(_ name: String, _ children: [ParsedNode]) -> ParsedGroup {
+        ParsedGroup(name: name, identifier: name, duration: 1, children: children)
+    }
+
+    /// A `Summary` over synthetic runs, already validated.
+    private func validatedSummary(_ runs: [ParsedRun]) -> Summary {
+        let summary = Summary(
+            parsedRuns: runs,
+            payloads: SyntheticResult.payloads,
+            renderingMode: .linking,
+            downsizeImagesEnabled: false,
+            downsizeScaleFactor: 0.25,
+            faultCollector: FaultCollector(),
+            bundleNames: ["Synthetic"]
+        )
+        summary.validate()
+        return summary
+    }
+
+    private func details(_ summary: Summary, _ kind: Fault.Kind) -> [String] {
+        summary.faults.filter { $0.kind == kind }.map(\.detail)
+    }
+
+    // MARK: An empty but planned testable
+
+    func testTestableWithNoTestRowsIsAFault() {
+        // The #478 shape: the target is in the bundle — it was planned, it was
+        // meant to run — and produced nothing.
+        let summary = validatedSummary([run(testables: [
+            ParsedTestable(targetName: "SampleAppUITests", groups: [
+                group("FirstSuite", [testCase("testOne()")]),
+            ]),
+            ParsedTestable(targetName: "SampleAppUnitTests", groups: []),
+        ])])
+
+        XCTAssertEqual(
+            details(summary, .emptyPlannedTestable), ["SampleAppUnitTests"],
+            "A testable present in the bundle with no test rows must be reported"
+        )
+    }
+
+    func testTestableWhoseGroupsAreAllEmptyIsAFault() {
+        // The other way the same loss arrives: the group survived, its rows
+        // did not. The beta's `--json` showed exactly this — `"children": []`.
+        let summary = validatedSummary([run(testables: [
+            ParsedTestable(targetName: "SampleAppUnitTests", groups: [
+                group("SwiftTestingSuite", []),
+            ]),
+        ])])
+
+        XCTAssertEqual(details(summary, .emptyPlannedTestable), ["SampleAppUnitTests"])
+    }
+
+    func testDeeplyNestedTestRowsAreNotAFault() {
+        // The counter has to see through nesting, or every suite-inside-a-suite
+        // target would be reported as empty.
+        let summary = validatedSummary([run(testables: [
+            ParsedTestable(targetName: "SampleAppUnitTests", groups: [
+                group("All tests", [.group(group("Outer", [
+                    .group(group("Inner", [testCase("testDeep()")])),
+                ]))]),
+            ]),
+        ])])
+
+        XCTAssertEqual(details(summary, .emptyPlannedTestable), [])
+    }
+
+    func testRunWithNoTestablesAtAllIsNotAFault() {
+        // The cardinal rule. A bundle that legitimately contains no testable
+        // — `-only-testing` prunes unselected targets from the document on both
+        // backends, which is why SanityResults and RetryResults carry one
+        // testable and not three — is structural absence, not degradation.
+        // Only a target that IS there and produced nothing is a loss (#387).
+        let summary = validatedSummary([run(testables: [])])
+
+        XCTAssertEqual(details(summary, .emptyPlannedTestable), [])
+    }
+
+    // MARK: A host-app / system-failure crash row
+
+    func testModernShapeOfACrashedRunFaults() {
+        // The shape the modern reader produced for the reproduced crash: the
+        // bucket carries the row, so the testable is not empty and only the
+        // system-failure signal fires.
+        let summary = validatedSummary([run(testables: [
+            ParsedTestable(targetName: "SampleAppUnitTests", groups: [
+                group("System Failures", [
+                    testCase("SampleApp (43043) encountered an error"),
+                ]),
+            ]),
+        ])])
+
+        XCTAssertEqual(
+            details(summary, .systemFailure),
+            ["SampleAppUnitTests: SampleApp (43043) encountered an error"],
+            "A system-failure row is direct evidence the run did not complete"
+        )
+        XCTAssertEqual(details(summary, .emptyPlannedTestable), [])
+    }
+
+    func testLegacyShapeOfACrashedRunFaults() {
+        // The shape the legacy reader produced for the *same* bundle:
+        // XCResultKit does not decode the crash row (it is an
+        // `ActionTestSummary`, not an `ActionTestMetadata`), so the bucket
+        // arrives empty. Keying the rule on the bucket rather than on its rows
+        // is what makes this fault too — and an empty bucket also means the
+        // testable holds no test rows, so both signals fire, each truthfully.
+        let summary = validatedSummary([run(testables: [
+            ParsedTestable(targetName: "SampleAppUnitTests", groups: [
+                group("System Failures", []),
+            ]),
+        ])])
+
+        XCTAssertEqual(details(summary, .systemFailure), ["SampleAppUnitTests: System Failures"])
+        XCTAssertEqual(details(summary, .emptyPlannedTestable), ["SampleAppUnitTests"])
+    }
+
+    func testNestedSystemFailureGroupIsFound() {
+        // Both backends put the bucket directly under the testable today. The
+        // walk is recursive anyway: the bucket is Apple's, so a deeper one is
+        // still a system failure, and missing a relocated bucket is the worse
+        // failure mode for a fault whose whole job is catching truncation.
+        let summary = validatedSummary([run(testables: [
+            ParsedTestable(targetName: "SampleAppUnitTests", groups: [
+                group("All tests", [
+                    .group(group("System Failures", [testCase("Host (1) encountered an error")])),
+                ]),
+            ]),
+        ])])
+
+        XCTAssertEqual(
+            details(summary, .systemFailure),
+            ["SampleAppUnitTests: Host (1) encountered an error"]
+        )
+    }
+
+    func testOrdinarySuiteNamesAreNotSystemFailures() {
+        let summary = validatedSummary([run(testables: [
+            ParsedTestable(targetName: "SampleAppUnitTests", groups: [
+                group("FirstSuite", [testCase("testOne()")]),
+            ]),
+        ])])
+
+        XCTAssertEqual(details(summary, .systemFailure), [])
+    }
+
+    // MARK: Shared post-conditions
+
+    func testTruncationFaultsAreNotDuplicatedAcrossRepeatedValidation() {
+        // `validate()` is idempotent for every other fault kind it records; a
+        // second call must not double these either.
+        let summary = Summary(
+            parsedRuns: [run(testables: [
+                ParsedTestable(targetName: "SampleAppUnitTests", groups: [
+                    group("System Failures", [testCase("SampleApp (1) encountered an error")]),
+                ]),
+                ParsedTestable(targetName: "SampleAppUITests", groups: []),
+            ])],
+            payloads: SyntheticResult.payloads,
+            renderingMode: .linking,
+            downsizeImagesEnabled: false,
+            downsizeScaleFactor: 0.25,
+            faultCollector: FaultCollector(),
+            bundleNames: ["Synthetic"]
+        )
+
+        summary.validate()
+        let afterFirst = summary.faults
+        XCTAssertEqual(afterFirst.count, 2, "One empty testable and one system failure")
+
+        summary.validate()
+
+        XCTAssertEqual(
+            summary.faults, afterFirst,
+            "validate() must not re-record truncation faults on a second call"
+        )
+    }
+
+    /// Every fixture, through every backend the toolchain can run, must produce
+    /// neither fault. These are healthy bundles; a rule that fires on them is a
+    /// rule that makes exit 3 meaningless.
+    func testHealthyFixturesProduceNoTruncationFaultsOnEitherBackend() throws {
+        var backends: [ResultBackend] = [.modern]
+        if case .use(.legacy) = ResultBackend.legacy.resolve() {
+            backends.append(.legacy)
+        }
+
+        for fixture in ["TestResults", "SanityResults", "RetryResults"] {
+            let url = try XCTUnwrap(
+                Bundle.testBundle.url(forResource: fixture, withExtension: "xcresult")
+            )
+            for backend in backends {
+                let summary = Summary(
+                    resultPaths: [url.path],
+                    renderingMode: .linking,
+                    downsizeImagesEnabled: false,
+                    downsizeScaleFactor: 0.25,
+                    faultCollector: FaultCollector(),
+                    backend: backend
+                )
+                summary.validate()
+
+                XCTAssertEqual(
+                    details(summary, .emptyPlannedTestable), [],
+                    "\(fixture) on \(backend.rawValue): healthy bundle reported an empty testable"
+                )
+                XCTAssertEqual(
+                    details(summary, .systemFailure), [],
+                    "\(fixture) on \(backend.rawValue): healthy bundle reported a system failure"
+                )
+            }
+        }
+    }
+}

--- a/Tests/XCTestHTMLReportTests/TruncationFaultTests.swift
+++ b/Tests/XCTestHTMLReportTests/TruncationFaultTests.swift
@@ -1,7 +1,7 @@
 //
 //  TruncationFaultTests.swift
 //
-//  The two faults that catch a run which stopped early (#478).
+//  The fault that catches a run which stopped early (#478).
 //
 //  On the Xcode 27 beta the sample app trapped at launch, `SampleAppUnitTests`
 //  never ran, and `xchtmlreport` rendered 10 of 21 tests, printed "Report
@@ -9,17 +9,22 @@
 //  silently dropping 57% of the suite is precisely what the fault machinery
 //  exists to prevent.
 //
-//  Both signals are read off `ParsedResult`, the model *both* readers produce,
-//  so there is one implementation and it cannot drift between backends — the
-//  same seam `unresolvedLog` uses. The shapes were not guessed: the crash was
-//  reproduced on Xcode 26.2 stable by trapping in the host app's
-//  `didFinishLaunchingWithOptions`, and both backends were dumped. They agree
-//  exactly, which is what makes a name-keyed rule defensible here:
+//  The signal is read off `ParsedResult`, the model *both* readers produce, so
+//  there is one implementation — the same seam `unresolvedLog` uses. One
+//  implementation is not the same as one behaviour, which is why the second
+//  half of this file exists: `testSelectedTargetWithNoTestRowsIsNotAFault`
+//  guards the shape a withdrawn second fault kind got wrong. The name this rule
+//  keys on is re-measured against the live toolchain by
+//  `SystemFailureCanaryTests`; these tests pin the logic over synthetic input.
+//
+//  The crash shapes below were not guessed. `prepareTestResults.sh` reproduces
+//  the crash by trapping in the host app's `didFinishLaunchingWithOptions`, and
+//  both backends read the resulting bundle as:
 //
 //    legacy  ActionTestSummaryGroup name='System Failures'
-//              └ ActionTestSummary  name='SampleApp (43043) encountered an error'
+//              └ (empty — the crash row is an ActionTestSummary, not decoded)
 //    modern  Test Suite            name='System Failures'
-//              └ Test Case         name='SampleApp (43043) encountered an error'
+//              └ Test Case         name='SampleApp (1669) encountered an error'
 //
 
 import XCTest
@@ -78,67 +83,11 @@ final class TruncationFaultTests: XCTestCase {
         summary.faults.filter { $0.kind == kind }.map(\.detail)
     }
 
-    // MARK: An empty but planned testable
-
-    func testTestableWithNoTestRowsIsAFault() {
-        // The #478 shape: the target is in the bundle — it was planned, it was
-        // meant to run — and produced nothing.
-        let summary = validatedSummary([run(testables: [
-            ParsedTestable(targetName: "SampleAppUITests", groups: [
-                group("FirstSuite", [testCase("testOne()")]),
-            ]),
-            ParsedTestable(targetName: "SampleAppUnitTests", groups: []),
-        ])])
-
-        XCTAssertEqual(
-            details(summary, .emptyPlannedTestable), ["SampleAppUnitTests"],
-            "A testable present in the bundle with no test rows must be reported"
-        )
-    }
-
-    func testTestableWhoseGroupsAreAllEmptyIsAFault() {
-        // The other way the same loss arrives: the group survived, its rows
-        // did not. The beta's `--json` showed exactly this — `"children": []`.
-        let summary = validatedSummary([run(testables: [
-            ParsedTestable(targetName: "SampleAppUnitTests", groups: [
-                group("SwiftTestingSuite", []),
-            ]),
-        ])])
-
-        XCTAssertEqual(details(summary, .emptyPlannedTestable), ["SampleAppUnitTests"])
-    }
-
-    func testDeeplyNestedTestRowsAreNotAFault() {
-        // The counter has to see through nesting, or every suite-inside-a-suite
-        // target would be reported as empty.
-        let summary = validatedSummary([run(testables: [
-            ParsedTestable(targetName: "SampleAppUnitTests", groups: [
-                group("All tests", [.group(group("Outer", [
-                    .group(group("Inner", [testCase("testDeep()")])),
-                ]))]),
-            ]),
-        ])])
-
-        XCTAssertEqual(details(summary, .emptyPlannedTestable), [])
-    }
-
-    func testRunWithNoTestablesAtAllIsNotAFault() {
-        // The cardinal rule. A bundle that legitimately contains no testable
-        // — `-only-testing` prunes unselected targets from the document on both
-        // backends, which is why SanityResults and RetryResults carry one
-        // testable and not three — is structural absence, not degradation.
-        // Only a target that IS there and produced nothing is a loss (#387).
-        let summary = validatedSummary([run(testables: [])])
-
-        XCTAssertEqual(details(summary, .emptyPlannedTestable), [])
-    }
-
     // MARK: A host-app / system-failure crash row
 
     func testModernShapeOfACrashedRunFaults() {
         // The shape the modern reader produced for the reproduced crash: the
-        // bucket carries the row, so the testable is not empty and only the
-        // system-failure signal fires.
+        // bucket carries the row, and the row names the fault.
         let summary = validatedSummary([run(testables: [
             ParsedTestable(targetName: "SampleAppUnitTests", groups: [
                 group("System Failures", [
@@ -152,7 +101,6 @@ final class TruncationFaultTests: XCTestCase {
             ["SampleAppUnitTests: SampleApp (43043) encountered an error"],
             "A system-failure row is direct evidence the run did not complete"
         )
-        XCTAssertEqual(details(summary, .emptyPlannedTestable), [])
     }
 
     func testLegacyShapeOfACrashedRunFaults() {
@@ -160,8 +108,9 @@ final class TruncationFaultTests: XCTestCase {
         // XCResultKit does not decode the crash row (it is an
         // `ActionTestSummary`, not an `ActionTestMetadata`), so the bucket
         // arrives empty. Keying the rule on the bucket rather than on its rows
-        // is what makes this fault too — and an empty bucket also means the
-        // testable holds no test rows, so both signals fire, each truthfully.
+        // is the whole reason this bundle faults on both readers — and it is
+        // what the two backends' fault details differing does *not* mean:
+        // each names the most specific thing its own document holds.
         let summary = validatedSummary([run(testables: [
             ParsedTestable(targetName: "SampleAppUnitTests", groups: [
                 group("System Failures", []),
@@ -169,7 +118,6 @@ final class TruncationFaultTests: XCTestCase {
         ])])
 
         XCTAssertEqual(details(summary, .systemFailure), ["SampleAppUnitTests: System Failures"])
-        XCTAssertEqual(details(summary, .emptyPlannedTestable), ["SampleAppUnitTests"])
     }
 
     func testNestedSystemFailureGroupIsFound() {
@@ -201,17 +149,60 @@ final class TruncationFaultTests: XCTestCase {
         XCTAssertEqual(details(summary, .systemFailure), [])
     }
 
+    // MARK: What a missing target is not
+
+    func testSelectedTargetWithNoTestRowsIsNotAFault() {
+        // The counterexample that withdrew a second fault kind. An earlier
+        // revision flagged any testable holding zero test rows as
+        // `emptyPlannedTestable`. This is that shape — and it is what an
+        // ordinary `-skip-testing:Target/SuiteA -skip-testing:Target/SuiteB`
+        // leaves behind on the legacy reader, which keeps a zero-row
+        // `Selected tests` group where the modern node tree prunes the bundle
+        // node entirely. Quarantining a flaky suite and sharding a target
+        // across CI jobs both produce it, on the default reader, on a run where
+        // every test that was planned to run ran. Faulting it made exit 3 mean
+        // less, not more.
+        //
+        // Whole-target loss is caught before the tool sees a bundle, by the
+        // per-bundle floors in `scripts/verify_fixtures.sh`; a target lost to a
+        // launch trap is caught here, by the system-failure bucket that comes
+        // with it.
+        let summary = validatedSummary([run(testables: [
+            ParsedTestable(targetName: "SampleAppUITests", groups: [
+                group("Selected tests", [testCase("testOne()")]),
+            ]),
+            ParsedTestable(targetName: "SampleAppUnitTests", groups: [
+                group("Selected tests", []),
+            ]),
+        ])])
+
+        XCTAssertEqual(
+            summary.faults, [],
+            "A selected target with no rows is a skip filter, not degradation"
+        )
+    }
+
+    func testRunWithNoTestablesAtAllIsNotAFault() {
+        // The cardinal rule. A bundle that legitimately contains no testable
+        // — `-only-testing` prunes unselected targets from the document on both
+        // backends, which is why SanityResults and RetryResults carry one
+        // testable and not three — is structural absence, not degradation
+        // (#387).
+        let summary = validatedSummary([run(testables: [])])
+
+        XCTAssertEqual(summary.faults, [])
+    }
+
     // MARK: Shared post-conditions
 
     func testTruncationFaultsAreNotDuplicatedAcrossRepeatedValidation() {
         // `validate()` is idempotent for every other fault kind it records; a
-        // second call must not double these either.
+        // second call must not double this one either.
         let summary = Summary(
             parsedRuns: [run(testables: [
                 ParsedTestable(targetName: "SampleAppUnitTests", groups: [
                     group("System Failures", [testCase("SampleApp (1) encountered an error")]),
                 ]),
-                ParsedTestable(targetName: "SampleAppUITests", groups: []),
             ])],
             payloads: SyntheticResult.payloads,
             renderingMode: .linking,
@@ -223,7 +214,7 @@ final class TruncationFaultTests: XCTestCase {
 
         summary.validate()
         let afterFirst = summary.faults
-        XCTAssertEqual(afterFirst.count, 2, "One empty testable and one system failure")
+        XCTAssertEqual(afterFirst.count, 1, "One system failure")
 
         summary.validate()
 
@@ -233,9 +224,9 @@ final class TruncationFaultTests: XCTestCase {
         )
     }
 
-    /// Every fixture, through every backend the toolchain can run, must produce
-    /// neither fault. These are healthy bundles; a rule that fires on them is a
-    /// rule that makes exit 3 meaningless.
+    /// Every healthy fixture, through every backend the toolchain can run, must
+    /// produce no system failure. These are healthy bundles; a rule that fires
+    /// on them is a rule that makes exit 3 meaningless.
     func testHealthyFixturesProduceNoTruncationFaultsOnEitherBackend() throws {
         var backends: [ResultBackend] = [.modern]
         if case .use(.legacy) = ResultBackend.legacy.resolve() {
@@ -257,10 +248,6 @@ final class TruncationFaultTests: XCTestCase {
                 )
                 summary.validate()
 
-                XCTAssertEqual(
-                    details(summary, .emptyPlannedTestable), [],
-                    "\(fixture) on \(backend.rawValue): healthy bundle reported an empty testable"
-                )
                 XCTAssertEqual(
                     details(summary, .systemFailure), [],
                     "\(fixture) on \(backend.rawValue): healthy bundle reported a system failure"

--- a/XCTestHTMLReportSampleApp/SampleApp.xcodeproj/project.pbxproj
+++ b/XCTestHTMLReportSampleApp/SampleApp.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		F39729081F2471A7006B1EF3 /* SecondSuite.swift in Sources */ = {isa = PBXBuildFile; fileRef = F39729071F2471A7006B1EF3 /* SecondSuite.swift */; };
 		F3AB012C1F2459FA00334580 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3AB012B1F2459FA00334580 /* AppDelegate.swift */; };
 		F3AB012E1F2459FA00334580 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3AB012D1F2459FA00334580 /* ViewController.swift */; };
+		A1D2E3F40000000000000002 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1D2E3F40000000000000001 /* SceneDelegate.swift */; };
 		F3AB01311F2459FA00334580 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F3AB012F1F2459FA00334580 /* Main.storyboard */; };
 		F3AB01331F2459FA00334580 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F3AB01321F2459FA00334580 /* Assets.xcassets */; };
 		F3AB01361F2459FA00334580 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F3AB01341F2459FA00334580 /* LaunchScreen.storyboard */; };
@@ -47,6 +48,7 @@
 		F3AB01281F2459FA00334580 /* SampleApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SampleApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		F3AB012B1F2459FA00334580 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		F3AB012D1F2459FA00334580 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		A1D2E3F40000000000000001 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		F3AB01301F2459FA00334580 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		F3AB01321F2459FA00334580 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		F3AB01351F2459FA00334580 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -109,6 +111,7 @@
 			isa = PBXGroup;
 			children = (
 				F3AB012B1F2459FA00334580 /* AppDelegate.swift */,
+				A1D2E3F40000000000000001 /* SceneDelegate.swift */,
 				F3AB012D1F2459FA00334580 /* ViewController.swift */,
 				F3AB012F1F2459FA00334580 /* Main.storyboard */,
 				F3AB01321F2459FA00334580 /* Assets.xcassets */,
@@ -280,6 +283,7 @@
 			files = (
 				F3AB012E1F2459FA00334580 /* ViewController.swift in Sources */,
 				F3AB012C1F2459FA00334580 /* AppDelegate.swift in Sources */,
+				A1D2E3F40000000000000002 /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/XCTestHTMLReportSampleApp/SampleApp/AppDelegate.swift
+++ b/XCTestHTMLReportSampleApp/SampleApp/AppDelegate.swift
@@ -10,12 +10,31 @@ import UIKit
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
+    /// The environment variable `prepareTestResults.sh` sets — and nothing else
+    /// does — when it generates `CrashResults.xcresult`.
+    ///
+    /// That bundle exists to feed a canary, and a canary for a host-app launch
+    /// failure needs a host app that really fails to launch. The
+    /// alternative was a scratch copy of the project patched at generation
+    /// time, which is a second sample app to keep in step with this one. A trap
+    /// nothing sets during a normal run is cheaper and reads as what it is.
+    static let trapAtLaunchVariable = "XCHR_TRAP_AT_LAUNCH"
+
     func application(
         _: UIApplication,
         didFinishLaunchingWithOptions _: [UIApplication.LaunchOptionsKey: Any]?
     ) -> Bool {
+        // Deliberate: this is what a host-app launch failure looks like from
+        // the inside, and `SystemFailureCanaryTests` needs a bundle carrying
+        // one to check that Apple still calls the bucket `System Failures`
+        // (#478). Absent the variable — every other invocation in
+        // prepareTestResults.sh, and every run from Xcode — this is a no-op.
+        if ProcessInfo.processInfo.environment[Self.trapAtLaunchVariable] != nil {
+            fatalError("\(Self.trapAtLaunchVariable) is set: trapping at launch on purpose")
+        }
+
         // Override point for customization after application launch.
-        true
+        return true
     }
 
     // The five app-level lifecycle stubs that used to sit here
@@ -24,10 +43,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     // keeping them would leave five methods nothing ever calls. They were empty
     // Xcode-template comments, so nothing this app does changed.
 
-    /// The scene manifest already declares this configuration; naming it here
-    /// is what ties `UISceneConfigurationName` in Info.plist to the code, so a
-    /// rename on one side stops compiling rather than silently falling back to
-    /// a default scene. See `SceneDelegate` for why adoption is required at all.
+    /// Hands UIKit the configuration the scene manifest declares.
+    ///
+    /// The name is matched against `UISceneConfigurationName` in Info.plist at
+    /// run time, and nothing checks it at compile time. Rename it on one side
+    /// only and this still builds: UIKit vends an unmatched configuration, with
+    /// no delegate class and no storyboard behind it, and the app comes up as a
+    /// blank window. Keep the two spellings in step by hand — the compiler will
+    /// not. See `SceneDelegate` for why adoption is required at all.
     func application(
         _: UIApplication,
         configurationForConnecting connectingSceneSession: UISceneSession,

--- a/XCTestHTMLReportSampleApp/SampleApp/AppDelegate.swift
+++ b/XCTestHTMLReportSampleApp/SampleApp/AppDelegate.swift
@@ -10,8 +10,6 @@ import UIKit
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
-    var window: UIWindow?
-
     func application(
         _: UIApplication,
         didFinishLaunchingWithOptions _: [UIApplication.LaunchOptionsKey: Any]?
@@ -20,36 +18,24 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         true
     }
 
-    func applicationWillResignActive(_: UIApplication) {
-        // Sent when the application is about to move from active to inactive state. This can occur
-        // for certain types of temporary interruptions (such as an incoming phone call or SMS
-        // message) or when the user quits the application and it begins the transition to the
-        // background state.
-        // Use this method to pause ongoing tasks, disable timers, and invalidate graphics rendering
-        // callbacks. Games should use this method to pause the game.
-    }
+    // The five app-level lifecycle stubs that used to sit here
+    // (applicationWillResignActive and friends) went with the scene adoption in
+    // #478: UIKit delivers those transitions to the scene delegate now, so
+    // keeping them would leave five methods nothing ever calls. They were empty
+    // Xcode-template comments, so nothing this app does changed.
 
-    func applicationDidEnterBackground(_: UIApplication) {
-        // Use this method to release shared resources, save user data, invalidate timers, and store
-        // enough application state information to restore your application to its current state in
-        // case it is terminated later.
-        // If your application supports background execution, this method is called instead of
-        // applicationWillTerminate: when the user quits.
-    }
-
-    func applicationWillEnterForeground(_: UIApplication) {
-        // Called as part of the transition from the background to the active state; here you can
-        // undo many of the changes made on entering the background.
-    }
-
-    func applicationDidBecomeActive(_: UIApplication) {
-        // Restart any tasks that were paused (or not yet started) while the application was
-        // inactive. If the application was previously in the background, optionally refresh the
-        // user interface.
-    }
-
-    func applicationWillTerminate(_: UIApplication) {
-        // Called when the application is about to terminate. Save data if appropriate. See also
-        // applicationDidEnterBackground:.
+    /// The scene manifest already declares this configuration; naming it here
+    /// is what ties `UISceneConfigurationName` in Info.plist to the code, so a
+    /// rename on one side stops compiling rather than silently falling back to
+    /// a default scene. See `SceneDelegate` for why adoption is required at all.
+    func application(
+        _: UIApplication,
+        configurationForConnecting connectingSceneSession: UISceneSession,
+        options _: UIScene.ConnectionOptions
+    ) -> UISceneConfiguration {
+        UISceneConfiguration(
+            name: "Default Configuration",
+            sessionRole: connectingSceneSession.role
+        )
     }
 }

--- a/XCTestHTMLReportSampleApp/SampleApp/Info.plist
+++ b/XCTestHTMLReportSampleApp/SampleApp/Info.plist
@@ -20,10 +20,27 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
-	<key>UIMainStoryboardFile</key>
-	<string>Main</string>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>armv7</string>

--- a/XCTestHTMLReportSampleApp/SampleApp/SceneDelegate.swift
+++ b/XCTestHTMLReportSampleApp/SampleApp/SceneDelegate.swift
@@ -1,0 +1,35 @@
+//
+//  SceneDelegate.swift
+//  SampleApp
+//
+//  UIScene adoption, so the host app still launches on the iOS 27 SDK.
+//
+//  Until #478 this app was pre-scene UIKit: `UIMainStoryboardFile` plus an
+//  `AppDelegate`, with no scene manifest anywhere. On Xcode 26 that is a
+//  console warning ("`UIScene` lifecycle will soon be required. Failure to
+//  adopt will result in an assert in the future."); on the Xcode 27 SDK the
+//  warning becomes the assert, and the app traps at launch:
+//
+//      Application failed to launch: UIScene life cycle is required for apps
+//      built with this SDK.
+//
+//  The unit tests are hosted in this app, so the trap took `SampleAppUnitTests`
+//  with it — 7 XCTest methods and all 5 `@Test` functions, 12 of the fixture's
+//  21 rows, gone before a single assertion ran. The UI tests survived only
+//  because #423 stopped them launching the host.
+//
+//  This delegate is deliberately empty. `UISceneStoryboardFile` in the manifest
+//  names `Main`, so UIKit instantiates the storyboard's initial view controller
+//  and assigns the window itself, exactly as `UIMainStoryboardFile` used to —
+//  the `window` property is all it needs from us. Adopting scenes changes which
+//  object receives the lifecycle callbacks, not what the app does.
+//
+
+import UIKit
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+    /// Populated by UIKit from the scene manifest's `UISceneStoryboardFile`.
+    /// `UIWindowSceneDelegate` looks this property up by name; without it the
+    /// storyboard is loaded into a window nothing retains.
+    var window: UIWindow?
+}

--- a/docs/release-notes/4.0.0.md
+++ b/docs/release-notes/4.0.0.md
@@ -209,6 +209,17 @@ Independent of the migration, and applying to both readers:
   `payloadExportFailed` fault existed but the legacy payload path could not
   reach its own call site, so a failed export degraded the report without
   saying so (#388).
+- **A run that stopped early is now a fault, not a clean exit.** Two new
+  kinds, both read off the model shared by the two readers so they behave
+  identically on either. `emptyPlannedTestable` fires when a test target is
+  present in the bundle with no test rows beneath it — it was planned, it ran
+  nothing. `systemFailure` fires on the `System Failures` group both formats
+  file host-app and system failures under. Between them they catch the report
+  that claims completeness while missing whole targets: an `.xcresult` whose
+  host app failed to launch used to render, print "Report successfully
+  created", and exit 0 with 57% of the suite silently absent. A bundle that
+  simply carries no testable for a target — what `-only-testing` produces — is
+  structural absence and is still never a fault (#478).
 - **Attachment filenames are escaped in the report's markup.** An attachment
   whose name contained HTML or quote characters was interpolated into the page
   and into inline JavaScript unescaped (#463).

--- a/docs/release-notes/4.0.0.md
+++ b/docs/release-notes/4.0.0.md
@@ -209,17 +209,18 @@ Independent of the migration, and applying to both readers:
   `payloadExportFailed` fault existed but the legacy payload path could not
   reach its own call site, so a failed export degraded the report without
   saying so (#388).
-- **A run that stopped early is now a fault, not a clean exit.** Two new
-  kinds, both read off the model shared by the two readers so they behave
-  identically on either. `emptyPlannedTestable` fires when a test target is
-  present in the bundle with no test rows beneath it — it was planned, it ran
-  nothing. `systemFailure` fires on the `System Failures` group both formats
-  file host-app and system failures under. Between them they catch the report
-  that claims completeness while missing whole targets: an `.xcresult` whose
-  host app failed to launch used to render, print "Report successfully
-  created", and exit 0 with 57% of the suite silently absent. A bundle that
-  simply carries no testable for a target — what `-only-testing` produces — is
-  structural absence and is still never a fault (#478).
+- **A run that stopped early is now a fault, not a clean exit.** A new
+  `systemFailure` kind fires on the `System Failures` group that both formats
+  file host-app and system failures under. It catches the report that claims
+  completeness while missing whole targets: an `.xcresult` whose host app
+  failed to launch used to render, print "Report successfully created", and
+  exit 0 with 57% of the suite silently absent. The rule is implemented once,
+  over the model both readers produce, rather than once per reader; the two
+  still word the fault differently, because each names the most specific node
+  its own document holds. A bundle that simply carries no testable for a target
+  — what `-only-testing` produces — is structural absence and is still never a
+  fault, and neither is a target left holding no rows by a suite-granular
+  `-skip-testing` (#478).
 - **Attachment filenames are escaped in the report's markup.** An attachment
   whose name contained HTML or quote characters was interpolated into the page
   and into inline JavaScript unescaped (#463).

--- a/prepareTestResults.sh
+++ b/prepareTestResults.sh
@@ -96,4 +96,42 @@ if [[ $XCODE_VERSION != 12.* && $XCODE_VERSION != 11.* ]]; then
     mv "$RETRY_FILENAME" "../Tests/XCTestHTMLReportTests/Resources/"
 fi
 
+# The one fixture that is deliberately a broken run.
+#
+# `systemFailure` (#478) keys on a group Apple names `System Failures`, and a
+# display name is a handle that can be renamed out from under us — nothing
+# structural tells that bucket apart from a user's own suite on either reader.
+# So the name is re-measured instead of assumed: SystemFailureCanaryTests reads
+# this bundle and asserts both readers still find the bucket in it, which turns
+# a rename in some future Xcode into a red suite on the toolchain that
+# introduces it rather than a fault that quietly stops firing.
+#
+# XCHR_TRAP_AT_LAUNCH makes the sample app's AppDelegate trap in
+# didFinishLaunchingWithOptions. SampleAppUnitTests is hosted in that app, so
+# the whole target dies with it — which is exactly what happened on the Xcode 27
+# beta, reproduced rather than simulated. `TEST_RUNNER_` is xcodebuild's own
+# channel for reaching the launched process: it strips the prefix and passes the
+# rest through, and for a hosted unit test that process is the host app. No
+# scheme edit and no second copy of the project to keep in step.
+#
+# Unit tests only. The UI tests launch the app themselves through
+# XCUIApplication, which does not inherit this environment, so including them
+# would add a minute of healthy rows the canary does not read.
+CRASH_FILENAME='CrashResults.xcresult'
+rm -rf "$CRASH_FILENAME"
+TEST_RUNNER_XCHR_TRAP_AT_LAUNCH=1 xcodebuild test-without-building \
+    -project SampleApp.xcodeproj \
+    -scheme MainScheme \
+    -destination "$SIM_DESTINATION" \
+    -derivedDataPath "$DERIVED_DATA" \
+    -only-testing:SampleAppUnitTests \
+    -resultBundlePath "$CRASH_FILENAME" || true
+
+# `|| true` above because this invocation is *meant* to fail — but the move is
+# not guarded, so a run that wrote no bundle at all still stops the script here
+# rather than leaving the canary to fail later with a missing resource.
+echo "${CRASH_FILENAME} should contain a host-app launch failure for the System Failures canary"
+rm -rf "../Tests/XCTestHTMLReportTests/Resources/${CRASH_FILENAME}"
+mv "$CRASH_FILENAME" "../Tests/XCTestHTMLReportTests/Resources/"
+
 echo "$(tput setaf 2)$(basename "$0") successfully finished$(tput sgr 0)"

--- a/scripts/verify_fixtures.sh
+++ b/scripts/verify_fixtures.sh
@@ -20,10 +20,46 @@
 # through (ModernResultReader), so this gate needs no toolchain the tool does
 # not already need.
 #
+# A stub is not the only way generation lies. `totalTestCount > 0` also passed a
+# bundle missing 57% of the suite: on the Xcode 27 beta the sample app trapped
+# at launch, taking the whole `SampleAppUnitTests` target with it, and this gate
+# reported `TestResults.xcresult: 10 tests` and waved 10-of-21 through to
+# `swift test` (#478). A global floor cannot catch that — 10 is a perfectly
+# healthy count for a bundle whose expected shape is 10. So the floor is
+# per bundle, below.
+#
 # Takes bundle paths as arguments, defaulting to the three CI fixtures. Every
 # bundle is checked before exiting, so one run names every offender rather than
 # stopping at the first.
 set -euo pipefail
+
+# Minimum test rows each known fixture must contain, keyed by bundle file name.
+#
+# These are floors, not equalities. The counts are fixed by the sample sources
+# and by the `-only-testing` / `-skip-testing` filters in prepareTestResults.sh,
+# so they only move when someone edits those — at which point this table is
+# meant to be edited too, deliberately, in the same commit. A floor rather than
+# `-eq` because adding a test to the sample app must not fail the gate on every
+# branch until the table catches up; losing one still must.
+#
+#   TestResults   21 = 9 SampleAppUITests (First/Second/Third, RetryTests
+#                      skipped) + 7 SampleAppUnitTests XCTest methods
+#                      + 5 SwiftTestingSuite `@Test` functions.
+#                      CoreTests.testResultStatusCount asserts the same 21.
+#   SanityResults  1 = -only-testing:SampleAppUITests/FirstSuite/testOne
+#   RetryResults   4 = -only-testing:SampleAppUITests/RetryTests, whose four
+#                      methods merge their repetitions into four rows
+#
+# A bundle not named here — anything passed as an argument by a human — keeps
+# the original `> 0` assertion, since this script cannot know its shape.
+expected_minimum() {
+    case "$1" in
+    TestResults.xcresult) echo 21 ;;
+    SanityResults.xcresult) echo 1 ;;
+    RetryResults.xcresult) echo 4 ;;
+    *) echo 1 ;;
+    esac
+}
 
 if [ "$#" -gt 0 ]; then
     bundles=("$@")
@@ -72,13 +108,25 @@ for bundle in "${bundles[@]}"; do
         ;;
     esac
 
+    minimum="$(expected_minimum "$name")"
+
     if [ "$total" -eq 0 ]; then
         fail "stub fixture: ${name} contains no tests (totalTestCount=0) — generation did not complete, so this bundle must not be trusted or cached"
         status=1
         continue
     fi
 
-    echo "${name}: ${total} tests"
+    # Distinct message from the stub case above on purpose: a partial bundle
+    # looks healthy from the outside, so the rejection has to say what was
+    # expected and what arrived, and name the bundle, or the next reader is left
+    # guessing which of the three is short.
+    if [ "$total" -lt "$minimum" ]; then
+        fail "partial fixture: ${name} contains ${total} tests, expected at least ${minimum} — part of the suite never ran (a host-app launch failure takes its whole target with it), so this bundle must not be trusted or cached"
+        status=1
+        continue
+    fi
+
+    echo "${name}: ${total} tests (expected at least ${minimum})"
 done
 
 exit "$status"

--- a/scripts/verify_fixtures.sh
+++ b/scripts/verify_fixtures.sh
@@ -28,7 +28,7 @@
 # healthy count for a bundle whose expected shape is 10. So the floor is
 # per bundle, below.
 #
-# Takes bundle paths as arguments, defaulting to the three CI fixtures. Every
+# Takes bundle paths as arguments, defaulting to the four CI fixtures. Every
 # bundle is checked before exiting, so one run names every offender rather than
 # stopping at the first.
 set -euo pipefail
@@ -49,14 +49,26 @@ set -euo pipefail
 #   SanityResults  1 = -only-testing:SampleAppUITests/FirstSuite/testOne
 #   RetryResults   4 = -only-testing:SampleAppUITests/RetryTests, whose four
 #                      methods merge their repetitions into four rows
+#   CrashResults   1 = the `System Failures` row from a host app that trapped
+#                      at launch. Deliberately weak: this bundle is a broken
+#                      run on purpose, so the floor only asserts that
+#                      generation wrote something rather than a stub, and
+#                      SystemFailureCanaryTests asserts the shape — a trap that
+#                      stopped firing yields a healthy 12-row bundle, which no
+#                      floor can reject.
 #
-# A bundle not named here — anything passed as an argument by a human — keeps
-# the original `> 0` assertion, since this script cannot know its shape.
+# Matched on the file's base name, so this table also claims any bundle a human
+# passes as an argument that happens to share one of these names: a personal
+# TestResults.xcresult is held to 21. The alternative — matching the fixture
+# directory too — would stop `verify_fixtures.sh path/to/copy/TestResults.xcresult`
+# from checking the thing the caller almost certainly meant. Anything named
+# something else keeps a plain `> 0`, since this script cannot know its shape.
 expected_minimum() {
     case "$1" in
     TestResults.xcresult) echo 21 ;;
     SanityResults.xcresult) echo 1 ;;
     RetryResults.xcresult) echo 4 ;;
+    CrashResults.xcresult) echo 1 ;;
     *) echo 1 ;;
     esac
 }
@@ -69,6 +81,7 @@ else
         "${resources}/TestResults.xcresult"
         "${resources}/SanityResults.xcresult"
         "${resources}/RetryResults.xcresult"
+        "${resources}/CrashResults.xcresult"
     )
 fi
 


### PR DESCRIPTION
The [triage on #478](https://github.com/XCTestHTMLReport/XCTestHTMLReport/issues/478) falsified the working hypothesis. The Swift Testing tests were missing from *both* backends because they were not in the bundle at all: the sample app is pre-scene UIKit, the iOS 27 SDK promotes a missing scene manifest from a runtime warning to a launch trap, and the app died on launch — taking `SampleAppUnitTests` with it, since the unit tests are hosted in it. Twelve of twenty-one rows never existed; every downstream failure was arithmetic on that hole. `XCResultKit` is not implicated.

Four changes, one story: **make beta runs measure reality.** The beta leg has to measure this project rather than a bundle that was never produced, and nothing in the chain should have let a 10-of-21 bundle through in silence.

> **Updated after review.** The review found a blocking counterexample against one of the two fault kinds originally proposed here. `emptyPlannedTestable` is **withdrawn**; `systemFailure` stays and gains a canary. Item 3 below is rewritten, and [Changed after review](#changed-after-review) records what moved and why.

---

### 1. The sample app adopts UIScene

A `SceneDelegate`, a scene manifest naming `Main` through `UISceneStoryboardFile`, and `UIMainStoryboardFile` retired since the manifest supersedes it. The delegate is deliberately empty — UIKit instantiates the storyboard and assigns the window itself, exactly as `UIMainStoryboardFile` did, so this changes which object receives the lifecycle callbacks, not what the app does. The five app-level lifecycle stubs go with it: scenes deliver those transitions to the scene delegate, so keeping them would leave five methods nothing calls, and they were empty Xcode-template comments.

**Behaviour on stable is unchanged, measured rather than asserted.** Fixtures regenerated on Xcode 26.2 and the whole suite run on both legs:

| | before | after |
| --- | --- | --- |
| `TestResults.xcresult` | 21 | 21 |
| `SanityResults.xcresult` | 1 | 1 |
| `RetryResults.xcresult` | 4 | 4 |
| `swift test` (`XCHR_RESULT_READER=auto`) | — | 151 executed, 3 skipped, 0 failures |
| `swift test` (`XCHR_RESULT_READER=modern`) | — | 151 executed, 3 skipped, 0 failures |

`DifferentialTests` is green on both legs. A direct smoke run of `-only-testing:SampleAppUnitTests` before and after tells the story most sharply: the console warning `UIScene lifecycle will soon be required. Failure to adopt will result in an assert in the future.` is gone, and all 12 rows the beta lost (7 XCTest + 5 `@Test`) run.

The app delegate also gains one deliberately inert branch — `XCHR_TRAP_AT_LAUNCH`, which nothing but fixture generation sets. Item 3 explains what it is for.

### 2. `verify_fixtures.sh` catches partials, not just stubs

`totalTestCount > 0` passed a bundle missing 57% of the suite. It could not have done otherwise — ten is a perfectly healthy count for a bundle whose expected count is ten, so no global floor catches this. The floors are now **per bundle**, in a table at the top of the script with the source of each count documented (21 = 9 UI + 7 XCTest + 5 `@Test`; 1 and 4 from the `-only-testing` filters). Floors rather than equalities, so adding a sample test does not redden every branch until the table catches up — losing one still does.

A rejection names the bundle and prints observed-versus-expected, in a message distinct from the stub case, because a partial bundle looks healthy from the outside:

```
::error::partial fixture: TestResults.xcresult contains 1 tests, expected at least 21 — part of
the suite never ran (a host-app launch failure takes its whole target with it), so this bundle
must not be trusted or cached
```

Verified against a real partial bundle (rejected, exit 1) and against the healthy fixtures (accepted). `pages.yml` and `pages-release.yml` inherit this for free — #470 already routed them through the shared script, and the table keys on the bundle's basename, so their explicit paths hit it.

**This is now where whole-target loss is caught.** With `emptyPlannedTestable` withdrawn, these floors are the gate that stops a 10-of-21 bundle, and they catch it one step earlier than the tool would have: before `swift test` runs and before the bundle can be written to the fixture cache.

### 3. `systemFailure`, and a canary for the name it keys on

`xchtmlreport` ran against the truncated beta bundle, printed `Report successfully created`, and exited 0. That is exactly what the fault machinery exists to prevent. One new fault kind closes it:

- **`systemFailure`** — the group both formats file host-app and system failures under.

It is read off `ParsedResult`, the model *both* readers produce, so there is one implementation rather than one per reader — the same seam `unresolvedLog` uses. That alone is not a guarantee the two behave alike, which is the lesson of the withdrawn second kind; what makes this one agree is that the node it keys on was measured on both readers from the same bundle, and is re-measured on every toolchain.

**The shapes were measured, not guessed.** The crash is reproduced by trapping in the host app's `didFinishLaunchingWithOptions`, producing the same `SampleApp (<pid>) encountered an error (Early unexpected exit, operation never finished bootstrapping…)` the beta hit. Both readers were dumped:

```
legacy   ActionTestSummaryGroup  name='System Failures'  id='System Failures'
modern   Test Suite              name='System Failures'  id='System Failures'
```

They stop agreeing one level down — modern carries the crash row, XCResultKit drops it (the node is an `ActionTestSummary`, not one of the `ActionTestMetadata` entries `subtests` decodes). **That asymmetry is why the bucket is the marker and its rows are not**: keying on the row would have fired only on modern. Against that bundle:

| | before | after |
| --- | --- | --- |
| `--result-reader legacy` | exit 0, no faults | **exit 3** — `systemFailure: SampleAppUnitTests: System Failures` |
| `--result-reader modern` | exit 0, no faults | **exit 3** — `systemFailure: SampleAppUnitTests: SampleApp (40280) encountered an error` |

The wording differs and that is not drift: each names the most specific node its own document holds.

**The rule fails open, so it gets a canary.** The bucket is a plain test suite on both surfaces, indistinguishable from a user's own suite by anything but its name, so detection cannot be made structural today. If Apple renames it, `systemFailure` silently stops firing and no healthy fixture notices. A recursive search of `Xcode.app/Contents` finds the literal in **no** binary and **no** `.strings` table — while the crash message `Early unexpected exit` *is* in `XCTHarness`, so the search demonstrably works — meaning the string is composed at run time. That is weak evidence against localization and none at all against a rename.

So `prepareTestResults.sh` now generates a fourth fixture, **`CrashResults.xcresult`**, with the toolchain in front of it: `TEST_RUNNER_XCHR_TRAP_AT_LAUNCH=1` (xcodebuild's own channel to the launched process, which for a hosted unit test is the host app) makes the sample app trap at launch and take `SampleAppUnitTests` with it. That is the #478 failure reproduced, not simulated. `SystemFailureCanaryTests` then asserts:

- the **modern** reader still finds a group named `System Failures` in it;
- the **legacy** reader does too (skipped, not failed, once a toolchain drops the legacy commands — at that point there is no legacy reader to disarm);
- the tool records exactly one `systemFailure` naming `SampleAppUnitTests` on every backend this toolchain can run.

A failing assertion prints every group name the reader *did* produce, so the failure says what the bucket is called now. Verified by flipping `ParsedGroup.systemFailureName` to a wrong value: three tests, four assertions, red on both readers, with the found name in the message. The canary reaches a new Xcode before a release does, because `toolchain-drift` regenerates fixtures and runs the suite on the beta leg.

**The cardinal rule holds.** A bundle carrying no testable for a target is structural absence — which is precisely what `-only-testing` produces, and what `SanityResults` and `RetryResults` are — and is never a fault. `testHealthyFixturesProduceNoTruncationFaultsOnEitherBackend` asserts every healthy fixture through every runnable backend reports no fault, and `CliTests` would fail if a healthy render started exiting 3.

### 4. The drift workflow uploads its bundles on failure

This triage was done from job logs, because `toolchain-drift.yml` uploaded nothing and `gh run download` on the run reported *no valid artifacts found*. Bundles now upload on any failing signal, named per leg per the #470 convention (`xcresult-fixtures-<channel>` — v4+ rejects duplicate names, so a run where both legs fail keeps both), at **5 days** retention since they are ~50 MB each and this workflow runs twice a week.

Placed before the report step, because that step exits 1 on the stable leg; gated on the explicit outcome list rather than `failure()`, because every signal above it is `continue-on-error` and so a bare `failure()` would never fire. `if-no-files-found: ignore`, since generation failing outright can leave no bundle at all and this must not add a red step of its own. The filed issue now points at the artifact by name — that pointer matters as much as the upload, since nobody knew there was nothing to download.

---

<a id="changed-after-review"></a>

## Changed after review

### `emptyPlannedTestable` is withdrawn

The review produced a counterexample I reproduced here at `a59640e` before changing anything. On the unmodified sample app, with stock flags:

```bash
xcodebuild test-without-building -project SampleApp.xcodeproj -scheme MainScheme \
  -destination "id=$UDID" -derivedDataPath .derivedData \
  -skip-testing:SampleAppUITests/RetryTests \
  -skip-testing:SampleAppUnitTests/SampleAppUnitTests \
  -skip-testing:SampleAppUnitTests/SwiftTestingSuite \
  -resultBundlePath SkipAllUnit.xcresult
```

Every test that was planned to run, ran. Measured at `a59640e`:

| | exit | fault |
| --- | --- | --- |
| `--result-reader legacy` (and `auto`, the default) | **3** | `emptyPlannedTestable: SampleAppUnitTests` |
| `--result-reader modern` | 0 | none |

Legacy keeps a zero-row `Selected tests` group for the still-selected unit target; the modern node tree drops the bundle node outright. One implementation, two inputs, two answers — so the kind was **observable on one backend only**, the one-backend-field shape the model doctrine exists to catch, and the divergence it produced was a false positive on the default reader.

It is not a contrived configuration: quarantining a flaky suite and sharding a target across CI jobs both produce it, and `--lenient` disables *all* fault detection, so a user had no way to suppress just this one.

Its residual value was near zero. The #478 partial bundle is caught by the per-bundle floors in item 2 — earlier in the chain, before the cache — and the launch-trap case by `systemFailure`, which the review confirmed fires on **both** readers. So the kind, its `validate()` arm, the now-unused `ParsedTestable.allTestCases`, its tests and its release-note line are all gone. `testSelectedTargetWithNoTestRowsIsNotAFault` pins the counterexample so the rule cannot return by accident.

**After this change, the same bundle exits 0 on both readers.**

### The other findings

| finding | change |
| --- | --- |
| "both read off the shared model so they **behave identically** on either" overstates it | The release note now says the rule is implemented once, and that the two readers still word the fault differently because each names the most specific node its own document holds. The same overstatement is corrected in `Summary.swift` and `ParsedResult.swift`. |
| `systemFailure` is name-keyed and fails open, undocumented | Documented as an accepted risk at the constant, with both consequences (a rename disarms it; a user suite literally named `System Failures` faults) — and given the canary in item 3, which is the part that makes the risk survivable. |
| `AppDelegate`'s scene-configuration comment claimed a rename "stops compiling" | The opposite of what happens. The name is matched against Info.plist at run time; a rename still builds, UIKit vends an unmatched configuration with no delegate class and no storyboard, and the app comes up as a blank window. Comment corrected; the code was already right. |
| the drift upload comment presents its condition as the same signal set `Report drift` uses | It is the `failure` subset of the same six steps. Now says so, and why the wider set (`skipped`, unevaluated) is deliberately excluded: those mean the step never ran, so there is no bundle to attach. |
| the floor table keys on basename alone | The comment now admits it, and says why the alternative is worse: matching the directory too would stop the script from checking a bundle a human passes by path. |

Kept as-is, all confirmed clean by the review: UIScene adoption, the count floors, `systemFailure`, the artifact upload.

---

### Deliberately not in this PR

- **The `.auto` preference is untouched.** Ruled: legacy was not at fault, and flipping it would have produced the identical 10-row report.
- **The modern `file:line`-on-27 question is not investigated.** On Xcode 27 every failure row in a modern-backend report loses its source location, and whether XCTest stopped *recording* the prefix or `xcresulttool` stopped *emitting* it cannot be told apart from CI logs — the `failureTitlePrefix` allow-list rule strips it from both renders, so the differential is blind to it by construction. **It needs a live Xcode 27 bundle, which item 4 above is what makes obtainable**: the next scheduled beta run will now attach one. That is the direct linkage between this PR and the follow-up.

### Gates

Re-verified on Xcode 26.2 / iPhone 17 Pro Max (iOS 26.2), fixtures regenerated from scratch by the updated script:

- 3 healthy fixtures × 3 readers (`auto`/`legacy`/`modern`) × 2 rendering modes (`linking`/`inline`) → exit 0, zero faults, **18/18**.
- `CrashResults.xcresult` → **exit 3 on both readers**.
- The `-skip-testing` counterexample → **exit 0 on both readers**, where legacy gave exit 3 before.
- `swift test` on `auto` and on `modern`: **151 executed, 3 skipped, 0 failures** on each.
- `verify_fixtures.sh` green on all four bundles.
- `shellcheck`, `actionlint`, `zizmor --min-severity low` (no findings), `swiftformat --lint` (0/88 require formatting), `swiftlint` (0 serious, no new warnings).

refs #478

🤖 Generated with [Claude Code](https://claude.com/claude-code)
