### PR TITLE
Make the Xcode-viewer comparison a tool instead of a transcript (refs #439)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,7 @@ visual/fixtures
 # Byte-compiled by Python whenever a module under scripts/ is imported.
 __pycache__/
 
-# Capture runs from scripts/viewer-compare. Each run is a few hundred MB of
-# PNGs and a copy of the fixture; they are local evidence, not repository
+# Capture runs from scripts/viewer-compare. Each run is about 64 MB, nearly all
+# of it the copy of the fixture bundle; they are local evidence, not repository
 # content (see scripts/viewer-compare/README.md).
 /.viewer-compare

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,8 @@ visual/fixtures
 
 # Byte-compiled by Python whenever a module under scripts/ is imported.
 __pycache__/
+
+# Capture runs from scripts/viewer-compare. Each run is a few hundred MB of
+# PNGs and a copy of the fixture; they are local evidence, not repository
+# content (see scripts/viewer-compare/README.md).
+/.viewer-compare

--- a/scripts/test_viewer_compare_manifest.py
+++ b/scripts/test_viewer_compare_manifest.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Tests for scripts/viewer-compare/make_manifest.py.
+
+The manifest is the only part of a viewer-compare run that survives contact
+with time: the PNGs show what the two viewers looked like, and the manifest is
+what says which Xcode and which commit that was. A run that silently drops the
+shot inventory, or that dies because one toolchain probe is missing, is worth
+nothing — and neither failure is visible until someone tries to read the run
+months later.
+
+The tool it covers is macOS-only and drives a GUI, so it cannot be exercised on
+CI. The manifest assembler is the piece that has no such excuse: it is plain
+stdlib Python over a directory of files, and it runs here on any platform.
+
+Driven as a subprocess, like test_assemble_site.py, so the assertions are about
+what an operator actually gets: exit status, stdout, and the file on disk.
+
+Run: python3 -m unittest discover -s scripts -p 'test_*.py'
+"""
+
+import json
+import os
+import struct
+import subprocess
+import sys
+import tempfile
+import unittest
+import zlib
+
+SCRIPT = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "viewer-compare", "make_manifest.py"
+)
+
+
+def write_png(path, width, height):
+    """Writes a real, minimal PNG so the IHDR reader has something to read."""
+
+    def chunk(kind, payload):
+        return (
+            struct.pack(">I", len(payload))
+            + kind
+            + payload
+            + struct.pack(">I", zlib.crc32(kind + payload) & 0xFFFFFFFF)
+        )
+
+    ihdr = struct.pack(">IIBBBBB", width, height, 8, 2, 0, 0, 0)
+    raw = b"".join(b"\x00" + b"\x00\x00\x00" * width for _ in range(height))
+    with open(path, "wb") as handle:
+        handle.write(b"\x89PNG\r\n\x1a\n")
+        handle.write(chunk(b"IHDR", ihdr))
+        handle.write(chunk(b"IDAT", zlib.compress(raw)))
+        handle.write(chunk(b"IEND", b""))
+
+
+class MakeManifestTests(unittest.TestCase):
+    def setUp(self):
+        self.dir = tempfile.mkdtemp()
+        self.addCleanup(lambda: __import__("shutil").rmtree(self.dir, ignore_errors=True))
+
+    def run_script(self, *args):
+        return subprocess.run(
+            [sys.executable, SCRIPT, "--out", self.dir, *args],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def manifest(self):
+        with open(os.path.join(self.dir, "manifest.json"), encoding="utf-8") as handle:
+            return json.load(handle)
+
+    def side(self, name, shots):
+        with open(os.path.join(self.dir, f"{name}-shots.json"), "w", encoding="utf-8") as handle:
+            json.dump({"tool": f"{name} tool", "shots": shots}, handle)
+
+    def test_writes_a_manifest_with_nothing_captured(self):
+        """An aborted run still has to explain itself.
+
+        The commonest way to end up here is a permissions failure on the Xcode
+        half, and the manifest is where the Xcode version that refused belongs.
+        """
+        result = self.run_script()
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+        manifest = self.manifest()
+        self.assertEqual(manifest["screenshots"], [])
+        for key in ("purpose", "capturedAt", "toolchain", "git", "fixture", "render"):
+            self.assertIn(key, manifest)
+
+    def test_inventories_both_sides_with_pixel_facts(self):
+        write_png(os.path.join(self.dir, "ours-summary-1440-light.png"), 2880, 946)
+        write_png(os.path.join(self.dir, "xcode-summary-1440-light.png"), 2880, 1800)
+        self.side(
+            "ours",
+            [
+                {
+                    "file": "ours-summary-1440-light.png",
+                    "side": "ours",
+                    "view": "summary",
+                    "width": 1440,
+                    "colorScheme": "light",
+                    "automated": True,
+                }
+            ],
+        )
+        self.side(
+            "xcode",
+            [
+                {
+                    "file": "xcode-summary-1440-light.png",
+                    "side": "xcode",
+                    "view": "summary",
+                    "width": 1440,
+                    "colorScheme": "light",
+                    "automated": False,
+                }
+            ],
+        )
+
+        result = self.run_script()
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+        shots = self.manifest()["screenshots"]
+        self.assertEqual(len(shots), 2)
+        by_side = {shot["side"]: shot for shot in shots}
+        self.assertEqual(by_side["ours"]["pixelHeight"], 946)
+        self.assertEqual(by_side["xcode"]["pixelHeight"], 1800)
+        self.assertFalse(by_side["xcode"]["automated"])
+        for shot in shots:
+            self.assertTrue(shot["exists"])
+            self.assertEqual(len(shot["sha256"]), 64)
+            self.assertGreater(shot["bytes"], 0)
+
+    def test_a_shot_that_never_landed_is_reported_not_hidden(self):
+        """A promised shot missing from disk must be loud.
+
+        `screencapture` can fail without failing the run — a denied Screen
+        Recording permission is the usual reason — and a manifest that just
+        omitted the entry would read as "we never asked for that view".
+        """
+        self.side(
+            "xcode",
+            [
+                {
+                    "file": "xcode-logs-1440-dark.png",
+                    "side": "xcode",
+                    "view": "logs",
+                    "width": 1440,
+                    "colorScheme": "dark",
+                    "automated": True,
+                }
+            ],
+        )
+
+        result = self.run_script()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("missing on disk", result.stdout)
+
+        shot = self.manifest()["screenshots"][0]
+        self.assertFalse(shot["exists"])
+        self.assertIsNone(shot["pixelWidth"])
+        self.assertIsNone(shot["bytes"])
+
+    def test_orders_shots_so_the_two_sides_pair_up(self):
+        """Inventory order is the reading order of a comparison page: one view
+        and appearance at a time, ours next to Xcode's."""
+        shots = []
+        for side in ("ours", "xcode"):
+            for view in ("logs", "summary"):
+                name = f"{side}-{view}-1440-light.png"
+                write_png(os.path.join(self.dir, name), 100, 100)
+                shots.append(
+                    {
+                        "file": name,
+                        "side": side,
+                        "view": view,
+                        "width": 1440,
+                        "colorScheme": "light",
+                        "automated": True,
+                    }
+                )
+        self.side("ours", [s for s in shots if s["side"] == "ours"])
+        self.side("xcode", [s for s in shots if s["side"] == "xcode"])
+
+        self.run_script()
+        order = [(s["view"], s["side"]) for s in self.manifest()["screenshots"]]
+        self.assertEqual(
+            order,
+            [
+                ("summary", "ours"),
+                ("summary", "xcode"),
+                ("logs", "ours"),
+                ("logs", "xcode"),
+            ],
+        )
+
+    def test_a_missing_fixture_does_not_sink_the_run(self):
+        """Runs against a bundle that has since been deleted or moved still
+        produce a manifest; the absence is recorded rather than raised."""
+        result = self.run_script("--fixture", os.path.join(self.dir, "gone.xcresult"))
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertFalse(self.manifest()["fixture"]["exists"])
+
+    def test_records_the_render_it_was_told_about(self):
+        result = self.run_script(
+            "--render-command",
+            "xchtmlreport --rendering-mode linking -o out bundle.xcresult",
+            "--result-reader",
+            "modern",
+            "--invocation",
+            "viewer_compare.sh --result-reader modern",
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+        manifest = self.manifest()
+        self.assertEqual(manifest["render"]["resultReader"], "modern")
+        self.assertIn("--rendering-mode linking", manifest["render"]["command"])
+        self.assertIn("--result-reader modern", manifest["harness"]["invocation"])
+        # No report/ in this temp directory, so the size is unknown rather than 0.
+        self.assertIsNone(manifest["render"]["renderedHtmlBytes"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/viewer-compare/README.md
+++ b/scripts/viewer-compare/README.md
@@ -1,0 +1,154 @@
+# viewer-compare
+
+Puts Xcode's own test-report viewer and this project's report side by side over
+the same `.xcresult`, and leaves behind a run directory that a comparison can
+still be written from months later.
+
+The question it answers is *"what does Apple's viewer show that ours does not,
+and where have we drifted from what an Xcode user expects to see?"* — which is
+worth re-asking every time Xcode's report viewer changes, and impossible to
+answer from memory.
+
+## When to run it
+
+- **Every new Xcode release, and every beta worth a look.** Apple reworks the
+  report viewer without announcing it; the last rework moved the summary from a
+  list to a card with a ring, and the report only caught up afterwards.
+- Before shipping a change to the summary header, the test tree or the Logs
+  tab, when the point of the change is to match or deliberately diverge from
+  what Xcode does.
+
+This is the **visual/UX** half of new-Xcode coverage. The **functional** half —
+does the tool still parse what the new `xcresulttool` emits — is
+[`.github/workflows/toolchain-drift.yml`](../../.github/workflows/toolchain-drift.yml),
+which runs twice a week against `macos-latest` and against the current beta
+image, and files a `drift` issue when the stable leg breaks. That one is
+automated because it can be; this one is not, and should not be. Driving Xcode's
+GUI on a hosted runner is a flake generator, and a red check nobody trusts is
+worse than a tool the maintainer runs deliberately.
+
+## Prerequisites
+
+- macOS with Xcode installed (verified against Xcode 26.2).
+- `node` and `python3` on `PATH`. Nothing else to install: Playwright is
+  borrowed from [`visual/`](../../visual), and the first run does its `npm ci`.
+- Two permissions, both for **whatever program runs the script** — your terminal
+  app, not Xcode — in System Settings → Privacy & Security:
+  - **Accessibility**, to drive Xcode's UI.
+  - **Screen Recording**, for `screencapture`.
+
+  Without Accessibility the run stops immediately and says so. Without Screen
+  Recording you get black or empty PNGs, which is the more confusing failure —
+  check one Xcode shot before trusting a run.
+- A fixture bundle. The default is the repository's own:
+
+  ```sh
+  ./prepareTestResults.sh        # boots a simulator, a few minutes
+  ```
+
+## Usage
+
+```sh
+scripts/viewer-compare/viewer_compare.sh
+```
+
+That builds the current checkout, renders the fixture, captures our side
+headlessly, then hands the screen to Xcode for its side.
+
+**The Xcode half takes over the machine.** It moves a window, changes the system
+appearance, and types into whatever is frontmost. Do not use the keyboard while
+it runs. It puts the appearance back when it finishes, including on Ctrl-C.
+
+Useful variations:
+
+```sh
+# A bundle from somewhere else — a user's attached .xcresult, say
+scripts/viewer-compare/viewer_compare.sh --fixture ~/Downloads/Theirs.xcresult
+
+# Just re-shoot our side after a CSS change
+scripts/viewer-compare/viewer_compare.sh --skip-xcode
+
+# Compare the two result readers by running it twice
+scripts/viewer-compare/viewer_compare.sh --result-reader legacy
+scripts/viewer-compare/viewer_compare.sh --result-reader modern
+
+# Add Xcode's Tests view with the All Tests filter (prompts you to switch it)
+scripts/viewer-compare/viewer_compare.sh --with-tests-all
+```
+
+Each piece also runs on its own — `capture_ours.mjs`, `capture_xcode.sh` and
+`make_manifest.py` all take `--help` or documented environment variables, which
+is how to iterate when only one side needs re-shooting.
+
+## Output
+
+A timestamped directory under `.viewer-compare/` (git-ignored):
+
+```
+.viewer-compare/20260814T203000Z/
+├── manifest.json            # the point of the run — see below
+├── report/                  # the rendered report, plus a copy of the bundle
+│   ├── index.html
+│   └── TestResults.xcresult
+├── ours-summary-1440-light.png       ours: 4 views x 3 viewports
+├── ours-overview-1440-light.png
+├── ours-tests-1440-light.png
+├── ours-logs-1440-light.png
+│   ... 1440 dark, 375 light
+├── xcode-summary-1440-light.png      xcode: 3 views x 2 appearances
+├── xcode-tests-1440-light.png
+├── xcode-logs-1440-light.png
+│   ... and dark
+├── ours-shots.json          # what each side recorded about its own capture
+└── xcode-shots.json
+```
+
+`manifest.json` is what makes a run worth keeping. It records the Xcode and
+`xcresulttool` versions, the OS, the commit and whether the tree was dirty, the
+fixture's size and test counts and when it was generated, the exact render
+command, and an inventory of every shot with its view, viewport, appearance,
+pixel dimensions, SHA-256, and whether a human drove it. A comparison page can
+be regenerated from any run directory using nothing else.
+
+Runs are a few hundred MB each (the bundle copy dominates). Delete old ones.
+
+## What is automated, and what is not
+
+Automated: opening the bundle, waiting for the report to load, pinning the
+window to exactly 1440×900 points, switching the system appearance, moving the
+Report navigator between Summary / Tests / Log, and every screenshot.
+
+Guided by numbered prompt:
+
+- **Xcode's Tests-view status filter** (`--with-tests-all`). The filter is a
+  pull-down whose items carry live counts — `All Tests (21)` — so matching them
+  by name is a guess that changes with the fixture.
+- **Anything that stops working.** A failed view switch degrades to a prompt
+  rather than aborting, and `xcode-shots.json` records `automated: false` for
+  the shots a human drove, so a half-automated run is still honest.
+
+`--manual` puts every view switch behind a prompt, which is the fallback when a
+new Xcode moves the accessibility tree far enough that nothing matches.
+
+## When a new Xcode breaks the automation
+
+Everything version-fragile is in `xcode_ui.applescript`, and the paths worth
+knowing are:
+
+- The report window is found by the **first row of its Report navigator**, which
+  is the bundle's filename. A window opened straight onto an `.xcresult` has an
+  empty title, so a title match finds nothing — and when a project is already
+  open, the bundle's window sits next to one named after the project.
+- The navigator outline is at
+  `outline 1 of scroll area 1 of group 1 of <window>`.
+- Views are switched by **arrow keys on the focused outline**, with Xcode
+  frontmost. Setting the row's AX `selected` attribute highlights it but does
+  not navigate, and a synthetic `click at {x, y}` does not land. This was true
+  in Xcode 26.2; check it first if the shots all come out identical.
+
+To re-derive the tree after an Xcode update:
+
+```sh
+osascript scripts/viewer-compare/xcode_ui.applescript rows 1
+osascript -l JavaScript scripts/viewer-compare/xcode_windows.js
+```

--- a/scripts/viewer-compare/README.md
+++ b/scripts/viewer-compare/README.md
@@ -69,6 +69,14 @@ headlessly, then hands the screen to Xcode for its side.
 appearance, and types into whatever is frontmost. Do not use the keyboard while
 it runs. It puts the appearance back when it finishes, including on Ctrl-C.
 
+It deliberately closes nothing, so report windows accumulate across runs — one
+per run, all showing a bundle with the same filename. That is handled (the
+harness addresses windows by the bundle they show, and takes the frontmost
+match), but you will want to close them yourself eventually. Do it by hand:
+System Events intermittently reports an **empty name for project windows too**,
+so a script that closes every untitled Xcode window will happily close the
+project you had open.
+
 Useful variations:
 
 ```sh

--- a/scripts/viewer-compare/README.md
+++ b/scripts/viewer-compare/README.md
@@ -110,7 +110,8 @@ command, and an inventory of every shot with its view, viewport, appearance,
 pixel dimensions, SHA-256, and whether a human drove it. A comparison page can
 be regenerated from any run directory using nothing else.
 
-Runs are a few hundred MB each (the bundle copy dominates). Delete old ones.
+A run over the repository fixture is about 64 MB, nearly all of it the bundle
+copy — it scales with the bundle, not with the number of shots. Delete old ones.
 
 ## What is automated, and what is not
 

--- a/scripts/viewer-compare/README.md
+++ b/scripts/viewer-compare/README.md
@@ -27,6 +27,16 @@ automated because it can be; this one is not, and should not be. Driving Xcode's
 GUI on a hosted runner is a flake generator, and a red check nobody trusts is
 worse than a tool the maintainer runs deliberately.
 
+## Why this lives in `scripts/` and not in `visual/`
+
+It borrows [`visual/`](../../visual)'s Playwright — the same pinned version, the
+same browser build, no second lockfile — but it is not part of that suite.
+`visual/` is assertions that run on every pull request, on Linux, headless, with
+no Xcode anywhere. This is a macOS-only, GUI-driving, screenshot-producing tool
+that runs when a human decides to run it. Folding it in would put `osascript`
+and `screencapture` inside a directory whose whole contract is "this runs in
+CI", and the first person to add a `playwright test` glob would pick it up.
+
 ## Prerequisites
 
 - macOS with Xcode installed (verified against Xcode 26.2).

--- a/scripts/viewer-compare/README.md
+++ b/scripts/viewer-compare/README.md
@@ -175,6 +175,6 @@ knowing are:
 To re-derive the tree after an Xcode update:
 
 ```sh
-osascript scripts/viewer-compare/xcode_ui.applescript rows 1
+osascript scripts/viewer-compare/xcode_ui.applescript rows TestResults.xcresult
 osascript -l JavaScript scripts/viewer-compare/xcode_windows.js
 ```

--- a/scripts/viewer-compare/README.md
+++ b/scripts/viewer-compare/README.md
@@ -149,7 +149,9 @@ Guided by numbered prompt:
   by name is a guess that changes with the fixture.
 - **Anything that stops working.** A failed view switch degrades to a prompt
   rather than aborting, and `xcode-shots.json` records `automated: false` for
-  the shots a human drove, so a half-automated run is still honest.
+  the shots a human drove, so a half-automated run is still honest. When there
+  is no terminal to prompt on, or nobody answers, the shot is skipped instead:
+  `automated: false` always means a person pressed RETURN for it.
 
 `--manual` puts every view switch behind a prompt, which is the fallback when a
 new Xcode moves the accessibility tree far enough that nothing matches.

--- a/scripts/viewer-compare/README.md
+++ b/scripts/viewer-compare/README.md
@@ -94,7 +94,7 @@ is how to iterate when only one side needs re-shooting.
 
 A timestamped directory under `.viewer-compare/` (git-ignored):
 
-```
+```text
 .viewer-compare/20260814T203000Z/
 ├── manifest.json            # the point of the run — see below
 ├── report/                  # the rendered report, plus a copy of the bundle

--- a/scripts/viewer-compare/README.md
+++ b/scripts/viewer-compare/README.md
@@ -42,14 +42,19 @@ CI", and the first person to add a `playwright test` glob would pick it up.
 - macOS with Xcode installed (verified against Xcode 26.2).
 - `node` and `python3` on `PATH`. Nothing else to install: Playwright is
   borrowed from [`visual/`](../../visual), and the first run does its `npm ci`.
-- Two permissions, both for **whatever program runs the script** — your terminal
-  app, not Xcode — in System Settings → Privacy & Security:
+- Three permissions, all for **whatever program runs the script** — your
+  terminal app, not Xcode — in System Settings → Privacy & Security:
   - **Accessibility**, to drive Xcode's UI.
   - **Screen Recording**, for `screencapture`.
+  - **Automation → System Events**, which macOS asks for at the first run.
 
-  Without Accessibility the run stops immediately and says so. Without Screen
-  Recording you get black or empty PNGs, which is the more confusing failure —
-  check one Xcode shot before trusting a run.
+  Accessibility and Automation are separate grants and the run needs both, so
+  the preflight probes Accessibility the only way that distinguishes them: a
+  no-op read of another app's UI elements, which is what that grant covers.
+  Missing either one stops the run before it opens anything, with the OS error
+  that says which grant to go fix. Without Screen Recording you get black or
+  empty PNGs, which is the more confusing failure — check one Xcode shot before
+  trusting a run.
 - A fixture bundle. The default is the repository's own:
 
   ```sh

--- a/scripts/viewer-compare/capture_ours.mjs
+++ b/scripts/viewer-compare/capture_ours.mjs
@@ -115,7 +115,7 @@ async function probe(page) {
 
 const browser = await chromium.launch({ headless: true });
 const shots = [];
-let probes = {};
+const probes = {};
 
 for (const combo of COMBOS) {
     const tag = `${combo.width}-${combo.scheme}`;

--- a/scripts/viewer-compare/capture_ours.mjs
+++ b/scripts/viewer-compare/capture_ours.mjs
@@ -1,0 +1,194 @@
+// Captures this checkout's rendered report headlessly, in the grid the Xcode
+// side is framed to match: summary / tests / logs, at 1440 in both appearances
+// and at 375 in light.
+//
+// Driven by viewer_compare.sh, which has already built the binary, rendered the
+// fixture and put an HTTP server in front of it. Run standalone with:
+//
+//   VC_OUT=<dir> VC_URL=http://127.0.0.1:8899/index.html \
+//     node scripts/viewer-compare/capture_ours.mjs
+//
+// Playwright is not a dependency of this directory. It is borrowed from
+// visual/, whose package-lock.json already pins the version CI uses, so the two
+// browser layers cannot drift apart and this tool adds no second lockfile.
+
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.resolve(HERE, '..', '..');
+const VISUAL = path.join(REPO, 'visual');
+
+const OUT = process.env.VC_OUT;
+const URL = process.env.VC_URL;
+if (!OUT || !URL) {
+    console.error('capture_ours.mjs: VC_OUT and VC_URL must both be set');
+    process.exit(2);
+}
+
+// Resolve from visual/node_modules rather than from this file's own directory,
+// which has no node_modules and is not meant to grow one.
+//
+// `playwright`, not `playwright-core`: visual/package-lock.json hoists a SECOND
+// playwright-core to the top of that tree (a transitive dependency of
+// @axe-core/playwright, on a looser range), and it is a different version from
+// the one @playwright/test runs — different enough to want a browser build that
+// `npx playwright install` never fetched. Going through `playwright` lands on
+// the same nested core, and therefore the same browser, that the visual suite
+// and CI use.
+const requireFromVisual = createRequire(path.join(VISUAL, 'package.json'));
+let chromium;
+let playwrightVersion = 'unknown';
+try {
+    ({ chromium } = requireFromVisual('playwright'));
+    playwrightVersion = requireFromVisual('playwright/package.json').version;
+} catch (err) {
+    console.error(
+        `capture_ours.mjs: could not load playwright from ${VISUAL}/node_modules.\n` +
+            `Run \`npm ci\` in ${VISUAL} first (viewer_compare.sh does this for you).\n` +
+            String(err)
+    );
+    process.exit(2);
+}
+
+// 2x everywhere, because `screencapture` on a Retina display hands back 2x and
+// a comparison page that mixes scales makes the two sides look like they differ
+// in weight when they only differ in sampling.
+const DEVICE_SCALE_FACTOR = 2;
+
+const COMBOS = [
+    { width: 1440, height: 900, scheme: 'light' },
+    { width: 1440, height: 900, scheme: 'dark' },
+    { width: 375, height: 812, scheme: 'light' },
+];
+
+// `clip` decides what part of the viewport a view is worth showing:
+//   header     — the summary band alone, the thing being compared to Xcode's
+//                summary pane; framing it whole keeps the comparison honest
+//                when its height changes between runs.
+//   viewport   — the window as it loads, the like-for-like against an Xcode
+//                window pinned to the same logical size.
+//   belowHeader — the content region, so a summary that grows does not push
+//                the test tree out of the shot and make it look empty.
+const VIEWS = [
+    { name: 'summary', tab: 'Tests', clip: 'header' },
+    { name: 'overview', tab: 'Tests', clip: 'viewport' },
+    { name: 'tests', tab: 'Tests', clip: 'belowHeader' },
+    { name: 'logs', tab: 'Logs', clip: 'viewport' },
+];
+
+async function selectTab(page, label) {
+    const tab = page.locator('#test-log-toolbar li', { hasText: new RegExp(`^${label}$`) }).first();
+    await tab.click();
+    // The Logs pane swaps in an iframe; give it a beat to lay out before the
+    // shutter, or the shot catches an empty frame that reads as a bug.
+    await page.waitForTimeout(800);
+}
+
+async function clipFor(page, view, combo) {
+    if (view.clip === 'viewport') return undefined;
+    const header = await page.locator('header').boundingBox();
+    if (!header) throw new Error(`no <header> found for view ${view.name}`);
+    if (view.clip === 'header') {
+        return { x: 0, y: 0, width: combo.width, height: Math.ceil(header.height) };
+    }
+    const y = Math.floor(header.height);
+    return { x: 0, y, width: combo.width, height: Math.max(1, combo.height - y) };
+}
+
+// Values a comparison page wants in prose next to the shots, and which are
+// cheaper to read from the DOM than to eyeball off a PNG later.
+async function probe(page) {
+    const text = async (sel) => page.locator(sel).first().innerText().catch(() => null);
+    const count = async (sel) => page.locator(sel).count().catch(() => 0);
+    const header = await page.locator('header').boundingBox();
+    return {
+        headerHeightCss: header ? Math.round(header.height) : null,
+        donut: await text('.donut-center'),
+        summaryMeta: await text('.summary-meta'),
+        failureDigestRows: await count('.failure-digest li'),
+        deviceRows: await count('.device-row-name'),
+    };
+}
+
+const browser = await chromium.launch({ headless: true });
+const shots = [];
+let probes = {};
+
+for (const combo of COMBOS) {
+    const tag = `${combo.width}-${combo.scheme}`;
+    const page = await browser.newPage({
+        viewport: { width: combo.width, height: combo.height },
+        deviceScaleFactor: DEVICE_SCALE_FACTOR,
+        colorScheme: combo.scheme,
+    });
+
+    const httpErrors = [];
+    page.on('response', (r) => {
+        // /favicon.ico is requested by the browser, not by the report, and is
+        // not shipped; it is the one 404 that means nothing.
+        if (r.status() >= 400 && !r.url().endsWith('/favicon.ico')) {
+            httpErrors.push(`${r.status()} ${r.url()}`);
+        }
+    });
+    const pageErrors = [];
+    page.on('pageerror', (e) => pageErrors.push(String(e.message)));
+
+    await page.goto(URL, { waitUntil: 'load' });
+    await page.waitForTimeout(500);
+    probes[tag] = { ...(await probe(page)), httpErrors, pageErrors };
+
+    let currentTab = 'Tests';
+    for (const view of VIEWS) {
+        if (view.tab !== currentTab) {
+            await selectTab(page, view.tab);
+            currentTab = view.tab;
+        }
+        const file = `ours-${view.name}-${tag}.png`;
+        const clip = await clipFor(page, view, combo);
+        await page.screenshot({ path: path.join(OUT, file), clip });
+        shots.push({
+            file,
+            side: 'ours',
+            view: view.name,
+            width: combo.width,
+            height: combo.height,
+            colorScheme: combo.scheme,
+            deviceScaleFactor: DEVICE_SCALE_FACTOR,
+            clip: view.clip,
+            automated: true,
+        });
+        console.log(`ours: ${file}`);
+    }
+    await page.close();
+}
+
+await browser.close();
+
+// A 404 here means the shots are of a report whose attachments did not load —
+// which looks like a rendering regression and is usually a serving mistake.
+// Say so rather than leaving it for whoever reads the manifest later.
+const broken = Object.entries(probes).filter(([, p]) => p.httpErrors.length > 0);
+for (const [tag, p] of broken) {
+    console.warn(`ours: WARNING ${tag} had ${p.httpErrors.length} failed request(s):`);
+    for (const line of p.httpErrors.slice(0, 5)) console.warn(`  ${line}`);
+}
+
+fs.writeFileSync(
+    path.join(OUT, 'ours-shots.json'),
+    JSON.stringify(
+        {
+            tool: `playwright ${playwrightVersion} (bundled Chromium, headless)`,
+            url: URL,
+            deviceScaleFactor: DEVICE_SCALE_FACTOR,
+            colorScheme: 'emulated via prefers-color-scheme; the report has no in-page theme toggle',
+            probes,
+            shots,
+        },
+        null,
+        2
+    ) + '\n'
+);
+console.log(`ours: ${shots.length} shots -> ${OUT}`);

--- a/scripts/viewer-compare/capture_xcode.sh
+++ b/scripts/viewer-compare/capture_xcode.sh
@@ -190,7 +190,13 @@ STEP=0
 prompt_step() {
     local instruction="$1"
     STEP=$((STEP + 1))
-    if [ ! -e /dev/tty ]; then
+    # Every path out of here that is not a person pressing RETURN is a skip.
+    # `automated: false` in the manifest asserts a human drove that shot, so a
+    # terminal that cannot be opened, or one that hangs up mid-run, has to lose
+    # the shot rather than let the run claim someone was watching. Existence is
+    # not enough: /dev/tty exists in a session with no controlling terminal and
+    # only fails on open.
+    if ! { true >/dev/tty; } 2>/dev/null; then
         note "step ${STEP} needed a prompt but there is no terminal to ask on: ${instruction}"
         return 1
     fi
@@ -202,7 +208,10 @@ prompt_step() {
         echo "  ------------------------------------------------------------"
     } >/dev/tty
     local reply=""
-    read -r reply </dev/tty || true
+    if ! read -r reply </dev/tty; then
+        note "step ${STEP} was never answered (terminal closed, or end of input) — skipping it: ${instruction}"
+        return 1
+    fi
     case "$reply" in
     s | S | skip) return 1 ;;
     esac

--- a/scripts/viewer-compare/capture_xcode.sh
+++ b/scripts/viewer-compare/capture_xcode.sh
@@ -195,7 +195,7 @@ prompt_step() {
 echo "capture_xcode: opening ${BUNDLE_NAME} in Xcode"
 open -a Xcode "$BUNDLE"
 
-WIN_INDEX=""
+loaded=0
 deadline=$((SECONDS + OPEN_TIMEOUT))
 while [ "$SECONDS" -lt "$deadline" ]; do
     found="$(ui find "$BUNDLE_NAME")"
@@ -209,7 +209,7 @@ while [ "$SECONDS" -lt "$deadline" ]; do
         '' | *[!0-9]*) ;;
         *)
             if [ "$rows" -ge 2 ]; then
-                WIN_INDEX="${found%%|*}"
+                loaded=1
                 break
             fi
             ;;
@@ -219,7 +219,7 @@ while [ "$SECONDS" -lt "$deadline" ]; do
     sleep 2
 done
 
-if [ -z "$WIN_INDEX" ]; then
+if [ "$loaded" -ne 1 ]; then
     echo "capture_xcode.sh: Xcode never showed a loaded report for ${BUNDLE_NAME} within ${OPEN_TIMEOUT}s" >&2
     echo "  (a very large bundle can index for longer — retry with --open-timeout)" >&2
     exit 1
@@ -229,7 +229,13 @@ note "report window found after $((OPEN_TIMEOUT - (deadline - SECONDS)))s"
 # Xcode keeps loading the editor after the navigator is populated.
 sleep "$SETTLE"
 
-pinned="$(ui pin "$WIN_INDEX" "$ORIGIN_X" "$ORIGIN_Y" "$WIDTH" "$HEIGHT")"
+pinned="$(ui pin "$BUNDLE_NAME" "$ORIGIN_X" "$ORIGIN_Y" "$WIDTH" "$HEIGHT")"
+case "$pinned" in
+ERR*)
+    echo "capture_xcode.sh: could not pin the report window: ${pinned#ERR|}" >&2
+    exit 1
+    ;;
+esac
 IFS='|' read -r got_x got_y got_w got_h <<<"$pinned"
 if [ "$got_w" != "$WIDTH" ] || [ "$got_h" != "$HEIGHT" ]; then
     note "WARNING: asked for ${WIDTH}x${HEIGHT}, Xcode settled at ${got_w}x${got_h} — filenames still say ${WIDTH}, the manifest records the truth"
@@ -284,7 +290,7 @@ for scheme in light dark; do
     for view in summary tests logs; do
         how="automated"
         if [ "$MANUAL" -eq 0 ]; then
-            result="$(ui select "$WIN_INDEX" "$view")"
+            result="$(ui select "$BUNDLE_NAME" "$view")"
         else
             result="ERR|--manual requested"
         fi
@@ -307,7 +313,7 @@ for scheme in light dark; do
 
     if [ "$WITH_TESTS_ALL" -eq 1 ]; then
         if [ "$MANUAL" -eq 0 ]; then
-            ui select "$WIN_INDEX" tests >/dev/null || true
+            ui select "$BUNDLE_NAME" tests >/dev/null || true
             sleep "$SETTLE"
         fi
         if prompt_step "In the Tests view, open the leftmost filter ('Failed Tests (N)') and choose 'All Tests (N)', in ${scheme} appearance."; then

--- a/scripts/viewer-compare/capture_xcode.sh
+++ b/scripts/viewer-compare/capture_xcode.sh
@@ -312,6 +312,13 @@ for scheme in light dark; do
         fi
         if prompt_step "In the Tests view, open the leftmost filter ('Failed Tests (N)') and choose 'All Tests (N)', in ${scheme} appearance."; then
             shoot "tests" "$scheme" "-all" "manual" || true
+            # Xcode keeps the filter across an appearance switch, so leaving it
+            # on All would make the NEXT appearance's plain `tests` shot show a
+            # different view from this one's — two shots named as a light/dark
+            # pair that are not comparable.
+            if ! prompt_step "Set that filter back to 'Failed Tests (N)', so the remaining shots stay comparable."; then
+                note "WARNING: Tests filter left on All Tests after ${scheme}; later tests shots may not match"
+            fi
         else
             note "skipped xcode tests-all ${scheme}"
         fi

--- a/scripts/viewer-compare/capture_xcode.sh
+++ b/scripts/viewer-compare/capture_xcode.sh
@@ -1,0 +1,386 @@
+#!/bin/bash
+# Captures Xcode's own test-report viewer showing the same bundle this
+# checkout just rendered, framed to the same logical window size.
+#
+# Driven by viewer_compare.sh; runnable on its own:
+#
+#   scripts/viewer-compare/capture_xcode.sh \
+#       --bundle /path/to/TestResults.xcresult --out /path/to/run-dir
+#
+# WHAT IS AUTOMATED: opening the bundle, waiting for the report to load,
+# pinning the window to an exact size, switching the system appearance, moving
+# the Report navigator between Summary / Tests / Log, and the screenshots.
+#
+# WHAT IS NOT: the Tests view's status filter (--with-tests-all), which opens a
+# pull-down whose item labels carry live counts, so matching them is a guess
+# that changes with the fixture. That one is a numbered prompt. Any automated
+# step that fails also degrades to a numbered prompt rather than aborting the
+# run — a half-captured comparison is worth more than none, and the manifest
+# records which shots were driven by hand.
+#
+# This drives a GUI. It takes over the keyboard focus for as long as it runs,
+# and it changes the system appearance and puts it back. Do not use the machine
+# while it works.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+UI="${HERE}/xcode_ui.applescript"
+WINDOWS_JS="${HERE}/xcode_windows.js"
+
+BUNDLE=""
+OUT=""
+WIDTH=1440
+HEIGHT=900
+ORIGIN_X=60
+ORIGIN_Y=100
+SETTLE=4
+OPEN_TIMEOUT=240
+MANUAL=0
+WITH_TESTS_ALL=0
+
+usage() {
+    cat <<'EOF'
+Usage: capture_xcode.sh --bundle <path.xcresult> --out <dir> [options]
+
+  --bundle PATH      .xcresult to open in Xcode (required)
+  --out DIR          directory to write PNGs and xcode-shots.json into (required)
+  --width N          logical window width in points (default 1440)
+  --height N         logical window height in points (default 900)
+  --origin X,Y       where to pin the window (default 60,100)
+  --settle SECONDS   pause after each view switch before the shutter (default 4)
+  --open-timeout N   how long to wait for the report to load (default 240)
+  --manual           drive every view switch by prompt instead of automatically
+  --with-tests-all   add a guided shot of the Tests view with the All Tests filter
+  -h, --help         this text
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+    --bundle)
+        BUNDLE="$2"
+        shift 2
+        ;;
+    --out)
+        OUT="$2"
+        shift 2
+        ;;
+    --width)
+        WIDTH="$2"
+        shift 2
+        ;;
+    --height)
+        HEIGHT="$2"
+        shift 2
+        ;;
+    --origin)
+        ORIGIN_X="${2%%,*}"
+        ORIGIN_Y="${2##*,}"
+        shift 2
+        ;;
+    --settle)
+        SETTLE="$2"
+        shift 2
+        ;;
+    --open-timeout)
+        OPEN_TIMEOUT="$2"
+        shift 2
+        ;;
+    --manual)
+        MANUAL=1
+        shift
+        ;;
+    --with-tests-all)
+        WITH_TESTS_ALL=1
+        shift
+        ;;
+    -h | --help)
+        usage
+        exit 0
+        ;;
+    *)
+        echo "capture_xcode.sh: unknown argument: $1" >&2
+        usage >&2
+        exit 2
+        ;;
+    esac
+done
+
+if [ -z "$BUNDLE" ] || [ -z "$OUT" ]; then
+    echo "capture_xcode.sh: --bundle and --out are both required" >&2
+    usage >&2
+    exit 2
+fi
+if [ ! -d "$BUNDLE" ]; then
+    echo "capture_xcode.sh: no such bundle: $BUNDLE" >&2
+    exit 2
+fi
+mkdir -p "$OUT"
+
+BUNDLE_NAME="$(basename "$BUNDLE")"
+RECORDS="$(mktemp -t viewer-compare-xcode)"
+NOTES="$(mktemp -t viewer-compare-notes)"
+trap 'rm -f "$RECORDS" "$NOTES"' EXIT
+
+note() {
+    echo "$1" >>"$NOTES"
+    echo "capture_xcode: $1"
+}
+
+ui() {
+    osascript "$UI" "$@"
+}
+
+# --- preflight -------------------------------------------------------------
+
+if [ "$(uname)" != "Darwin" ]; then
+    echo "capture_xcode.sh: macOS only — this drives Xcode's GUI" >&2
+    exit 1
+fi
+if ! /usr/bin/xcode-select -p >/dev/null 2>&1; then
+    echo "capture_xcode.sh: no Xcode selected (xcode-select -p failed)" >&2
+    exit 1
+fi
+
+# One accessibility call before anything else, so a missing permission fails
+# here with the fix rather than fifty lines later as a mystery.
+appearance_before="$(ui get-appearance)"
+case "$appearance_before" in
+light | dark) ;;
+*)
+    cat >&2 <<EOF
+capture_xcode.sh: cannot drive System Events ($appearance_before)
+
+Grant Accessibility permission to the program running this script (your
+terminal app), in System Settings > Privacy & Security > Accessibility, then
+run it again. Screen Recording permission is needed too, for screencapture.
+EOF
+    exit 1
+    ;;
+esac
+note "system appearance on entry: ${appearance_before}"
+
+restore_appearance() {
+    ui set-appearance "$appearance_before" >/dev/null 2>&1 || true
+}
+trap 'restore_appearance; rm -f "$RECORDS" "$NOTES"' EXIT
+
+# --- numbered prompts ------------------------------------------------------
+
+STEP=0
+prompt_step() {
+    local instruction="$1"
+    STEP=$((STEP + 1))
+    if [ ! -e /dev/tty ]; then
+        note "step ${STEP} needed a prompt but there is no terminal to ask on: ${instruction}"
+        return 1
+    fi
+    {
+        echo
+        echo "  ---- MANUAL STEP ${STEP} ----------------------------------------"
+        echo "  ${instruction}"
+        echo "  Press RETURN when the screen shows it, or type s + RETURN to skip."
+        echo "  ------------------------------------------------------------"
+    } >/dev/tty
+    local reply=""
+    read -r reply </dev/tty || true
+    case "$reply" in
+    s | S | skip) return 1 ;;
+    esac
+    return 0
+}
+
+# --- open the bundle and find its window -----------------------------------
+
+echo "capture_xcode: opening ${BUNDLE_NAME} in Xcode"
+open -a Xcode "$BUNDLE"
+
+WIN_INDEX=""
+deadline=$((SECONDS + OPEN_TIMEOUT))
+while [ "$SECONDS" -lt "$deadline" ]; do
+    found="$(ui find "$BUNDLE_NAME")"
+    case "$found" in
+    ERR*) ;;
+    *)
+        rows="${found##*|}"
+        # The bundle row alone means the window exists but the report tree has
+        # not been read yet; wait for at least one child before framing shots.
+        case "$rows" in
+        '' | *[!0-9]*) ;;
+        *)
+            if [ "$rows" -ge 2 ]; then
+                WIN_INDEX="${found%%|*}"
+                break
+            fi
+            ;;
+        esac
+        ;;
+    esac
+    sleep 2
+done
+
+if [ -z "$WIN_INDEX" ]; then
+    echo "capture_xcode.sh: Xcode never showed a loaded report for ${BUNDLE_NAME} within ${OPEN_TIMEOUT}s" >&2
+    echo "  (a very large bundle can index for longer — retry with --open-timeout)" >&2
+    exit 1
+fi
+note "report window found after $((OPEN_TIMEOUT - (deadline - SECONDS)))s"
+
+# Xcode keeps loading the editor after the navigator is populated.
+sleep "$SETTLE"
+
+pinned="$(ui pin "$WIN_INDEX" "$ORIGIN_X" "$ORIGIN_Y" "$WIDTH" "$HEIGHT")"
+IFS='|' read -r got_x got_y got_w got_h <<<"$pinned"
+if [ "$got_w" != "$WIDTH" ] || [ "$got_h" != "$HEIGHT" ]; then
+    note "WARNING: asked for ${WIDTH}x${HEIGHT}, Xcode settled at ${got_w}x${got_h} — filenames still say ${WIDTH}, the manifest records the truth"
+fi
+note "window pinned at ${got_x},${got_y} ${got_w}x${got_h}"
+
+# screencapture needs a CGWindowID, which the accessibility API does not expose;
+# match the window by the bounds we just pinned it to.
+WIN_ID="$(osascript -l JavaScript "$WINDOWS_JS" Xcode | python3 -c '
+import json, sys
+x, y, w, h = (int(v) for v in sys.argv[1:5])
+for win in json.load(sys.stdin):
+    if (win["x"], win["y"], win["width"], win["height"]) == (x, y, w, h):
+        print(win["id"])
+        break
+' "$got_x" "$got_y" "$got_w" "$got_h")"
+
+if [ -z "$WIN_ID" ]; then
+    echo "capture_xcode.sh: could not match a CGWindowID to the pinned window" >&2
+    exit 1
+fi
+note "CGWindowID ${WIN_ID}"
+
+# --- capture ---------------------------------------------------------------
+
+view_label() {
+    case "$1" in
+    summary) echo "the Summary view (the scheme row in the Report navigator)" ;;
+    tests) echo "the Tests view (the 'Tests' row in the Report navigator)" ;;
+    logs) echo "the Log view (the 'Log' row in the Report navigator)" ;;
+    *) echo "the ${1} view" ;;
+    esac
+}
+
+shoot() {
+    local view="$1" scheme="$2" suffix="$3" how="$4"
+    local file="xcode-${view}${suffix}-${WIDTH}-${scheme}.png"
+    if ! screencapture -x -o -l "$WIN_ID" "${OUT}/${file}"; then
+        note "screencapture failed for ${file}"
+        return 1
+    fi
+    printf '%s\t%s\t%s\t%s\t%s\n' "$file" "$view$suffix" "$WIDTH" "$scheme" "$how" >>"$RECORDS"
+    echo "capture_xcode: ${file} (${how})"
+}
+
+for scheme in light dark; do
+    ui set-appearance "$scheme" >/dev/null
+    # Xcode redraws the whole report on an appearance change; the settle here is
+    # what keeps a half-repainted window out of the shot.
+    sleep $((SETTLE + 2))
+
+    for view in summary tests logs; do
+        how="automated"
+        if [ "$MANUAL" -eq 0 ]; then
+            result="$(ui select "$WIN_INDEX" "$view")"
+        else
+            result="ERR|--manual requested"
+        fi
+        case "$result" in
+        OK*) ;;
+        *)
+            if [ "$MANUAL" -eq 0 ]; then
+                note "automatic view switch to ${view} failed: ${result}"
+            fi
+            if ! prompt_step "Switch Xcode to $(view_label "$view"), in ${scheme} appearance."; then
+                note "skipped xcode ${view} ${scheme}"
+                continue
+            fi
+            how="manual"
+            ;;
+        esac
+        sleep "$SETTLE"
+        shoot "$view" "$scheme" "" "$how" || true
+    done
+
+    if [ "$WITH_TESTS_ALL" -eq 1 ]; then
+        if [ "$MANUAL" -eq 0 ]; then
+            ui select "$WIN_INDEX" tests >/dev/null || true
+            sleep "$SETTLE"
+        fi
+        if prompt_step "In the Tests view, open the leftmost filter ('Failed Tests (N)') and choose 'All Tests (N)', in ${scheme} appearance."; then
+            shoot "tests" "$scheme" "-all" "manual" || true
+        else
+            note "skipped xcode tests-all ${scheme}"
+        fi
+    fi
+done
+
+restore_appearance
+note "system appearance restored to ${appearance_before}"
+
+python3 - "$OUT" "$RECORDS" "$NOTES" "$BUNDLE" "$WIN_ID" "$got_x" "$got_y" "$got_w" "$got_h" <<'PY'
+import json
+import os
+import subprocess
+import sys
+
+out, records, notes, bundle, win_id, x, y, w, h = sys.argv[1:10]
+
+
+def lines(path):
+    if not os.path.exists(path):
+        return []
+    with open(path, encoding="utf-8") as handle:
+        return [line.rstrip("\n") for line in handle if line.strip()]
+
+
+shots = []
+for line in lines(records):
+    file, view, width, scheme, how = line.split("\t")
+    shots.append(
+        {
+            "file": file,
+            "side": "xcode",
+            "view": view,
+            "width": int(width),
+            "colorScheme": scheme,
+            "automated": how == "automated",
+        }
+    )
+
+xcode_version = "unknown"
+try:
+    xcode_version = " ".join(
+        subprocess.run(
+            ["xcodebuild", "-version"], capture_output=True, text=True, check=True
+        ).stdout.split()
+    )
+except (OSError, subprocess.CalledProcessError):
+    pass
+
+payload = {
+    "tool": "osascript (System Events + JXA/CoreGraphics) + screencapture",
+    "xcode": xcode_version,
+    "howOpened": f"open -a Xcode {os.path.basename(bundle)}; the window is identified by "
+    "the first row of its Report navigator, because a window opened straight "
+    "onto an .xcresult has no title",
+    "window": f"pinned to {w}x{h} points at ({x},{y}); CGWindowID {win_id}",
+    "screenshotCommand": f"screencapture -x -o -l {win_id} (window only, no shadow)",
+    "appearance": "system appearance toggled via System Events; Xcode's report "
+    "viewer has no appearance of its own",
+    "viewSwitching": "Report-navigator selection moved with arrow keys on the "
+    "focused outline — setting the AX selected attribute highlights the row "
+    "without navigating, and a synthetic click does not land",
+    "notes": lines(notes),
+    "shots": shots,
+}
+
+with open(os.path.join(out, "xcode-shots.json"), "w", encoding="utf-8") as handle:
+    json.dump(payload, handle, indent=2)
+    handle.write("\n")
+
+print(f"xcode: {len(shots)} shots -> {out}")
+PY

--- a/scripts/viewer-compare/capture_xcode.sh
+++ b/scripts/viewer-compare/capture_xcode.sh
@@ -142,19 +142,38 @@ if ! /usr/bin/xcode-select -p >/dev/null 2>&1; then
     exit 1
 fi
 
-# One accessibility call before anything else, so a missing permission fails
-# here with the fix rather than fifty lines later as a mystery.
+# One UI-element read before anything else, so a missing permission fails here
+# with the fix rather than fifty lines later as a mystery. It has to be a UI
+# read specifically: the appearance commands below go through System Events'
+# scripting properties, which Automation alone can do, so probing with those
+# would wave through a terminal that lacks Accessibility — and the run would
+# then die in the wait loop, where a denied UI call is indistinguishable from a
+# report that has not finished loading.
+ax_probe="$(ui check-accessibility)"
+case "$ax_probe" in
+OK*) ;;
+*)
+    cat >&2 <<EOF
+capture_xcode.sh: cannot read another app's UI through System Events
+  ${ax_probe#ERR|}
+
+Both grants below are for the program running this script — your terminal app,
+not Xcode — in System Settings > Privacy & Security:
+
+  Accessibility   "not allowed assistive access" (-25211) means this one
+  Automation      "Not authorized to send Apple events" (-1743) means this one
+
+Screen Recording, also for your terminal app, is needed later for screencapture.
+EOF
+    exit 1
+    ;;
+esac
+
 appearance_before="$(ui get-appearance)"
 case "$appearance_before" in
 light | dark) ;;
 *)
-    cat >&2 <<EOF
-capture_xcode.sh: cannot drive System Events ($appearance_before)
-
-Grant Accessibility permission to the program running this script (your
-terminal app), in System Settings > Privacy & Security > Accessibility, then
-run it again. Screen Recording permission is needed too, for screencapture.
-EOF
+    echo "capture_xcode.sh: cannot read the system appearance: ${appearance_before#ERR|}" >&2
     exit 1
     ;;
 esac
@@ -196,11 +215,12 @@ echo "capture_xcode: opening ${BUNDLE_NAME} in Xcode"
 open -a Xcode "$BUNDLE"
 
 loaded=0
+last_err=""
 deadline=$((SECONDS + OPEN_TIMEOUT))
 while [ "$SECONDS" -lt "$deadline" ]; do
     found="$(ui find "$BUNDLE_NAME")"
     case "$found" in
-    ERR*) ;;
+    ERR*) last_err="${found#ERR|}" ;;
     *)
         rows="${found##*|}"
         # The bundle row alone means the window exists but the report tree has
@@ -221,6 +241,9 @@ done
 
 if [ "$loaded" -ne 1 ]; then
     echo "capture_xcode.sh: Xcode never showed a loaded report for ${BUNDLE_NAME} within ${OPEN_TIMEOUT}s" >&2
+    if [ -n "$last_err" ]; then
+        echo "  (last window lookup: ${last_err})" >&2
+    fi
     echo "  (a very large bundle can index for longer — retry with --open-timeout)" >&2
     exit 1
 fi

--- a/scripts/viewer-compare/make_manifest.py
+++ b/scripts/viewer-compare/make_manifest.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+"""Assembles manifest.json for one viewer-compare run.
+
+The manifest is the point of the run. A directory of PNGs answers "what did the
+two viewers look like"; only the manifest answers "on which Xcode, against which
+commit, over which fixture" — which is the question anyone reading a comparison
+six months later actually has, and the one nobody can reconstruct afterwards.
+
+It also has to be enough to rebuild a comparison page from a run directory
+alone, so every shot is inventoried with its side, view, viewport, appearance,
+pixel dimensions and digest, not just its filename.
+
+Toolchain probes are all best-effort: a probe that cannot run records `null`
+rather than failing the run, because a manifest missing one version string is
+worth more than no manifest at all.
+
+Standard library only.
+"""
+
+import argparse
+import hashlib
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+
+PURPOSE = (
+    "Like-for-like comparison of Xcode's own test-report viewer against the "
+    "report this checkout renders, over the same .xcresult bundle."
+)
+
+
+def run(cmd, cwd=None):
+    """Returns collapsed stdout, or None when the command is unavailable."""
+    try:
+        proc = subprocess.run(
+            cmd, capture_output=True, text=True, check=True, cwd=cwd, timeout=120
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    return " ".join(proc.stdout.split()) or None
+
+
+def read_json(path):
+    if not os.path.exists(path):
+        return None
+    try:
+        with open(path, encoding="utf-8") as handle:
+            return json.load(handle)
+    except (OSError, ValueError):
+        return None
+
+
+def png_size(path):
+    """Reads width/height straight out of the IHDR chunk.
+
+    Shelling out to `sips` once per shot costs more than the whole rest of this
+    script, and the header is eight bytes at a fixed offset.
+    """
+    try:
+        with open(path, "rb") as handle:
+            head = handle.read(24)
+    except OSError:
+        return (None, None)
+    if len(head) < 24 or head[:8] != b"\x89PNG\r\n\x1a\n":
+        return (None, None)
+    return (
+        int.from_bytes(head[16:20], "big"),
+        int.from_bytes(head[20:24], "big"),
+    )
+
+
+def digest(path):
+    sha = hashlib.sha256()
+    try:
+        with open(path, "rb") as handle:
+            for chunk in iter(lambda: handle.read(1 << 20), b""):
+                sha.update(chunk)
+    except OSError:
+        return None
+    return sha.hexdigest()
+
+
+def directory_bytes(path):
+    total = 0
+    for root, _dirs, files in os.walk(path):
+        for name in files:
+            try:
+                total += os.lstat(os.path.join(root, name)).st_size
+            except OSError:
+                continue
+    return total
+
+
+def human_bytes(count):
+    if count is None:
+        return None
+    value = float(count)
+    for unit in ("B", "KB", "MB", "GB"):
+        if value < 1024 or unit == "GB":
+            return f"{value:.0f} {unit}" if unit == "B" else f"{value:.1f} {unit}"
+        value /= 1024
+    return None
+
+
+def iso(timestamp):
+    return datetime.fromtimestamp(timestamp, timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def git_facts(repo):
+    if not os.path.isdir(os.path.join(repo, ".git")) and not os.path.exists(
+        os.path.join(repo, ".git")
+    ):
+        return {"sha": None}
+    status = run(["git", "status", "--porcelain"], cwd=repo)
+    return {
+        "sha": run(["git", "rev-parse", "HEAD"], cwd=repo),
+        "branch": run(["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd=repo),
+        "subject": run(["git", "log", "-1", "--pretty=%s"], cwd=repo),
+        "committedAt": run(["git", "log", "-1", "--pretty=%cI"], cwd=repo),
+        "workingTree": "clean" if not status else "dirty",
+    }
+
+
+def toolchain_facts():
+    product = run(["sw_vers", "-productName"])
+    version = run(["sw_vers", "-productVersion"])
+    kernel = run(["uname", "-sr"])
+    return {
+        "xcode": run(["xcodebuild", "-version"]),
+        "xcresulttool": run(["xcrun", "xcresulttool", "version"]),
+        "swift": run(["swift", "--version"]),
+        "node": run(["node", "--version"]),
+        "os": f"{product} {version} ({kernel})" if product else kernel,
+        "display": (
+            "Screenshots on both sides are captured at 2x. `screencapture` "
+            "follows the display's backing scale, so a non-Retina display "
+            "produces 1x Xcode shots against 2x ours — check pixelWidth in the "
+            "inventory before comparing weights across runs."
+        ),
+    }
+
+
+def fixture_facts(bundle):
+    if not bundle or not os.path.isdir(bundle):
+        return {"bundle": bundle, "exists": False}
+
+    facts = {
+        "bundle": bundle,
+        "exists": True,
+        "generatedBy": "./prepareTestResults.sh (unless --fixture pointed elsewhere)",
+        "sizeOnDisk": human_bytes(directory_bytes(bundle)),
+    }
+
+    info_plist = os.path.join(bundle, "Info.plist")
+    stamp = info_plist if os.path.exists(info_plist) else bundle
+    try:
+        facts["generatedAt"] = iso(os.path.getmtime(stamp))
+    except OSError:
+        facts["generatedAt"] = None
+
+    summary = run(["xcrun", "xcresulttool", "get", "test-results", "summary", "--path", bundle])
+    if summary:
+        try:
+            parsed = json.loads(summary)
+        except ValueError:
+            parsed = {}
+        facts["content"] = {
+            key: parsed.get(key)
+            for key in (
+                "totalTestCount",
+                "passedTests",
+                "failedTests",
+                "skippedTests",
+                "expectedFailures",
+                "startTime",
+                "finishTime",
+            )
+            if key in parsed
+        }
+        devices = parsed.get("devicesAndConfigurations") or []
+        facts["content"]["devices"] = [
+            (entry.get("device") or {}).get("deviceName")
+            for entry in devices
+            if isinstance(entry, dict)
+        ]
+
+    return facts
+
+
+def inventory(out_dir, ours, xcode):
+    """Merges the two capture sides into one list, ordered for a comparison page.
+
+    Side records come from the capture scripts, which know the intent (which
+    view, which appearance, whether a human drove it). The pixel facts are read
+    off the files here, so a shot that silently came out at the wrong size is
+    visible in the manifest instead of only in the image.
+    """
+    records = []
+    for side in (ours, xcode):
+        for shot in (side or {}).get("shots", []):
+            path = os.path.join(out_dir, shot["file"])
+            width, height = png_size(path)
+            record = dict(shot)
+            record["exists"] = os.path.exists(path)
+            record["pixelWidth"] = width
+            record["pixelHeight"] = height
+            record["bytes"] = os.path.getsize(path) if record["exists"] else None
+            record["sha256"] = digest(path)
+            records.append(record)
+
+    order = {"summary": 0, "overview": 1, "tests": 2, "tests-all": 3, "logs": 4}
+    records.sort(
+        key=lambda r: (
+            order.get(r.get("view"), 99),
+            r.get("colorScheme") or "",
+            r.get("width") or 0,
+            r.get("side") or "",
+        )
+    )
+    return records
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out", required=True, help="run directory to write manifest.json into")
+    parser.add_argument("--repo", default=".", help="repository checkout the render came from")
+    parser.add_argument("--fixture", default=None, help="the .xcresult both sides were shown")
+    parser.add_argument("--render-command", default=None, help="how the report was rendered")
+    parser.add_argument("--result-reader", default=None, help="--result-reader the render used")
+    parser.add_argument("--invocation", default=None, help="the command line that started the run")
+    args = parser.parse_args(argv)
+
+    out_dir = os.path.abspath(args.out)
+    ours = read_json(os.path.join(out_dir, "ours-shots.json"))
+    xcode = read_json(os.path.join(out_dir, "xcode-shots.json"))
+
+    rendered = os.path.join(out_dir, "report", "index.html")
+    manifest = {
+        "purpose": PURPOSE,
+        "capturedAt": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "harness": {
+            "tool": "scripts/viewer-compare",
+            "invocation": args.invocation,
+            "runDirectory": out_dir,
+        },
+        "toolchain": toolchain_facts(),
+        "git": git_facts(os.path.abspath(args.repo)),
+        "fixture": fixture_facts(args.fixture),
+        "render": {
+            "command": args.render_command,
+            "resultReader": args.result_reader,
+            "renderedHtml": "report/index.html",
+            "renderedHtmlBytes": (
+                os.path.getsize(rendered) if os.path.exists(rendered) else None
+            ),
+        },
+        "capture": {"ours": ours, "xcode": xcode},
+        "screenshots": inventory(out_dir, ours, xcode),
+    }
+
+    # The shot lists are already inventoried above with their pixel facts;
+    # repeating them inside `capture` would double the file for no reader.
+    for side in ("ours", "xcode"):
+        if isinstance(manifest["capture"][side], dict):
+            manifest["capture"][side].pop("shots", None)
+
+    path = os.path.join(out_dir, "manifest.json")
+    with open(path, "w", encoding="utf-8") as handle:
+        json.dump(manifest, handle, indent=2)
+        handle.write("\n")
+
+    missing = [r["file"] for r in manifest["screenshots"] if not r["exists"]]
+    print(f"manifest: {len(manifest['screenshots'])} shots -> {path}")
+    if missing:
+        print(f"manifest: {len(missing)} inventoried shot(s) missing on disk: {', '.join(missing)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/viewer-compare/viewer_compare.sh
+++ b/scripts/viewer-compare/viewer_compare.sh
@@ -1,0 +1,248 @@
+#!/bin/bash
+# One command that puts Xcode's test-report viewer and ours side by side over
+# the same .xcresult, and leaves a run directory a comparison can be written
+# from months later.
+#
+#   scripts/viewer-compare/viewer_compare.sh
+#
+# See README.md in this directory for when to run it and what it needs.
+#
+# Local-only by design: the Xcode half drives a GUI, which is exactly the kind
+# of thing that flakes on a CI runner. Nothing here is wired into a workflow,
+# and it should stay that way — the FUNCTIONAL half of new-Xcode coverage is
+# .github/workflows/toolchain-drift.yml.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "${HERE}/../.." && pwd)"
+
+FIXTURE="${REPO}/Tests/XCTestHTMLReportTests/Resources/TestResults.xcresult"
+OUT=""
+RESULT_READER=""
+PORT=""
+SKIP_OURS=0
+SKIP_XCODE=0
+XCODE_ARGS=()
+
+usage() {
+    cat <<'EOF'
+Usage: viewer_compare.sh [options]
+
+  --fixture PATH        .xcresult to show both viewers
+                        (default Tests/XCTestHTMLReportTests/Resources/TestResults.xcresult)
+  --out DIR             run directory (default .viewer-compare/<UTC timestamp>)
+  --result-reader NAME  auto | legacy | modern, passed through to xchtmlreport
+  --port N              port for the local report server (default: first free one)
+  --skip-ours           do not capture this checkout's report
+  --skip-xcode          do not capture Xcode's viewer
+  --manual              drive every Xcode view switch by prompt
+  --with-tests-all      add a guided shot of Xcode's Tests view, All Tests filter
+  -h, --help            this text
+
+Everything after `--` is passed to capture_xcode.sh unchanged.
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+    --fixture)
+        FIXTURE="$2"
+        shift 2
+        ;;
+    --out)
+        OUT="$2"
+        shift 2
+        ;;
+    --result-reader)
+        RESULT_READER="$2"
+        shift 2
+        ;;
+    --port)
+        PORT="$2"
+        shift 2
+        ;;
+    --skip-ours)
+        SKIP_OURS=1
+        shift
+        ;;
+    --skip-xcode)
+        SKIP_XCODE=1
+        shift
+        ;;
+    --manual | --with-tests-all)
+        XCODE_ARGS+=("$1")
+        shift
+        ;;
+    --)
+        shift
+        while [ "$#" -gt 0 ]; do
+            XCODE_ARGS+=("$1")
+            shift
+        done
+        ;;
+    -h | --help)
+        usage
+        exit 0
+        ;;
+    *)
+        echo "viewer_compare.sh: unknown argument: $1" >&2
+        usage >&2
+        exit 2
+        ;;
+    esac
+done
+
+INVOCATION="viewer_compare.sh $*"
+
+if [ "$(uname)" != "Darwin" ]; then
+    echo "viewer_compare.sh: macOS only — the comparison needs Xcode's own viewer" >&2
+    exit 1
+fi
+
+for tool in swift python3 node osascript; do
+    if ! command -v "$tool" >/dev/null 2>&1; then
+        echo "viewer_compare.sh: missing required tool: ${tool}" >&2
+        exit 1
+    fi
+done
+
+if [ ! -d "$FIXTURE" ]; then
+    cat >&2 <<EOF
+viewer_compare.sh: no fixture at ${FIXTURE}
+
+Generate the repository fixtures first (boots a simulator, takes a few minutes):
+
+    ./prepareTestResults.sh
+
+or point at a bundle you already have with --fixture.
+EOF
+    exit 1
+fi
+FIXTURE="$(cd "$(dirname "$FIXTURE")" && pwd)/$(basename "$FIXTURE")"
+
+if [ -z "$OUT" ]; then
+    OUT="${REPO}/.viewer-compare/$(date -u +%Y%m%dT%H%M%SZ)"
+fi
+mkdir -p "$OUT"
+OUT="$(cd "$OUT" && pwd)"
+
+echo "viewer-compare: run directory ${OUT}"
+
+# --- build and render ------------------------------------------------------
+
+echo "viewer-compare: building xchtmlreport (release)"
+swift build -c release --package-path "$REPO"
+BINARY="$(swift build -c release --package-path "$REPO" --show-bin-path)/xchtmlreport"
+
+# Render from a copy INSIDE the report directory, for two reasons.
+#
+# `--rendering-mode linking` writes hrefs of the form `<bundle>/<attachment>`,
+# relative to index.html, and the renderer exports every attachment into the
+# bundle directory itself. Serve a report directory that does not contain the
+# bundle and every screenshot, video and log in the report 404s — invisibly, in
+# shots that otherwise look fine.
+#
+# And a copy rather than the fixture in the tree, because that export step
+# writes into the bundle: pointing it at Tests/.../TestResults.xcresult would
+# leave the checked-out fixture modified.
+mkdir -p "${OUT}/report"
+BUNDLE_COPY="${OUT}/report/$(basename "$FIXTURE")"
+rm -rf "$BUNDLE_COPY"
+ditto "$FIXTURE" "$BUNDLE_COPY"
+
+RENDER_CMD=("$BINARY" --rendering-mode linking -o "${OUT}/report")
+if [ -n "$RESULT_READER" ]; then
+    RENDER_CMD+=(--result-reader "$RESULT_READER")
+fi
+RENDER_CMD+=("$BUNDLE_COPY")
+
+echo "viewer-compare: rendering ${BUNDLE_COPY##*/}"
+"${RENDER_CMD[@]}"
+
+if [ ! -f "${OUT}/report/index.html" ]; then
+    echo "viewer_compare.sh: render produced no ${OUT}/report/index.html" >&2
+    exit 1
+fi
+
+# --- ours ------------------------------------------------------------------
+
+SERVER_PID=""
+stop_server() {
+    if [ -n "$SERVER_PID" ]; then
+        kill "$SERVER_PID" 2>/dev/null || true
+        wait "$SERVER_PID" 2>/dev/null || true
+        SERVER_PID=""
+    fi
+}
+trap stop_server EXIT
+
+if [ "$SKIP_OURS" -eq 0 ]; then
+    if [ ! -d "${REPO}/visual/node_modules" ]; then
+        echo "viewer-compare: installing visual/ dependencies (npm ci)"
+        (cd "${REPO}/visual" && npm ci)
+    fi
+    if ! (cd "${REPO}/visual" && node -e "require('playwright')" >/dev/null 2>&1); then
+        echo "viewer_compare.sh: playwright is not usable in visual/node_modules" >&2
+        exit 1
+    fi
+    # Chromium is downloaded once into the shared Playwright cache; this is a
+    # no-op on a machine that has already run the visual suite.
+    (cd "${REPO}/visual" && npx --no-install playwright install chromium >/dev/null)
+
+    if [ -z "$PORT" ]; then
+        PORT="$(python3 -c '
+import socket
+s = socket.socket()
+s.bind(("127.0.0.1", 0))
+print(s.getsockname()[1])
+s.close()
+')"
+    fi
+
+    # A server rather than file:// — the report loads its attachments over HTTP,
+    # and file:// would fail them silently in a way the shots would not show.
+    python3 -m http.server "$PORT" --bind 127.0.0.1 --directory "${OUT}/report" >"${OUT}/server.log" 2>&1 &
+    SERVER_PID=$!
+
+    ready=0
+    for _ in $(seq 1 40); do
+        if curl -fsS -o /dev/null "http://127.0.0.1:${PORT}/index.html" 2>/dev/null; then
+            ready=1
+            break
+        fi
+        sleep 0.25
+    done
+    if [ "$ready" -ne 1 ]; then
+        echo "viewer_compare.sh: local server never answered on port ${PORT} (see ${OUT}/server.log)" >&2
+        exit 1
+    fi
+    echo "viewer-compare: serving report on http://127.0.0.1:${PORT}/"
+
+    VC_OUT="$OUT" VC_URL="http://127.0.0.1:${PORT}/index.html" \
+        node "${HERE}/capture_ours.mjs"
+
+    stop_server
+fi
+
+# --- xcode -----------------------------------------------------------------
+
+if [ "$SKIP_XCODE" -eq 0 ]; then
+    echo
+    echo "viewer-compare: handing the screen to Xcode — do not use the machine until this finishes"
+    echo
+    "${HERE}/capture_xcode.sh" --bundle "$BUNDLE_COPY" --out "$OUT" ${XCODE_ARGS[@]+"${XCODE_ARGS[@]}"}
+fi
+
+# --- manifest --------------------------------------------------------------
+
+python3 "${HERE}/make_manifest.py" \
+    --out "$OUT" \
+    --repo "$REPO" \
+    --fixture "$FIXTURE" \
+    --render-command "${RENDER_CMD[*]}" \
+    --result-reader "${RESULT_READER:-auto (default)}" \
+    --invocation "$INVOCATION"
+
+echo
+echo "viewer-compare: done"
+echo "  ${OUT}"

--- a/scripts/viewer-compare/viewer_compare.sh
+++ b/scripts/viewer-compare/viewer_compare.sh
@@ -16,6 +16,11 @@ set -euo pipefail
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO="$(cd "${HERE}/../.." && pwd)"
 
+# Captured before the parse loop below shifts it all away. The manifest records
+# this, and "which flags was that run given" is most of what a reader wants from
+# a run directory that does not match the one next to it.
+INVOCATION="viewer_compare.sh $*"
+
 FIXTURE="${REPO}/Tests/XCTestHTMLReportTests/Resources/TestResults.xcresult"
 OUT=""
 RESULT_READER=""
@@ -91,8 +96,6 @@ while [ "$#" -gt 0 ]; do
         ;;
     esac
 done
-
-INVOCATION="viewer_compare.sh $*"
 
 if [ "$(uname)" != "Darwin" ]; then
     echo "viewer_compare.sh: macOS only — the comparison needs Xcode's own viewer" >&2

--- a/scripts/viewer-compare/viewer_compare.sh
+++ b/scripts/viewer-compare/viewer_compare.sh
@@ -229,11 +229,18 @@ fi
 
 # --- xcode -----------------------------------------------------------------
 
+XCODE_STATUS=0
 if [ "$SKIP_XCODE" -eq 0 ]; then
     echo
     echo "viewer-compare: handing the screen to Xcode — do not use the machine until this finishes"
     echo
-    "${HERE}/capture_xcode.sh" --bundle "$BUNDLE_COPY" --out "$OUT" ${XCODE_ARGS[@]+"${XCODE_ARGS[@]}"}
+    # Deliberately not under `set -e`. The Xcode half is the half that fails —
+    # a denied permission, an Xcode that never finished indexing — and it fails
+    # AFTER our side has already been captured. Aborting here would throw away
+    # the manifest, which is the one artefact that would have said which Xcode
+    # refused and what was captured before it did. Write the manifest, then
+    # carry the failure out in the exit status.
+    "${HERE}/capture_xcode.sh" --bundle "$BUNDLE_COPY" --out "$OUT" ${XCODE_ARGS[@]+"${XCODE_ARGS[@]}"} || XCODE_STATUS=$?
 fi
 
 # --- manifest --------------------------------------------------------------
@@ -247,5 +254,11 @@ python3 "${HERE}/make_manifest.py" \
     --invocation "$INVOCATION"
 
 echo
+if [ "$XCODE_STATUS" -ne 0 ]; then
+    echo "viewer-compare: the Xcode half failed (exit ${XCODE_STATUS}); our side and the manifest are still in"
+    echo "  ${OUT}"
+    exit "$XCODE_STATUS"
+fi
+
 echo "viewer-compare: done"
 echo "  ${OUT}"

--- a/scripts/viewer-compare/xcode_ui.applescript
+++ b/scripts/viewer-compare/xcode_ui.applescript
@@ -4,6 +4,7 @@
 -- accessibility paths this depends on — which are the part that breaks when
 -- Xcode ships a new report viewer — are all in one place to re-derive.
 --
+--   osascript xcode_ui.applescript check-accessibility
 --   osascript xcode_ui.applescript get-appearance
 --   osascript xcode_ui.applescript set-appearance dark|light
 --   osascript xcode_ui.applescript find <bundle-basename>
@@ -23,14 +24,18 @@
 -- the caller decides whether to fall back to a guided manual step rather than
 -- dying on a `set -e` trip.
 --
--- Requires Accessibility permission for whatever runs osascript (Terminal,
--- iTerm, the editor's shell — the prompt names it). Xcode 26.2 verified.
+-- Requires two separate grants for whatever runs osascript (Terminal, iTerm,
+-- the editor's shell — the prompt names it): Automation, to talk to System
+-- Events at all, and Accessibility, for every UI-element read below.
+-- `check-accessibility` is the probe for the second one. Xcode 26.2 verified.
 
 on run argv
 	if (count of argv) < 1 then return "ERR|usage: xcode_ui.applescript <command> [args]"
 	set cmd to item 1 of argv
 	try
-		if cmd is "get-appearance" then
+		if cmd is "check-accessibility" then
+			return checkAccessibility()
+		else if cmd is "get-appearance" then
 			return getAppearance()
 		else if cmd is "set-appearance" then
 			return setAppearance(item 2 of argv)
@@ -48,6 +53,35 @@ on run argv
 		return "ERR|" & msg
 	end try
 end run
+
+-- Accessibility and Automation are independently grantable, and the appearance
+-- handlers below need only Automation: `appearance preferences` is a scripting
+-- property of System Events, not a UI element. Everything else in this file
+-- reads UI elements — windows, outlines, rows — which is the part Accessibility
+-- gates. So a caller that checks its permissions by calling `get-appearance`
+-- learns nothing about the grant it actually depends on.
+--
+-- This is that check: one read of another process's UI-element tree, no side
+-- effect, nothing typed, nothing brought forward. The Dock is the target
+-- because it is always running in a GUI login session and has no windows to
+-- enumerate; the count is thrown away, only the error matters. Without the
+-- grant this returns macOS's own "not allowed assistive access" (-25211);
+-- without Automation it returns "Not authorized to send Apple events" (-1743),
+-- and the caller's message names both.
+on checkAccessibility()
+	tell application "System Events"
+		try
+			set windowCount to count of (windows of application process "Dock")
+		on error msg
+			-- Asked only after the read has already failed, so a machine with
+			-- no Dock is not reported as a permission problem and a permission
+			-- problem is never reported as a missing Dock.
+			if not (exists application process "Dock") then return "ERR|no Dock process — not a GUI login session?"
+			return "ERR|" & msg
+		end try
+	end tell
+	return "OK|" & (windowCount as string) & " Dock windows"
+end checkAccessibility
 
 -- Xcode's report viewer has no appearance of its own; it follows the system,
 -- which is why the harness moves the whole machine between shots and puts the

--- a/scripts/viewer-compare/xcode_ui.applescript
+++ b/scripts/viewer-compare/xcode_ui.applescript
@@ -1,0 +1,212 @@
+-- Xcode UI automation for the viewer-compare harness.
+--
+-- One file with a command dispatcher rather than five one-liner scripts, so the
+-- accessibility paths this depends on — which are the part that breaks when
+-- Xcode ships a new report viewer — are all in one place to re-derive.
+--
+--   osascript xcode_ui.applescript get-appearance
+--   osascript xcode_ui.applescript set-appearance dark|light
+--   osascript xcode_ui.applescript find <bundle-basename>
+--   osascript xcode_ui.applescript pin <winIndex> <x> <y> <w> <h>
+--   osascript xcode_ui.applescript select <winIndex> summary|tests|logs
+--   osascript xcode_ui.applescript rows <winIndex>
+--
+-- Every command prints one line. Failures print "ERR|<reason>" and exit 0, so
+-- the caller decides whether to fall back to a guided manual step rather than
+-- dying on a `set -e` trip.
+--
+-- Requires Accessibility permission for whatever runs osascript (Terminal,
+-- iTerm, the editor's shell — the prompt names it). Xcode 26.2 verified.
+
+on run argv
+	if (count of argv) < 1 then return "ERR|usage: xcode_ui.applescript <command> [args]"
+	set cmd to item 1 of argv
+	try
+		if cmd is "get-appearance" then
+			return getAppearance()
+		else if cmd is "set-appearance" then
+			return setAppearance(item 2 of argv)
+		else if cmd is "find" then
+			return findReportWindow(item 2 of argv)
+		else if cmd is "pin" then
+			return pinWindow(item 2 of argv, item 3 of argv, item 4 of argv, item 5 of argv, item 6 of argv)
+		else if cmd is "select" then
+			return selectView(item 2 of argv, item 3 of argv)
+		else if cmd is "rows" then
+			return listRows(item 2 of argv)
+		end if
+		return "ERR|unknown command " & cmd
+	on error msg
+		return "ERR|" & msg
+	end try
+end run
+
+-- Xcode's report viewer has no appearance of its own; it follows the system,
+-- which is why the harness moves the whole machine between shots and puts the
+-- original value back afterwards.
+on getAppearance()
+	tell application "System Events"
+		tell appearance preferences
+			if dark mode then return "dark"
+			return "light"
+		end tell
+	end tell
+end getAppearance
+
+on setAppearance(mode)
+	tell application "System Events"
+		tell appearance preferences
+			set dark mode to (mode is "dark")
+		end tell
+	end tell
+	return mode
+end setAppearance
+
+-- Identifies the report window by what it contains, not by its title: a window
+-- opened straight onto an .xcresult has an EMPTY title bar, and when a project
+-- is already open the bundle's window sits alongside one titled after the
+-- project. The discriminator is the first row of the Report navigator, which is
+-- the bundle's own filename.
+--
+-- System Events orders windows front to back, and this returns the FIRST match.
+-- That matters when a previous run left a window open on a different bundle
+-- with the same filename: `open -a Xcode` puts the one just asked for in front,
+-- so the frontmost match is the right one.
+--
+-- Prints "idx|x|y|w|h|rowCount".
+on findReportWindow(bundleName)
+	tell application "System Events" to tell process "Xcode"
+		repeat with i from 1 to (count of windows)
+			try
+				set w to window i
+				set ol to outline 1 of scroll area 1 of group 1 of w
+				set rws to rows of ol
+				if (count of rws) > 0 then
+					if my rowLabel(item 1 of rws) is bundleName then
+						set p to position of w
+						set s to size of w
+						return (i as string) & "|" & (item 1 of p as string) & "|" & (item 2 of p as string) & "|" & (item 1 of s as string) & "|" & (item 2 of s as string) & "|" & ((count of rws) as string)
+					end if
+				end if
+			end try
+		end repeat
+	end tell
+	return "ERR|no Xcode window whose report navigator starts with " & bundleName
+end findReportWindow
+
+-- Prints "x|y|w|h" as the window actually ended up. The caller compares that
+-- against what it asked for: Xcode refuses sizes below its own minimum, and a
+-- silently smaller window would put the two sides at different logical widths
+-- while every filename still claimed 1440.
+on pinWindow(idx, px, py, pw, ph)
+	set theIndex to idx as integer
+	tell application "System Events" to tell process "Xcode"
+		set w to window theIndex
+		set position of w to {px as integer, py as integer}
+		set size of w to {pw as integer, ph as integer}
+		set p to position of w
+		set s to size of w
+		return (item 1 of p as string) & "|" & (item 2 of p as string) & "|" & (item 1 of s as string) & "|" & (item 2 of s as string)
+	end tell
+end pinWindow
+
+on listRows(idx)
+	set theIndex to idx as integer
+	tell application "System Events" to tell process "Xcode"
+		set ol to outline 1 of scroll area 1 of group 1 of window theIndex
+		set out to ""
+		repeat with r in (rows of ol)
+			if out is not "" then set out to out & "|"
+			set out to out & my rowLabel(r)
+		end repeat
+		return out
+	end tell
+end listRows
+
+-- Selects a view by moving the Report navigator's selection with the arrow
+-- keys.
+--
+-- Setting `selected of row` directly does NOT work: the row highlights and the
+-- editor keeps showing whatever it showed before, because the AX write never
+-- reaches the outline's selection delegate. `click at {x, y}` does not work
+-- either. A keyboard press on the focused outline is the one gesture Xcode 26.2
+-- treats as a real navigation — and it only lands when Xcode is frontmost,
+-- which is why this activates first and why the harness cannot share the
+-- machine with someone else's typing while it runs.
+on selectView(idx, mode)
+	set theIndex to idx as integer
+	tell application "Xcode" to activate
+	delay 0.8
+	tell application "System Events" to tell process "Xcode"
+		set ol to outline 1 of scroll area 1 of group 1 of window theIndex
+		set rws to rows of ol
+		set n to (count of rws)
+		if n = 0 then return "ERR|report navigator is empty"
+
+		set labels to {}
+		repeat with i from 1 to n
+			set end of labels to my rowLabel(item i of rws)
+		end repeat
+
+		set target to 0
+		repeat with i from 1 to n
+			set lbl to item i of labels
+			if mode is "tests" and lbl is "Tests" then
+				set target to i
+			else if mode is "logs" and (lbl is "Log" or lbl is "Logs") then
+				set target to i
+			else if mode is "summary" and target is 0 and i > 1 then
+				-- The summary row is named after the scheme, so it cannot be
+				-- matched by name across projects. It is the first row under
+				-- the bundle that is not one of the named sub-reports.
+				if lbl is not "Tests" and lbl is not "Log" and lbl is not "Logs" and lbl does not end with "Insights" then set target to i
+			end if
+		end repeat
+		if target is 0 then return "ERR|no report-navigator row matched " & mode & " (rows: " & my joinList(labels) & ")"
+
+		set focused of ol to true
+		delay 0.3
+
+		-- Bounded: a row that will not take the selection must surface as a
+		-- failure the caller can fall back from, not as a spin.
+		repeat 16 times
+			set cur to 0
+			repeat with i from 1 to n
+				if selected of (item i of rws) then set cur to i
+			end repeat
+			if cur is target then return "OK|" & (item target of labels)
+			if cur is 0 or cur < target then
+				key code 125 -- down arrow
+			else
+				key code 126 -- up arrow
+			end if
+			delay 0.35
+		end repeat
+		return "ERR|selection never reached " & mode & " row"
+	end tell
+end selectView
+
+on rowLabel(r)
+	set lbl to ""
+	tell application "System Events"
+		repeat with t in (static texts of UI element 1 of r)
+			try
+				set v to (value of t) as string
+				if v is not "" then
+					if lbl is not "" then set lbl to lbl & " "
+					set lbl to lbl & v
+				end if
+			end try
+		end repeat
+	end tell
+	return lbl
+end rowLabel
+
+on joinList(items_)
+	set out to ""
+	repeat with x in items_
+		if out is not "" then set out to out & ", "
+		set out to out & (x as string)
+	end repeat
+	return out
+end joinList

--- a/scripts/viewer-compare/xcode_ui.applescript
+++ b/scripts/viewer-compare/xcode_ui.applescript
@@ -7,9 +7,17 @@
 --   osascript xcode_ui.applescript get-appearance
 --   osascript xcode_ui.applescript set-appearance dark|light
 --   osascript xcode_ui.applescript find <bundle-basename>
---   osascript xcode_ui.applescript pin <winIndex> <x> <y> <w> <h>
---   osascript xcode_ui.applescript select <winIndex> summary|tests|logs
---   osascript xcode_ui.applescript rows <winIndex>
+--   osascript xcode_ui.applescript pin <bundle-basename> <x> <y> <w> <h>
+--   osascript xcode_ui.applescript select <bundle-basename> summary|tests|logs
+--   osascript xcode_ui.applescript rows <bundle-basename>
+--
+-- Everything addresses the window by the bundle it is showing, never by a
+-- window index the caller resolved earlier. System Events numbers windows by
+-- z-order, `select` has to bring Xcode forward to send keystrokes, and a run
+-- that left a window open on a same-named bundle puts a second candidate in the
+-- list — so an index captured a step ago can name a different window by the
+-- time it is used. Re-resolving inside each command removes that race instead
+-- of narrowing it.
 --
 -- Every command prints one line. Failures print "ERR|<reason>" and exit 0, so
 -- the caller decides whether to fall back to a guided manual step rather than
@@ -74,32 +82,40 @@ end setAppearance
 -- so the frontmost match is the right one.
 --
 -- Prints "idx|x|y|w|h|rowCount".
-on findReportWindow(bundleName)
+on windowIndexFor(bundleName)
 	tell application "System Events" to tell process "Xcode"
 		repeat with i from 1 to (count of windows)
 			try
-				set w to window i
-				set ol to outline 1 of scroll area 1 of group 1 of w
+				set ol to outline 1 of scroll area 1 of group 1 of window i
 				set rws to rows of ol
 				if (count of rws) > 0 then
-					if my rowLabel(item 1 of rws) is bundleName then
-						set p to position of w
-						set s to size of w
-						return (i as string) & "|" & (item 1 of p as string) & "|" & (item 2 of p as string) & "|" & (item 1 of s as string) & "|" & (item 2 of s as string) & "|" & ((count of rws) as string)
-					end if
+					if my rowLabel(item 1 of rws) is bundleName then return i
 				end if
 			end try
 		end repeat
 	end tell
-	return "ERR|no Xcode window whose report navigator starts with " & bundleName
+	return 0
+end windowIndexFor
+
+on findReportWindow(bundleName)
+	set i to my windowIndexFor(bundleName)
+	if i is 0 then return "ERR|no Xcode window whose report navigator starts with " & bundleName
+	tell application "System Events" to tell process "Xcode"
+		set w to window i
+		set p to position of w
+		set s to size of w
+		set n to count of (rows of (outline 1 of scroll area 1 of group 1 of w))
+		return (i as string) & "|" & (item 1 of p as string) & "|" & (item 2 of p as string) & "|" & (item 1 of s as string) & "|" & (item 2 of s as string) & "|" & (n as string)
+	end tell
 end findReportWindow
 
 -- Prints "x|y|w|h" as the window actually ended up. The caller compares that
 -- against what it asked for: Xcode refuses sizes below its own minimum, and a
 -- silently smaller window would put the two sides at different logical widths
 -- while every filename still claimed 1440.
-on pinWindow(idx, px, py, pw, ph)
-	set theIndex to idx as integer
+on pinWindow(bundleName, px, py, pw, ph)
+	set theIndex to my windowIndexFor(bundleName)
+	if theIndex is 0 then return "ERR|no report window for " & bundleName & " to pin"
 	tell application "System Events" to tell process "Xcode"
 		set w to window theIndex
 		set position of w to {px as integer, py as integer}
@@ -110,8 +126,9 @@ on pinWindow(idx, px, py, pw, ph)
 	end tell
 end pinWindow
 
-on listRows(idx)
-	set theIndex to idx as integer
+on listRows(bundleName)
+	set theIndex to my windowIndexFor(bundleName)
+	if theIndex is 0 then return "ERR|no report window for " & bundleName
 	tell application "System Events" to tell process "Xcode"
 		set ol to outline 1 of scroll area 1 of group 1 of window theIndex
 		set out to ""
@@ -133,10 +150,14 @@ end listRows
 -- treats as a real navigation — and it only lands when Xcode is frontmost,
 -- which is why this activates first and why the harness cannot share the
 -- machine with someone else's typing while it runs.
-on selectView(idx, mode)
-	set theIndex to idx as integer
+on selectView(bundleName, mode)
+	-- Activate FIRST, then resolve: bringing Xcode forward is what can reorder
+	-- the window list, so an index resolved before this point is exactly the
+	-- one that goes stale.
 	tell application "Xcode" to activate
 	delay 0.8
+	set theIndex to my windowIndexFor(bundleName)
+	if theIndex is 0 then return "ERR|no report window for " & bundleName & " to select " & mode & " in"
 	tell application "System Events" to tell process "Xcode"
 		set ol to outline 1 of scroll area 1 of group 1 of window theIndex
 		set rws to rows of ol

--- a/scripts/viewer-compare/xcode_windows.js
+++ b/scripts/viewer-compare/xcode_windows.js
@@ -1,0 +1,45 @@
+// Lists Xcode's on-screen windows as JSON, including the CGWindowID that
+// `screencapture -l` needs. AppleScript cannot see a CGWindowID at all — the
+// System Events window object exposes position and size but no window number —
+// so this reaches CGWindowListCopyWindowInfo through JXA's ObjC bridge.
+//
+// JXA rather than a Swift helper on purpose: osascript is already a dependency
+// of the Xcode side, while a .swift file in this repository would be linted by
+// SwiftFormat and SwiftLint in CI for no benefit.
+//
+// Usage: osascript -l JavaScript xcode_windows.js [ownerName]
+// Prints a JSON array of {id, x, y, width, height, title, layer}, ordered
+// front to back, restricted to layer 0 (normal document windows — this filters
+// out Xcode's tooltips, popovers and sheets, which would otherwise be picked
+// up as "the new window" right after a bundle opens).
+
+ObjC.import('CoreGraphics');
+ObjC.import('Foundation');
+
+function run(argv) {
+    const owner = argv.length > 0 ? argv[0] : 'Xcode';
+
+    // kCGWindowListOptionOnScreenOnly (1) | kCGWindowListExcludeDesktopElements (16).
+    // The named constants come back undefined through the JXA bridge, so the
+    // literal values are used with the names recorded here.
+    const ref = $.CGWindowListCopyWindowInfo(1 | 16, 0);
+    const list = ObjC.castRefToObject(ref);
+
+    const windows = [];
+    for (let i = 0; i < list.count; i++) {
+        const w = ObjC.deepUnwrap(list.objectAtIndex(i));
+        if (w.kCGWindowOwnerName !== owner) continue;
+        if (w.kCGWindowLayer !== 0) continue;
+        const b = w.kCGWindowBounds;
+        windows.push({
+            id: w.kCGWindowNumber,
+            x: b.X,
+            y: b.Y,
+            width: b.Width,
+            height: b.Height,
+            title: w.kCGWindowName || '',
+            layer: w.kCGWindowLayer,
+        });
+    }
+    return JSON.stringify(windows);
+}


### PR DESCRIPTION
Refs #439.

The Xcode-viewer comparison has been run by hand twice now, and both times the scripts that did it died with the scratch directory they lived in. The PNGs survived; the ability to ask the question again did not. Apple reworks the report viewer without announcing it, so this is a question with a schedule — every new Xcode, every beta worth a look — and it deserves something checked in.

## What this adds

`scripts/viewer-compare/viewer_compare.sh` — one command that builds the checkout, renders a fixture, captures our side headlessly, then hands the screen to Xcode and captures the same three views there.

```sh
scripts/viewer-compare/viewer_compare.sh
```

Output is one timestamped directory under `.viewer-compare/` (git-ignored) holding the rendered report, the paired PNGs, and a `manifest.json` recording the Xcode and `xcresulttool` versions, the OS, the commit and whether the tree was dirty, the fixture's test counts and generation time, the exact render command, and every shot's view, viewport, appearance, pixel size, SHA-256 and whether a human drove it. A comparison page can be rebuilt from a run directory and nothing else.

| | ours | Xcode |
|---|---|---|
| summary / tests / logs | 1440 light + dark, 375 light | 1440 light + dark |
| overview (window as loaded) | same three | — |

## Local-only, deliberately

Not wired into any workflow, and it should stay that way — driving Xcode's GUI on a hosted runner is the reliable way to manufacture a flaky check. The **functional** half of new-Xcode coverage already has a home in `toolchain-drift.yml`; this is the **visual/UX** half, and the README points between the two.

## The three Xcode 26.2 facts that cost the previous runs the most time

All now written down in `xcode_ui.applescript`, because they are exactly what a new Xcode will invalidate:

- **A window opened straight onto an `.xcresult` has an empty title**, and when a project is already open it sits beside a window named after the project. Title matching finds nothing. The window is identified by the first row of its Report navigator — the bundle's own filename — and, when a stale run left a same-named window open, by taking the frontmost match.
- **Setting a navigator row's AX `selected` attribute highlights the row without navigating.** The editor keeps showing the previous view, so every shot comes out identical and reads as a capture bug rather than a selection one. A synthetic click does not land either. Arrow keys on the focused outline do — and only while Xcode is frontmost.
- **`screencapture` needs a CGWindowID, which AppleScript cannot see at all.** `xcode_windows.js` reaches `CGWindowListCopyWindowInfo` through JXA's ObjC bridge, rather than adding a `.swift` file CI would lint for no benefit.

## Two bugs worth naming

- **The ours side goes through `playwright`, not `playwright-core`.** `visual/package-lock.json` hoists a *second* `playwright-core` to the top of that tree — a transitive dependency of `@axe-core/playwright` on a looser range, two minor versions ahead of the one `@playwright/test` runs, wanting a browser build `playwright install` never fetched. The first draft launched it and failed. Going through `playwright` lands on the browser the visual suite and CI use.
- **The bundle is copied *inside* the served report directory.** `--rendering-mode linking` writes hrefs relative to `index.html`, and the renderer exports attachments into the bundle itself; serving a report directory without the bundle 404s every screenshot, video and log — invisibly, in shots that otherwise look correct. The first draft did exactly that. `capture_ours.mjs` now warns loudly on any non-favicon 404.

## Degradation

Every version-fragile step falls back to a numbered prompt instead of aborting, and the manifest records `automated: false` for shots a human drove — a half-automated run stays honest about which half. Xcode's Tests-view status filter is a prompt by design (`--with-tests-all`): its items carry live counts (`All Tests (21)`), so matching them by name is a guess that changes with the fixture. `--manual` puts every view switch behind a prompt, for the day a new Xcode moves the tree far enough that nothing matches.

## Verification

Ran end to end on this machine — Xcode 26.2 (17C52), macOS 15.6, Swift 6.2.3:

```
capture_xcode: report window found after 1s
capture_xcode: window pinned at 60,100 1440x900
capture_xcode: xcode-summary/tests/logs-1440-{light,dark}.png (automated) x6
capture_xcode: system appearance restored to dark
manifest: 18 shots
```

18 shots, 18 distinct digests, all six Xcode shots automated, no manual fallback needed, system appearance restored. Xcode shots verified by eye to be the right view in the right appearance.

`make_manifest.py` is covered by `scripts/test_viewer_compare_manifest.py`, which rides the existing stdlib-only lint job (20 tests pass, up from 14). The shell and GUI halves cannot run on CI; the piece that decides whether a run is still readable in six months has no such excuse. `shellcheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a macOS viewer-comparison workflow for capturing local and Xcode report views across themes and screen sizes.
  * Added automated screenshot metadata, manifest generation, artifact tracking, and diagnostic reporting.
  * Added optional manual and automated Xcode capture with accessibility checks and recovery handling.

* **Documentation**
  * Added setup, usage, troubleshooting, prerequisites, and workflow documentation.

* **Tests**
  * Added coverage for manifest creation, screenshot pairing, metadata, missing files, and deterministic ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->