### PR TITLE
Make the tests tree read like Xcode's outline (refs #439)

### DIFF
--- a/Sources/XCTestHTMLReportCore/Classes/HTMLTemplates.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/HTMLTemplates.swift
@@ -67,6 +67,27 @@ struct HTMLTemplates
       --color-bg-sidebar: #F2F2F2;
       --color-bg-group-header: #F6F6F6;
 
+      /* Colour — the tests tree (#439, A2). Four roles the sheet had no way
+         to say before, because before this the tree painted nothing at all
+         between the page background and a selected row.
+
+         Every pairing was computed before it was used; the table is in the
+         PR body. The tightest text pairing these introduce is the failure
+         message on its own tint — 4.74:1 light, 5.35:1 dark, against a 4.5
+         floor — and the tightest status badge is passed on a hovered row,
+         3.69:1 light and 6.54:1 dark against the 3:1 non-text floor.
+
+         --color-tree-guide is deliberately below 3:1 (1.28 light / 1.44
+         dark, against the panel it is drawn on), for the same reason
+         --color-summary-border is: the timeline
+         rule restates the nesting that indentation already states, so it is
+         decorative under 1.4.11 and drawing it at 3:1 would put a hard black
+         bar down the middle of every expanded test. */
+      --color-row-hover: #F0F0F2;
+      --color-bg-activities: #F7F7F9;
+      --color-fail-tint: #FDEDEC;
+      --color-tree-guide: #DCDCE1;
+
       /* Colour — the summary header (#439, A1). A band with cards on it,
          which is one more surface level than the rest of the report has, so
          these are their own tokens rather than reuses. Values are Apple's
@@ -97,7 +118,13 @@ struct HTMLTemplates
       --color-border-medium: #CCC;
       --color-border-light: #DDD;
       --color-border-faint: #E5E5E5;
-      --color-preview-border: #021a40;
+      /* Was #021A40 — a near-black navy, and the only colour in the light
+         theme that belonged to no family. It framed the screenshot flow in a
+         hard dark rectangle; the dark theme had already been given a normal
+         border value for it. This is the light theme's equivalent, so the
+         frame now reads as a frame in both. Decorative: it outlines an image
+         that is itself the content. */
+      --color-preview-border: #D2D2D7;
 
       /* Typography — the system UI face, so the report looks native on the
          platform it is read on. `system-ui` first, `-apple-system` for the
@@ -128,22 +155,50 @@ struct HTMLTemplates
       --preview-height: 600px;
       --radius-sm: 3px;
 
+      /* One nesting level of the tree. Applied to the child container, not
+         written into the markup — see the indentation rule below for why
+         that distinction is load-bearing for the differential. */
+      --tree-indent: 16px;
+
+      /* How far a row's background bleeds left, past the indentation its
+         container spends. Declared here at its *off* value and overridden to
+         a real distance by the three row kinds that want it, so the default
+         lives in one place and `tokens.spec.ts` can see it declared like any
+         other custom property. */
+      --row-bleed: 0;
+
       /* Glyphs. Shapes, not colours — the colour is applied separately (see
          the icon block below), which is why these are shared by both themes
          and the dark block does not repeat them. Kept here so the sheet has
          exactly one place where the report's iconography is defined.
 
-         Geometry note: every status glyph is the same rounded diamond, so
-         the six states differ by what sits inside it and by shape — filled
-         with a knock-out for the three settled outcomes, outlined for the
-         three that are qualified. That reproduces the diamond the PNGs drew,
-         which is the identity this refresh is keeping. */
-      --icon-status-passed: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cmask id='a'%3E%3Cpath d='M9.06 1.66 14.34 6.94Q15.4 8 14.34 9.06L9.06 14.34Q8 15.4 6.94 14.34L1.66 9.06Q.6 8 1.66 6.94L6.94 1.66Q8 .6 9.06 1.66Z' fill='white'/%3E%3Cpath d='M4.7 8.2 6.9 10.5 11.3 5.6' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/mask%3E%3Crect width='16' height='16' mask='url(%23a)'/%3E%3C/svg%3E");
-      --icon-status-failed: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cmask id='a'%3E%3Cpath d='M9.06 1.66 14.34 6.94Q15.4 8 14.34 9.06L9.06 14.34Q8 15.4 6.94 14.34L1.66 9.06Q.6 8 1.66 6.94L6.94 1.66Q8 .6 9.06 1.66Z' fill='white'/%3E%3Cpath d='M5.6 5.6 10.4 10.4M10.4 5.6 5.6 10.4' fill='none' stroke='black' stroke-width='2' stroke-linecap='round'/%3E%3C/mask%3E%3Crect width='16' height='16' mask='url(%23a)'/%3E%3C/svg%3E");
-      --icon-status-skipped: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cmask id='a'%3E%3Cpath d='M9.06 1.66 14.34 6.94Q15.4 8 14.34 9.06L9.06 14.34Q8 15.4 6.94 14.34L1.66 9.06Q.6 8 1.66 6.94L6.94 1.66Q8 .6 9.06 1.66Z' fill='white'/%3E%3Cpath d='M5.4 9.9 10.6 6.1M6.1 6.1h4.5v4.5' fill='none' stroke='black' stroke-width='1.8' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/mask%3E%3Crect width='16' height='16' mask='url(%23a)'/%3E%3C/svg%3E");
-      --icon-status-mixed: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cmask id='a'%3E%3Cpath d='M9.06 1.66 14.34 6.94Q15.4 8 14.34 9.06L9.06 14.34Q8 15.4 6.94 14.34L1.66 9.06Q.6 8 1.66 6.94L6.94 1.66Q8 .6 9.06 1.66Z' fill='white'/%3E%3Cpath d='M8 1.2V14.8' fill='none' stroke='black' stroke-width='1.4'/%3E%3C/mask%3E%3Crect width='16' height='16' mask='url(%23a)'/%3E%3C/svg%3E");
-      --icon-status-unknown: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M9.06 1.66 14.34 6.94Q15.4 8 14.34 9.06L9.06 14.34Q8 15.4 6.94 14.34L1.66 9.06Q.6 8 1.66 6.94L6.94 1.66Q8 .6 9.06 1.66Z' fill='none' stroke='black' stroke-width='1.6'/%3E%3Cpath d='M6.5 6.4a1.6 1.6 0 1 1 1.6 1.9v.8' fill='none' stroke='black' stroke-width='1.3' stroke-linecap='round'/%3E%3Ccircle cx='8.1' cy='11.2' r='.8'/%3E%3C/svg%3E");
-      --icon-status-expected: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M9.06 1.66 14.34 6.94Q15.4 8 14.34 9.06L9.06 14.34Q8 15.4 6.94 14.34L1.66 9.06Q.6 8 1.66 6.94L6.94 1.66Q8 .6 9.06 1.66Z' fill='none' stroke='black' stroke-width='1.6'/%3E%3Cpath d='M8 4.8v3.6' stroke='black' stroke-width='1.6' stroke-linecap='round'/%3E%3Ccircle cx='8' cy='11' r='.9'/%3E%3C/svg%3E");
+         Geometry note (#439, A2). Every status glyph is the same rounded
+         square — Xcode 26's badge — and the six states differ by the glyph
+         inside it and by whether the square is filled or outlined. Filled
+         means the outcome is settled (passed, failed, skipped, mixed and
+         expected-failure: a test that failed exactly as it declared it
+         would is a settled outcome); outlined means it is not (unknown is
+         the only state that means "we could not tell").
+
+         This replaces the rounded diamond #459 drew. The six *shapes* are
+         the same six #459 introduced, which is the property that mattered:
+         status is never colour alone, and no state renders a blank cell.
+         Only the silhouette moved, and it moved because Option A's whole
+         premise is reading as a sibling of Xcode's own report.
+
+         The glyph is a knock-out — a hole showing whatever surface the row
+         paints — rather than the white glyph the mockup draws. White on the
+         mockup's green is 3.13:1; a knock-out's contrast against its fill
+         is by construction the status token's contrast against the row,
+         which is the pairing #439 already sized to clear 3:1 in both
+         themes. Same picture on a white row, a measured one everywhere
+         else. */
+      --icon-status-passed: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cmask id='a'%3E%3Crect x='1' y='1' width='14' height='14' rx='4.2' fill='white'/%3E%3Cpath d='M4.6 8.15 6.85 10.4 11.4 5.75' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/mask%3E%3Crect width='16' height='16' mask='url(%23a)'/%3E%3C/svg%3E");
+      --icon-status-failed: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cmask id='a'%3E%3Crect x='1' y='1' width='14' height='14' rx='4.2' fill='white'/%3E%3Cpath d='M5.7 5.7 10.3 10.3M10.3 5.7 5.7 10.3' fill='none' stroke='black' stroke-width='2' stroke-linecap='round'/%3E%3C/mask%3E%3Crect width='16' height='16' mask='url(%23a)'/%3E%3C/svg%3E");
+      --icon-status-skipped: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cmask id='a'%3E%3Crect x='1' y='1' width='14' height='14' rx='4.2' fill='white'/%3E%3Cpath d='M5.5 10.1 10.4 5.9M6.2 5.9h4.3v4.3' fill='none' stroke='black' stroke-width='1.8' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/mask%3E%3Crect width='16' height='16' mask='url(%23a)'/%3E%3C/svg%3E");
+      --icon-status-mixed: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cmask id='a'%3E%3Crect x='1' y='1' width='14' height='14' rx='4.2' fill='white'/%3E%3Cpath d='M8 .6V15.4' fill='none' stroke='black' stroke-width='1.4'/%3E%3C/mask%3E%3Crect width='16' height='16' mask='url(%23a)'/%3E%3C/svg%3E");
+      --icon-status-unknown: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Crect x='1.8' y='1.8' width='12.4' height='12.4' rx='3.4' fill='none' stroke='black' stroke-width='1.6'/%3E%3Cpath d='M6.5 6.4a1.6 1.6 0 1 1 1.6 1.9v.8' fill='none' stroke='black' stroke-width='1.3' stroke-linecap='round'/%3E%3Ccircle cx='8.1' cy='11.2' r='.8'/%3E%3C/svg%3E");
+      --icon-status-expected: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cmask id='a'%3E%3Crect x='1' y='1' width='14' height='14' rx='4.2' fill='white'/%3E%3Cpath d='M8 4.3v4.2' fill='none' stroke='black' stroke-width='2' stroke-linecap='round'/%3E%3Ccircle cx='8' cy='11.4' r='1.05' fill='black'/%3E%3C/mask%3E%3Crect width='16' height='16' mask='url(%23a)'/%3E%3C/svg%3E");
       --icon-disclosure: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 10'%3E%3Cpath d='M3 1.4 8 5 3 8.6Z'/%3E%3C/svg%3E");
       --icon-disclosure-open: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 10'%3E%3Cpath d='M1.4 3 8.6 3 5 8Z'/%3E%3C/svg%3E");
       --icon-paperclip: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M2.7 15.3c-.7 0-1.4-.3-1.9-.8-.9-.9-1.2-2.5 0-3.7l8.9-8.9c1.4-1.4 3.8-1.4 5.2 0s1.4 3.8 0 5.2l-7.4 7.4c-.2.2-.5.2-.7 0s-.2-.5 0-.7l7.4-7.4c1-1 1-2.7 0-3.7s-2.7-1-3.7 0l-8.9 8.9c-.8.8-.6 1.7 0 2.2.6.6 1.5.8 2.2 0l8.9-8.9c.2-.2.2-.5 0-.7s-.5-.2-.7 0l-7.4 7.4c-.2.2-.5.2-.7 0s-.2-.5 0-.7l7.4-7.4c.6-.6 1.6-.6 2.2 0s.6 1.6 0 2.2l-8.9 8.9c-.6.4-1.3.7-1.9.7z'/%3E%3C/svg%3E");
@@ -151,7 +206,6 @@ struct HTMLTemplates
       --icon-document: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cmask id='a'%3E%3Cpath d='M3.2 1.4h6L13 5.2v9.4H3.2Z' fill='white'/%3E%3Cpath d='M5.2 7.4h5.6M5.2 9.6h5.6M5.2 11.8h3.6' stroke='black' stroke-width='1.1' stroke-linecap='round'/%3E%3Cpath d='M8.9 1.6v3.6h3.6' fill='none' stroke='black' stroke-width='1.1'/%3E%3C/mask%3E%3Crect width='16' height='16' mask='url(%23a)'/%3E%3C/svg%3E");
       --icon-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cmask id='a'%3E%3Crect x='1.4' y='2.8' width='13.2' height='10.4' rx='1.4' fill='white'/%3E%3Cpath d='M2.6 12 6.3 7.6l2.5 2.6 2-2 2.6 3.8Z' fill='black'/%3E%3Ccircle cx='5.4' cy='6' r='1.3' fill='black'/%3E%3C/mask%3E%3Crect width='16' height='16' mask='url(%23a)'/%3E%3C/svg%3E");
       --icon-video: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cmask id='a'%3E%3Crect x='1.4' y='3.2' width='13.2' height='9.6' rx='1.4' fill='white'/%3E%3Cpath d='M6.6 5.9 11 8l-4.4 2.1Z' fill='black'/%3E%3C/mask%3E%3Crect width='16' height='16' mask='url(%23a)'/%3E%3C/svg%3E");
-      --icon-test: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cmask id='a'%3E%3Crect x='1.6' y='1.6' width='12.8' height='12.8' rx='2.6' fill='white'/%3E%3Cpath d='M8.6 3.9v6.4a1.4 1.4 0 0 0 1.4 1.4h.6M6.1 6.6h4.3' fill='none' stroke='black' stroke-width='1.5' stroke-linecap='round'/%3E%3C/mask%3E%3Crect width='16' height='16' mask='url(%23a)'/%3E%3C/svg%3E");
     }
 
     /* Dark theme. Token values only — every selector in the sheet is shared
@@ -189,6 +243,16 @@ struct HTMLTemplates
         --color-surface: #161619;
         --color-bg-sidebar: #232327;
         --color-bg-group-header: #202024;
+
+        /* The tree's own surfaces. The activities panel is *darker* than the
+           page rather than lighter, which is the inversion of the light
+           theme and is what makes an expanded test read as recessed under
+           its row instead of floating above it — the same relationship the
+           summary band has to its cards. */
+        --color-row-hover: #25252A;
+        --color-bg-activities: #1D1D21;
+        --color-fail-tint: #3A2226;
+        --color-tree-guide: #38383E;
 
         /* The summary header's own surfaces. The card is the same value as
            the sidebar, which is deliberate: it is the lightest ground in the
@@ -384,10 +448,16 @@ struct HTMLTemplates
       color: var(--color-text-muted);
     }
 
+    /* The tree's column header. Two labels, at the two ends of the row the
+       columns actually occupy, rather than the old "Status | Tests" pair
+       stacked against the left edge — there is a duration column to name now,
+       and naming it is the only thing that makes it read as a column. */
     .table-header {
+      display: flex;
       min-height: 18px;
       margin: 0;
-      padding-top: 0;
+      padding: 2px var(--space-sm) 2px 6px;
+      border-bottom: 1px solid var(--color-border-light);
     }
 
     .table-header li {
@@ -396,8 +466,7 @@ struct HTMLTemplates
     }
 
     .table-header li+li {
-      border-left: 1px solid var(--color-border-medium);
-      padding-left: var(--space-xs);
+      margin-left: auto;
     }
 
     #logs {
@@ -460,10 +529,10 @@ struct HTMLTemplates
       display: inline-block;
     }
 
-    .left {
-      float: left;
-    }
-
+    /* `.left` lived here until A2. Every element that carried it was a tree
+       icon clearing a float gutter, and the tree is flex now, so the class
+       reached nothing in the rendered page — verified against both goldens.
+       `.clear` stays: `#title` and `#container` still float. */
     .clear {
       clear: both;
     }
@@ -490,93 +559,68 @@ struct HTMLTemplates
       mask-image: var(--icon-video);
     }
 
-    /* The one glyph that is not `currentColor`: the rounded blue tile is the
-       project's own mark, so it keeps its colour instead of inheriting the
-       row's — except on a selected row, where the accent fill would put blue
-       on blue. Today's PNG has no such escape and does disappear there. */
-    .test-icon {
-      display: none;
-      background-color: var(--color-accent);
-      -webkit-mask-image: var(--icon-test);
-      mask-image: var(--icon-test);
-    }
-
-    .list-item.selected .test-icon {
-      background-color: var(--color-on-accent);
-    }
-
-    .test-summary p > .test-icon {
-      display: block;
-    }
-
-    .test-summary.no-drop-down .drop-down-icon {
-      display: none;
-    }
-
-    .test-summary.no-drop-down .test-icon {
-      margin-left: 22px;
-    }
-
-    /* The gutter the status glyph sits in. `margin-left` lives here rather
-       than on the per-status rules below so that one single-class rule can
-       narrow it on small screens; the per-status rules carry three classes
-       each, which no media query could outrank without `!important`. */
+    /* The status badge. It is a flex item of the row now rather than a float
+       beside it, so the gutter it used to need — a 28px margin on the icon
+       plus a matching 52px padding on every `<p>` in the tree, whether or not
+       that row had a badge — is gone, and the tree recovers ~38px of width at
+       every screen size. */
     .test-result-icon {
-      float: left;
       display: none;
-      margin: var(--space-xs);
-      margin-left: 28px;
+      flex: none;
+      margin: 0;
     }
 
     /* Which rows show a status glyph at all. Before #439 only the three
        states that had a PNG appeared here, so `mixed`, `unknown` and
        `expectedFailure` rows rendered an empty status cell — the audit's
        finding 4. All six states now have one, and each is a distinct shape,
-       not just a distinct colour. Group headings are deliberately still
-       absent: giving them icons is a layout change beyond this PR.
+       not just a distinct colour.
 
-       `>`, not a descendant combinator, throughout the status rules. A
-       retried test nests its iterations *inside* the row, and each carries
-       its own `.test-result-icon`; matched loosely, the outer row's rule
-       reaches them too, and since every one of these selectors has the same
-       specificity the winner is whichever is written last. That was
-       invisible while only three states had rules — a failed test's
-       iterations are usually failed as well — and showed up the moment
-       `mixed` existed: `testRetryOnFailure()`'s two iterations, one failed
-       and one passed, both drew the split diamond of their parent. */
-    .test-summary.succeeded > .test-result-icon,
-    .test-summary.skipped > .test-result-icon,
-    .test-summary.failed > .test-result-icon,
-    .test-summary.mixed > .test-result-icon,
-    .test-summary.unknown > .test-result-icon,
-    .test-summary.expected-failure > .test-result-icon,
-    .iteration.succeeded > .test-result-icon,
-    .iteration.skipped > .test-result-icon,
-    .iteration.failed > .test-result-icon,
-    .iteration.mixed > .test-result-icon,
-    .iteration.unknown > .test-result-icon,
-    .iteration.expected-failure > .test-result-icon {
+       Suite headings join them in A2. #459 left them out because the badge
+       was a float and giving one to a heading meant reworking the gutter;
+       now that a row is a flex line it is a selector, and the mockup's tree
+       puts a badge on every suite. Nothing new is computed for it —
+       `TestGroup.status` already folds its children's outcomes and already
+       writes the class onto the row.
+
+       `> p >`, not a descendant combinator, throughout. It used to be
+       `> .test-result-icon` because the badge was a sibling of the row; A2
+       makes it a flex item *of* the row, so the path gained a level and kept
+       the same property. That property is load-bearing twice over: a retried
+       test nests its iterations inside the row and a suite nests its cases
+       inside its own, and every one of those carries a `.test-result-icon`.
+       Matched loosely, an outer row's rule reaches all of them, and since
+       these selectors all have the same specificity the winner would be
+       whichever is written last — which is how `testRetryOnFailure()`'s two
+       iterations, one failed and one passed, once both drew their parent's
+       split glyph.
+
+       `:is()` groups the three row kinds rather than writing eighteen
+       selectors out. It contributes the specificity of its most specific
+       argument, and every argument here is one class, so each rule stays at
+       exactly the (0,3,1) the written-out form had — which the selection
+       override below relies on. */
+    :is(.test-summary, .test-summary-group, .iteration):is(
+      .succeeded, .skipped, .failed, .mixed, .unknown, .expected-failure
+    ) > p > .test-result-icon {
       display: block;
     }
 
-    .test-summary.succeeded > .test-result-icon,
-    .iteration.succeeded > .test-result-icon,
+    :is(.test-summary, .test-summary-group, .iteration).succeeded > p > .test-result-icon,
     .success {
       background-color: var(--status-passed);
       -webkit-mask-image: var(--icon-status-passed);
       mask-image: var(--icon-status-passed);
     }
 
-    .test-summary.skipped > .test-result-icon,
-    .iteration.skipped > .test-result-icon,
+    :is(.test-summary, .test-summary-group, .iteration).skipped > p > .test-result-icon,
     .skip {
       background-color: var(--status-skipped);
       -webkit-mask-image: var(--icon-status-skipped);
       mask-image: var(--icon-status-skipped);
     }
 
-    .test-summary.failed > .test-result-icon,
-    .iteration.failed > .test-result-icon,
+    :is(.test-summary, .test-summary-group, .iteration).failed > p > .test-result-icon,
     .failure {
       background-color: var(--status-failed);
       -webkit-mask-image: var(--icon-status-failed);
@@ -584,11 +628,10 @@ struct HTMLTemplates
     }
 
     /* Mixed is the one glyph that carries two colours, because "some passed,
-       some failed" is what it means. The mask is a plain diamond split by a
+       some failed" is what it means. The mask is a plain badge split by a
        thin cut, and the two halves are a hard-stop gradient — so both halves
        are tokens and follow the theme, which a two-colour image could not. */
-    .test-summary.mixed > .test-result-icon,
-    .iteration.mixed > .test-result-icon {
+    :is(.test-summary, .test-summary-group, .iteration).mixed > p > .test-result-icon {
       background-color: transparent;
       background-image: linear-gradient(
         90deg,
@@ -599,25 +642,46 @@ struct HTMLTemplates
       mask-image: var(--icon-status-mixed);
     }
 
-    .test-summary.unknown > .test-result-icon,
-    .iteration.unknown > .test-result-icon {
+    :is(.test-summary, .test-summary-group, .iteration).unknown > p > .test-result-icon {
       background-color: var(--status-unknown);
       -webkit-mask-image: var(--icon-status-unknown);
       mask-image: var(--icon-status-unknown);
     }
 
-    .test-summary.expected-failure > .test-result-icon,
-    .iteration.expected-failure > .test-result-icon {
+    :is(.test-summary, .test-summary-group, .iteration).expected-failure > p > .test-result-icon {
       background-color: var(--status-expected);
       -webkit-mask-image: var(--icon-status-expected);
       mask-image: var(--icon-status-expected);
     }
 
+    /* On a selected row the badge is painted in the selection's own text
+       colour and the accent knocks through the glyph, rather than the badge
+       staying a status hue. Measured against the fill it would otherwise sit
+       on: passed is 1.36:1 light and 2.07:1 dark against the accent — an
+       invisible badge on precisely the row the reader is looking at.
+       White-on-accent is 5.71 / 4.82. The outcome stays readable because the
+       *shape* carries it, which is the #459 property that status is never
+       colour alone.
+
+       Written with the element selector and placed after the status rules
+       deliberately: it has to match their (0,3,1) and win on order, and it
+       has to clear `mixed`'s gradient as well as the flat fills. */
+    p.list-item.selected > .test-result-icon {
+      background-color: var(--color-on-accent);
+      background-image: none;
+    }
+
+    /* The triangle is the row's quietest element, so it takes the muted text
+       colour rather than `currentColor` — which on a failure row would have
+       made it as loud as the failure. `flex: none` because it is the column
+       every row's badge aligns against; a shrunk triangle is a bent column. */
     .drop-down-icon {
       cursor: pointer;
+      flex: none;
       height: var(--icon-size-sm);
       width: var(--icon-size-sm);
-      margin-top: 2px;
+      margin: 0;
+      background-color: var(--color-text-muted);
       -webkit-mask-image: var(--icon-disclosure);
       mask-image: var(--icon-disclosure);
     }
@@ -627,31 +691,70 @@ struct HTMLTemplates
       mask-image: var(--icon-disclosure-open);
     }
 
+    p.list-item.selected > .drop-down-icon {
+      background-color: var(--color-on-accent);
+    }
+
+    /* The eye is a control, not a label, so it takes the accent the rest of
+       the sheet uses for "you can click this" (`.digest-jump`) instead of
+       inheriting the row's text colour. */
     .preview-icon {
       cursor: pointer;
       display: inline-block;
+      flex: none;
       height: 11px;
       width: 14px;
+      background-color: var(--color-accent-text);
       -webkit-mask-image: var(--icon-preview);
       mask-image: var(--icon-preview);
     }
 
-    .activities {
-      display: none;
+    p.list-item.selected > .preview-icon,
+    p.list-item.selected > .paperclip-icon {
+      background-color: var(--color-on-accent);
     }
 
-    .activity.activity-assertion-failure > p {
+    /* An expanded test's activities (#439, A2). The mockup draws this as a
+       timeline: an inset panel under the test, a rule down its gutter, and an
+       elapsed offset against every row.
+
+       The offsets are not here, and are not faked. 4.0's `ParsedActivity`
+       carries a title, a failure flag, attachments and sub-activities —
+       `finish` and the per-activity timestamps left with the legacy reader
+       (see the port's decision 2), so there is no field to render and no
+       honest way to derive one. The rest of the treatment applies unchanged,
+       and the gutter still does the job the offsets shared: it says where the
+       detail of one test starts and stops. */
+    .activities {
+      display: none;
+      margin-left: var(--tree-indent);
+      border-left: 2px solid var(--color-tree-guide);
+      background-color: var(--color-bg-activities);
+    }
+
+    /* Single class, so `.list-item:hover` (two) still wins the background and
+       a failure row highlights like any other. The red text is what survives
+       the hover, which is the part that carries the meaning. */
+    .activity-assertion-failure > p {
+      background-color: var(--color-fail-tint);
       color: var(--status-failed);
+      font-weight: var(--font-weight-medium);
     }
 
     .sub-activities {
       display: none;
     }
 
+    /* Depth inside the activities panel, one 10px step per level, written by
+       `Activity.padding` into the element's own style attribute. Kept as a
+       spacer element rather than folded into the row's padding because the
+       model already computes it — including the +18px a leaf spends standing
+       in for the triangle it does not draw. `float` had to go: floats do not
+       apply to flex items, and the row is a flex line now. */
     .padding {
-      float: left;
+      flex: none;
       width: 1px;
-      height:1px;
+      height: 1px;
     }
 
     .activity.no-drop-down .drop-down-icon {
@@ -674,6 +777,16 @@ struct HTMLTemplates
       overflow-y: scroll;
     }
 
+    /* The list takes focus so it can be scrolled from the keyboard (see the
+       `run` template). `:focus-visible`, not `:focus`, so clicking a row does
+       not draw a ring around the whole tree; `outline-offset` is negative
+       because the outline of a scroll container is drawn at its padding edge
+       and a positive offset would sit under the pane beside it. */
+    .tests:focus-visible {
+      outline: 2px solid var(--color-accent);
+      outline-offset: -2px;
+    }
+
     .tests-header, #logs-header {
       width: 100%;
     }
@@ -686,19 +799,136 @@ struct HTMLTemplates
       margin-left: var(--space-sm);
     }
 
+    /* ---- The tests tree (#439, A2) ------------------------------------
+
+       Every row in the tree — suite heading, test case, iteration, activity,
+       attachment — is one flex line: triangle, status badge, name, then the
+       duration pushed to its own right-hand column. What this replaces was a
+       pair of floats clearing a fixed 52px of left padding, which is why the
+       duration could only ever be more text after the name and why a row with
+       no badge still paid for the gutter of one. */
     .test-summary p, .test-summary-group p, .iteration p, .activity p {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      min-height: 24px;
       font-size: var(--font-size-sm);
-      padding: var(--space-xs) var(--space-xs) var(--space-xs) 52px;
+      padding: 3px var(--space-sm) 3px 6px;
       border-bottom: 1px solid var(--color-border-faint);
+    }
+
+    /* No hairlines inside an expanded test. The panel's own inset surface and
+       the rule down its gutter already bound the region, and the mockup's
+       timeline draws no separators between its steps — with them, a test with
+       thirty activities reads as thirty more tests. */
+    .activities p {
+      border-bottom: 0;
+    }
+
+    /* The name takes the slack and wraps inside it; `min-width: 0` because a
+       flex item refuses to shrink below its content otherwise, and test names
+       are long unbroken identifiers. */
+    .row-name {
+      flex: 1 1 auto;
+      min-width: 0;
+      overflow-wrap: anywhere;
+    }
+
+    /* Inside the activities panel there is no right-hand column to push
+       against — no per-activity duration exists to put there — so the name
+       stops claiming the slack and the paperclip and the eye stay beside the
+       thing they belong to instead of drifting to the far edge. */
+    .activity > p > .row-name,
+    .attachment > .row-name {
+      flex: 0 1 auto;
+    }
+
+    /* The duration column.
+
+       `(N.NNs)` is not a styling choice and must not be edited into a bare
+       `N.NNs`: it is literally the shape `KnownLossMasker`'s `durations` rule
+       normalises, so every duration in the tree inherits a loss the allow-list
+       already declares. A2 moves where the text sits and changes nothing about
+       what it says. `RunSummaryTests.testTheHeadersDurationIsWrittenInAMaskedShape`
+       holds the same property for the header. */
+    .row-duration {
+      flex: none;
+      padding-left: var(--space-sm);
+      color: var(--color-text-muted);
+      font-variant-numeric: tabular-nums;
+    }
+
+    /* Annotations beside a name — today only a retried test's per-status
+       breakdown ("1 failed, 1 succeeded"). A bordered chip, the mockup's
+       treatment for the same class of aside. */
+    .row-note {
+      flex: none;
+      padding: 0 5px;
+      border: 1px solid var(--color-border-medium);
+      border-radius: var(--radius-sm);
+      color: var(--color-text-muted);
+      font-size: var(--font-size-xs);
+    }
+
+    p.list-item.selected > .row-duration,
+    p.list-item.selected > .row-note {
+      color: var(--color-on-accent);
+    }
+
+    /* Indentation.
+
+       Nesting depth is carried by the DOM and applied to the child container,
+       never written into the markup as a number. That is not a stylistic
+       preference: the legacy backend interposes two wrapper levels ("Selected
+       tests", "<target>.xctest") that the modern backend does not, so a depth
+       written into an attribute would differ between the two renders in every
+       row of the tree — and `KnownLossMasker`'s `wrapperGroups` rule unwraps
+       the *element*, which would leave the numbers behind and turn
+       `DifferentialTests` red with no allow-list entry able to cover it.
+       Nested padding indents by construction and costs the differential
+       exactly nothing. */
+    .test-summary-group > .test-summary,
+    .test-summary-group > .test-summary-group {
+      padding-left: var(--tree-indent);
+    }
+
+    /* Rows are indented by their container's padding, so a row's own box
+       starts at the indent and its background would too. `--row-bleed` paints
+       that background back out to the left edge with a horizontal shadow;
+       `.tests` is a scroll container, so it clips there. A shadow is ink
+       overflow rather than scrollable overflow, so nothing here widens the
+       page — the 375px probe covers that.
+
+       Only the three row kinds that sit *in* the tree override it. Activity
+       and attachment rows deliberately do not: they live inside the
+       activities panel, whose inset background and gutter rule are the thing
+       that says "this belongs to the test above", and a row bleeding past
+       them would erase exactly that. They keep the `:root` default of `0` and
+       highlight in place. */
+    .test-summary > p,
+    .test-summary-group > p,
+    .iteration > p {
+      --row-bleed: -100vw;
+    }
+
+    .list-item:hover {
+      background-color: var(--color-row-hover);
+      box-shadow: var(--row-bleed) 0 0 var(--color-row-hover);
     }
 
     .test-summary-group > p {
       background-color: var(--color-bg-group-header);
+      box-shadow: var(--row-bleed) 0 0 var(--color-bg-group-header);
       font-weight: var(--font-weight-medium);
     }
 
+    /* `visibility`, not `display`: a suite row has no working disclosure to
+       draw — collapsing a group is a script change, and the filter and
+       collapse scripts are A3's to rewire, not A2's to restyle around — but
+       the column still has to hold, or a suite's badge would sit 16px left of
+       its own children's and the tree would look bent. */
     .test-summary-group > p > .drop-down-icon {
-      display: none;
+      visibility: hidden;
     }
 
     .screenshot {
@@ -747,16 +977,28 @@ struct HTMLTemplates
       display:none;
     }
 
-    .screenshot-flow {
-        border: 1px solid var(--color-preview-border);
-        background-color: var(--color-surface);
-        height: 200px;
-    }
+    /* The screenshot flow — the frames a UI test walked through, rendered in
+       the tree rather than in the attachment pane.
 
+       Sized like the mockup's inline player: a bounded box, not a slab. At a
+       fixed 200px (350px for the tail) and no width bound these were the
+       tallest thing in the tree by a factor of eight, so a test with a flow
+       pushed every row after it off the screen — and `.screenshot-tail` is
+       emitted *between* rows, so it did that to the tree, not to the panel.
+       `max-height` with `height: auto` keeps whatever aspect ratio the device
+       recorded instead of stretching a phone frame to a fixed height. */
+    .screenshot-flow,
     .screenshot-tail {
+        display: block;
+        width: auto;
+        max-width: min(300px, 100%);
+        height: auto;
+        max-height: 200px;
+        margin: 6px 0 6px var(--tree-indent);
+        object-fit: contain;
         border: 1px solid var(--color-preview-border);
+        border-radius: 8px;
         background-color: var(--color-surface);
-        height: 350px;
     }
 
     #content {
@@ -888,11 +1130,11 @@ struct HTMLTemplates
       color: var(--status-failed);
     }
 
+    /* After `.list-item:hover`, and matching its specificity, so hovering the
+       selected row leaves it selected rather than tinting it. */
     .list-item.selected {
       background-color: var(--color-accent);
-    }
-
-    .list-item.selected {
+      box-shadow: var(--row-bleed) 0 0 var(--color-accent);
       color: var(--color-on-accent);
     }
 
@@ -911,6 +1153,18 @@ struct HTMLTemplates
       padding: var(--space-sm) var(--space-sm) 12px;
       max-height: 50vh;
       overflow-y: auto;
+    }
+
+    /* The band belongs to the test run, so the Logs tab gets the column to
+       itself (#439, A2). `display: none` rather than a height animation: the
+       band is up to half the viewport and the log is an iframe, so anything
+       that resized it over several frames would reflow and repaint the frame
+       the whole way down. One class, one reflow, no jank. The rule sits with
+       the band's own styles and applies at every width — below 700px, where
+       the band already yields to a 40vh cap, reclaiming all of it is the
+       difference between a readable log and four lines of one. */
+    body.logs-active #run-summary {
+      display: none;
     }
 
     .summary-card {
@@ -1176,11 +1430,30 @@ struct HTMLTemplates
          filenames. Stacked vertically that minimum became the column's
          width, which pushed the whole tree, and the filter pills with it,
          off the side of a 375px screen. Nothing above the query needs this
-         because there the panes are fixed widths. */
+         because there the panes are fixed widths.
+
+         `min-height` for the same reason on the other axis, and it fixes a
+         worse bug: below 700px `#container` is a *column*, so the tree is
+         sized on the block axis by this same automatic minimum, and
+         `min-height: auto` let `.tests` grow to the full height of every row
+         it holds instead of scrolling inside its share. `body` has
+         `overflow: hidden`, so everything past the first viewport was not
+         merely unscrolled but unreachable — on a long run the last test in
+         the report could not be brought on screen at all. Only the scroll
+         container itself strictly needs it, but the automatic minimum
+         propagates up a flex chain, so all three do.
+
+         Pre-existing — the column layout arrived with the narrow-screen work
+         in #459 — and made materially worse by A1: the summary band spends
+         real height above the tree, so the clipped region grew by exactly
+         what the band occupies. Found while shooting this PR's 375px
+         screenshots; `visual/tests/behaviour.spec.ts` now scrolls to the last
+         row at 375 so it cannot come back. */
       #main-content,
       .run,
       .tests {
         min-width: 0;
+        min-height: 0;
       }
 
       /* `flex: none` because the strip is now a row in a column container:
@@ -1242,19 +1515,25 @@ struct HTMLTemplates
         display: none;
       }
 
-      /* Reclaim the 16px the status gutter spends. At 375px that is the
-         difference between a test name fitting on one line and wrapping. */
-      .test-summary p, .test-summary-group p, .iteration p, .activity p {
-        padding-left: 36px;
+      /* The flex row already spends only what it draws, so there is no fixed
+         gutter left to reclaim here — what A1 needed this rule for is gone.
+         What is left is the indentation step: 16px per level is right at
+         1440px and profligate on a 375px screen four levels deep, where the
+         legacy backend's two wrapper levels alone would eat 32px before the
+         first suite. */
+      .test-summary-group > .test-summary,
+      .test-summary-group > .test-summary-group {
+        padding-left: 10px;
+      }
+
+      .activities {
+        margin-left: 10px;
+      }
+
+      /* Long identifiers still have to break somewhere rather than push the
+         duration column off the screen. */
+      .row-name {
         overflow-wrap: break-word;
-      }
-
-      .test-result-icon {
-        margin-left: 12px;
-      }
-
-      .test-summary.no-drop-down .test-icon {
-        margin-left: 6px;
       }
 
       #right-sidebar {
@@ -1800,16 +2079,25 @@ struct HTMLTemplates
       }
     }
 
+    // The summary header describes the *test* run — an outcome ring, a
+    // failure digest, per-device bars — and none of it says anything about
+    // the log the Logs tab shows. Xcode does the same thing: switching to a
+    // different report gives that report the whole column. A body class
+    // rather than a style written onto #run-summary, so the band's own rules
+    // (including its two max-heights) stay in the stylesheet and A3 can move
+    // the tabs without hunting for a display value in a script.
     function showLogs(el) {
       selectedElement(el);
       setDisplayToElementsWithSelector('#logs', 'flex');
       setDisplayToElementsWithSelector('.tests', 'none');
+      document.body.classList.add('logs-active');
     }
 
     function showTests(el) {
       selectedElement(el);
       setDisplayToElementsWithSelector('#logs', 'none');
       setDisplayToElementsWithSelector('.tests', 'flex');
+      document.body.classList.remove('logs-active');
     }
 
     document.querySelectorAll('.device-info')[0].classList.add(\"selected\");
@@ -2007,9 +2295,22 @@ struct HTMLTemplates
   </ul>
   """
 
+  /// One device's run.
+  ///
+  /// `tabindex="0"` on the scrolling test list is an accessibility fix, not a
+  /// layout one: axe's `scrollable-region-focusable` (serious) requires that a
+  /// region a sighted user can scroll is reachable by a keyboard user too, and
+  /// a `div` with `overflow-y: scroll` and no focusable descendant is not. The
+  /// tree has always been that region — the gate stayed green only because the
+  /// synthetic fixture's rows happened to fall seven pixels short of
+  /// overflowing it, so the rule never fired on the one page CI checks. Any
+  /// real report has always tripped it. With the attribute the list takes
+  /// focus and Page Up/Down, Home and End scroll it; the arrow keys keep going
+  /// to the existing row navigation, which scrolls the same region by moving
+  /// the selection.
   static let run = """
   <div class=\"run\" id=\"device_[[DEVICE_IDENTIFIER]]\">
-    <div class=\"tests\">
+    <div class=\"tests\" tabindex=\"0\">
       <div class=\"tests-header\">
         <ul class=\"toolbar toggle-toolbar\">
           <li onclick=\"showAllScenarios(this);\" class=\"selected\">All ([[N_OF_TESTS]])</li>
@@ -2019,8 +2320,8 @@ struct HTMLTemplates
           <li onclick=\"showMixedScenariosOnly(this);\">Mixed ([[N_OF_MIXED_TESTS]])</li>
         </ul>
         <ul class=\"toolbar table-header\">
-          <li>Status</li>
-          <li>Tests</li>
+          <li>Test</li>
+          <li>Duration</li>
         </ul>
       </div>
       [[TEST_SUMMARIES]]
@@ -2042,14 +2343,38 @@ struct HTMLTemplates
   </div>
   """
     
+  /// A test-case row (#439, A2).
+  ///
+  /// Three things about this shape are contracts rather than layout, and the
+  /// three of them are why the restyle is markup-shallow:
+  ///
+  /// - The status badge is now a child of the `<p>` instead of a float beside
+  ///   it, which is what lets the row be a single flex line. The stylesheet's
+  ///   status rules moved from `> .test-result-icon` to `> p >` to match, and
+  ///   the direct combinator is still doing the work of keeping a retried
+  ///   test's iterations off their parent's glyph.
+  /// - `[[TITLE]]` and `([[DURATION]])` are separate elements so the duration
+  ///   can be a right-hand column, but the rendered *text* is unchanged:
+  ///   whitespace between the two spans keeps `text()` reading
+  ///   `name (1.23s)`, which `KnownLossMasker`'s `durations` and
+  ///   `wrapperGroups` rules and `CoreTests`' `hasPrefix` lookups all depend
+  ///   on. The parentheses are the masked shape; do not drop them.
+  /// - `p.list-item > span.drop-down-icon` is pinned by
+  ///   `ReproducibilityTests` as the place a test case's identifier is
+  ///   findable in the rendered page.
+  ///
+  /// The blue test tile that used to sit between the triangle and the title is
+  /// gone: the status badge beside it already says "this row is a test", the
+  /// mockup has no equivalent, and it cost 20px of a 375px row to repeat a
+  /// fact. Nothing selects it.
   static let testCase = """
     [[SCREENSHOT_TAIL]]
     <div class=\"[[ITEM_CLASS]] [[ICON_CLASS]]\">
-        <span class=\"icon left test-result-icon\"></span>
         <p class=\"list-item\">
-            <span class=\"icon left drop-down-icon\" onclick=\"toggle(this, '[[UUID]]')\"></span>
-            <span class=\"icon left test-icon\"></span>
-            [[TITLE]] ([[DURATION]])
+            <span class=\"icon drop-down-icon\" onclick=\"toggle(this, '[[UUID]]')\"></span>
+            <span class=\"icon test-result-icon\"></span>
+            <span class=\"row-name\">[[TITLE]]</span>
+            <span class=\"row-duration\">([[DURATION]])</span>
         </p>
         <div id=\"activities-[[UUID]]\" class=\"activities\">
             [[SCREENSHOT_FLOW]]
@@ -2057,28 +2382,35 @@ struct HTMLTemplates
         </div>
     </div>
   """
-    
+
   static let testCaseWithIterations = """
     <div class=\"[[ITEM_CLASS]] [[ICON_CLASS]]\">
-        <span class=\"icon left test-result-icon\"></span>
         <p class=\"list-item\">
-            <span class=\"icon left drop-down-icon dropped\" onclick=\"toggle(this, '[[UUID]]')\"></span>
-            <span class=\"icon left test-icon\"></span>
-            [[TITLE]] [[RESULT_STRING]] ([[DURATION]])
+            <span class=\"icon drop-down-icon dropped\" onclick=\"toggle(this, '[[UUID]]')\"></span>
+            <span class=\"icon test-result-icon\"></span>
+            <span class=\"row-name\">[[TITLE]]</span>
+            <span class=\"row-note\">[[RESULT_STRING]]</span>
+            <span class=\"row-duration\">([[DURATION]])</span>
         </p>
         <div id=\"iterations-[[UUID]]\" class=\"iterations\" style=\"display: block\">
             [[ITERATIONS]]
         </div>
     </div>
   """
-    
+
+  /// A suite heading. Its `<p>` carries no `list-item` class — group rows are
+  /// not selectable and never have been — and `KnownLossMasker`'s
+  /// `wrapperGroups` rule reads this heading's text to recognise the two
+  /// wrapper levels only the legacy backend emits, so the `Title (1.23s)`
+  /// reading has to survive the split into spans. It does: the newline
+  /// between them is a text node.
   static let testGroup = """
     <div class=\"[[ITEM_CLASS]] [[ICON_CLASS]]\">
-        <span class=\"icon left test-result-icon\"></span>
         <p>
-            <span class=\"icon left drop-down-icon\" onclick=\"toggle(this, '[[UUID]]')\"></span>
-            <span class=\"icon left test-icon\"></span>
-            [[TITLE]] ([[DURATION]])
+            <span class=\"icon drop-down-icon\" onclick=\"toggle(this, '[[UUID]]')\"></span>
+            <span class=\"icon test-result-icon\"></span>
+            <span class=\"row-name\">[[TITLE]]</span>
+            <span class=\"row-duration\">([[DURATION]])</span>
         </p>
         [[SUB_TESTS]]
     </div>
@@ -2086,11 +2418,11 @@ struct HTMLTemplates
 
   static let iteration = """
     <div class=\"iteration [[ICON_CLASS]]\">
-        <span class=\"icon left test-result-icon\"></span>
         <p class=\"list-item\">
-            <span class=\"icon left drop-down-icon\" onclick=\"toggle(this, '[[UUID]]')\"></span>
-            <span class=\"icon left test-icon\"></span>
-            [[TITLE]] ([[DURATION]])
+            <span class=\"icon drop-down-icon\" onclick=\"toggle(this, '[[UUID]]')\"></span>
+            <span class=\"icon test-result-icon\"></span>
+            <span class=\"row-name\">[[TITLE]]</span>
+            <span class=\"row-duration\">([[DURATION]])</span>
         </p>
         <div id=\"activities-[[UUID]]\" class=\"activities\">
             [[SCREENSHOT_FLOW]]
@@ -2103,8 +2435,8 @@ struct HTMLTemplates
   <div class=\"activity [[ACTIVITY_TYPE_CLASS]] [[HAS_SUB-ACTIVITIES_CLASS]]\">
     <p class=\"list-item\">
       <span style=\"margin-left: [[PADDING]]px\" class=\"padding\"></span>
-      <span class=\"icon left drop-down-icon\" onclick=\"toggle(this, '[[UUID]]')\"></span>
-      [[TITLE]]
+      <span class=\"icon drop-down-icon\" onclick=\"toggle(this, '[[UUID]]')\"></span>
+      <span class=\"row-name\">[[TITLE]]</span>
       <span class=\"icon paperclip-icon\" style=\"display: [[PAPER_CLIP_CLASS]]\"></span>
     </p>
     <div id=\"attachments-[[UUID]]\" class=\"attachments\">
@@ -2118,8 +2450,8 @@ struct HTMLTemplates
 
   static let screenshot = """
   <p class=\"attachment list-item\">
-    <span class=\"icon left screenshot-icon\" style=\"margin-left: [[PADDING]]px\"></span>
-    [[NAME]]
+    <span class=\"icon screenshot-icon\" style=\"margin-left: [[PADDING]]px\"></span>
+    <span class=\"row-name\">[[NAME]]</span>
     <span class=\"icon preview-icon\" data=\"[[FILENAME]]\" onclick=\"showScreenshot(this.getAttribute('data'))\"></span>
     <img class=\"screenshot\" src=\"[[SOURCE]]\" id=\"screenshot-[[FILENAME]]\" alt=\"[[NAME]]\" loading=\"lazy\"/>
   </p>
@@ -2127,8 +2459,8 @@ struct HTMLTemplates
 
   static let gif = """
   <p class="attachment list-item">
-    <span class="icon left screenshot-icon" style="margin-left: [[PADDING]]px"></span>
-    [[NAME]]
+    <span class="icon screenshot-icon" style="margin-left: [[PADDING]]px"></span>
+    <span class="row-name">[[NAME]]</span>
   <span class=\"icon preview-icon\" data=\"[[FILENAME]]\" onclick=\"showGif(this.getAttribute('data'))\"></span>
     <img class=\"gif\" src=\"[[SOURCE]]\" id=\"gif-[[FILENAME]]\" alt=\"[[NAME]]\" loading=\"lazy\"/>
   </p>
@@ -2136,8 +2468,8 @@ struct HTMLTemplates
 
   static let video = """
   <p class=\"attachment list-item\">
-    <span class=\"icon left video-icon\" style=\"margin-left: [[PADDING]]px\"></span>
-    [[NAME]]
+    <span class=\"icon video-icon\" style=\"margin-left: [[PADDING]]px\"></span>
+    <span class=\"row-name\">[[NAME]]</span>
     <span class=\"icon preview-icon\" data=\"[[FILENAME]]\" onclick=\"showVideo(this.getAttribute('data'))\"></span>
     <video class=\"video\" controls src=\"[[SOURCE]]\" id=\"video-[[FILENAME]]\" preload=\"none\"/>
   </p>
@@ -2145,16 +2477,16 @@ struct HTMLTemplates
 
   static let text = """
   <p class=\"attachment list-item\">
-    <span class=\"icon left text-icon\" style=\"margin-left: [[PADDING]]px\"></span>
-    [[NAME]]
+    <span class=\"icon text-icon\" style=\"margin-left: [[PADDING]]px\"></span>
+    <span class=\"row-name\">[[NAME]]</span>
     <span class=\"icon preview-icon\" data=\"[[SOURCE]]\" onclick=\"showText(this.getAttribute('data'))\"></span>
   </p>
   """
 
   static let link = """
   <p class=\"attachment list-item\">
-    <span class=\"icon left text-icon\" style=\"margin-left: [[PADDING]]px\"></span>
-    [[NAME]]
+    <span class=\"icon text-icon\" style=\"margin-left: [[PADDING]]px\"></span>
+    <span class=\"row-name\">[[NAME]]</span>
     <span class=\"icon preview-icon\" data=\"[[FILENAME]]\" onclick=\"showLinkAttachment(this.getAttribute('data'))\"></span>
     <a class=\"file-attachment-link\" href=\"[[SOURCE]]\" id=\"file-attachment-[[FILENAME]]\"></a>
   </p>

--- a/Sources/XCTestHTMLReportCore/Classes/HTMLTemplates.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/HTMLTemplates.swift
@@ -244,11 +244,13 @@ struct HTMLTemplates
         --color-bg-sidebar: #232327;
         --color-bg-group-header: #202024;
 
-        /* The tree's own surfaces. The activities panel is *darker* than the
-           page rather than lighter, which is the inversion of the light
-           theme and is what makes an expanded test read as recessed under
-           its row instead of floating above it — the same relationship the
-           summary band has to its cards. */
+        /* The tree's own surfaces. The activities panel is *lighter* than the
+           page here and *darker* than it in light, because white has no room
+           above it and this ground has little worth reading below it: each
+           theme steps the panel in the direction it actually has. What
+           carries the meaning is that it steps at all — one value off the
+           page is what makes an expanded test's steps read as their own
+           region under the row rather than as more tree. */
         --color-row-hover: #25252A;
         --color-bg-activities: #1D1D21;
         --color-fail-tint: #3A2226;
@@ -893,13 +895,29 @@ struct HTMLTemplates
     }
 
     /* Rows are indented by their container's padding, so a row's own box
-       starts at the indent and its background would too. `--row-bleed` paints
-       that background back out to the left edge with a horizontal shadow;
-       `.tests` is a scroll container, so it clips there. A shadow is ink
-       overflow rather than scrollable overflow, so nothing here widens the
-       page — the 375px probe covers that.
+       starts at the indent and its background would too. `--row-bleed` is how
+       far that background is carried back out into the gutter the indentation
+       spent; `.tests` is a scroll container, so it clips there. The mockup
+       does this — its failure tint and its expanded-test band both run to the
+       card's edge, under the disclosure column rather than starting after it.
 
-       Only the three row kinds that sit *in* the tree override it. Activity
+       A strip painted by `::before`, not an outer `box-shadow`. A shadow is
+       the whole border box translated, so an offset far enough left to clear
+       any indentation drags the box's *right* edge that far left with it: at
+       `-100vw` the shadow lands entirely at `x <= 0`, outside the viewport
+       and outside the container that clips it, and paints nothing at all. An
+       offset small enough to still overlap the row is one that a deep enough
+       tree or a narrow enough pane outruns. `right: 100%` has no such
+       arithmetic — the strip begins where the row begins and runs left for as
+       far as it is told, at every depth and every width.
+
+       `background-color: inherit`, so hover, selection and a suite heading's
+       own ground each reach the gutter by the same declaration that paints
+       the row, and a fourth state would too. Leftward overflow is unreachable
+       in a left-to-right scroll container, so nothing here widens the page —
+       the 375px probe covers that.
+
+       Only the three row kinds that sit *in* the tree get a strip. Activity
        and attachment rows deliberately do not: they live inside the
        activities panel, whose inset background and gutter rule are the thing
        that says "this belongs to the test above", and a row bleeding past
@@ -908,17 +926,33 @@ struct HTMLTemplates
     .test-summary > p,
     .test-summary-group > p,
     .iteration > p {
-      --row-bleed: -100vw;
+      --row-bleed: 100vw;
+      position: relative;
+    }
+
+    /* `bottom: -1px`, not `0`: an absolutely positioned child is laid out
+       against its containing block's *padding* box, so `0` would stop the
+       strip one hairline short of the row's own background and leave a bright
+       seam under every selected row. The 1px is the row's `border-bottom`
+       above. */
+    .test-summary > p::before,
+    .test-summary-group > p::before,
+    .iteration > p::before {
+      content: "";
+      position: absolute;
+      top: 0;
+      bottom: -1px;
+      right: 100%;
+      width: var(--row-bleed);
+      background-color: inherit;
     }
 
     .list-item:hover {
       background-color: var(--color-row-hover);
-      box-shadow: var(--row-bleed) 0 0 var(--color-row-hover);
     }
 
     .test-summary-group > p {
       background-color: var(--color-bg-group-header);
-      box-shadow: var(--row-bleed) 0 0 var(--color-bg-group-header);
       font-weight: var(--font-weight-medium);
     }
 
@@ -1134,15 +1168,16 @@ struct HTMLTemplates
        selected row leaves it selected rather than tinting it. */
     .list-item.selected {
       background-color: var(--color-accent);
-      box-shadow: var(--row-bleed) 0 0 var(--color-accent);
       color: var(--color-on-accent);
     }
 
     /* Summary header (#439, redesign A1).
 
-       Everything from here to the media query is new, and nothing below the
-       header was restyled: the tree, the panes and the filter pills are byte
-       for byte what they were. A2 restyles the tree; A3 the filters.
+       Everything from here to the media query is the header's own. A1 landed
+       it without restyling anything else; A2 has since restyled the tree, in
+       the block above, and the filter pills are still A3's. So a rule about a
+       row or a pill belongs where that thing is styled, not here — this block
+       stays the header's or it stops being findable.
 
        The band is a flex item of #content, capped at half the viewport so a
        run with a long failure digest can never push the tree off the screen —

--- a/Tests/XCTestHTMLReportTests/KnownLossMasker.swift
+++ b/Tests/XCTestHTMLReportTests/KnownLossMasker.swift
@@ -93,9 +93,19 @@ enum KnownLossMasker {
             // between the `<p>` and the name — so the anchor spans both
             // preceding lines. Anchoring on the icon span also keeps the rule
             // from ever touching a non-attachment `<p>`.
+            //
+            // `(?:left )?` because A2 (#439) made the row a flex line and
+            // dropped the `left` float class from the type icon. The optional
+            // group rather than a straight deletion: the anchor then matches
+            // a report rendered by either revision, and since the rule is
+            // still anchored on `<p class="attachment…">` above it, widening
+            // it here cannot reach a `<p>` it did not already reach. The
+            // replacement takes the whole name *line*, so it is indifferent
+            // to the name having gained a `<span class="row-name">` wrapper —
+            // both backends emit the wrapper, only the name inside it differs.
             let namedLines = replace(
                 html,
-                #"(<p class="attachment[^"]*">\n\s*<span class="icon left [a-z-]*icon"[^\n]*></span>\n)[^\n]*\n"#,
+                #"(<p class="attachment[^"]*">\n\s*<span class="icon (?:left )?[a-z-]*icon"[^\n]*></span>\n)[^\n]*\n"#,
                 with: "$1ATTACHMENT_NAME\n"
             )
             // One divergence, two sites since #462: the same display name is

--- a/Tests/XCTestHTMLReportTests/KnownLossMasker.swift
+++ b/Tests/XCTestHTMLReportTests/KnownLossMasker.swift
@@ -94,20 +94,24 @@ enum KnownLossMasker {
             // preceding lines. Anchoring on the icon span also keeps the rule
             // from ever touching a non-attachment `<p>`.
             //
-            // `(?:left )?` because A2 (#439) made the row a flex line and
-            // dropped the `left` float class from the type icon. The optional
-            // group rather than a straight deletion: the anchor then matches
-            // a report rendered by either revision, and since the rule is
-            // still anchored on `<p class="attachment…">` above it, widening
-            // it here cannot reach a `<p>` it did not already reach. The
-            // replacement takes the whole name *line*, so it is indifferent
-            // to the name having gained a `<span class="row-name">` wrapper —
-            // both backends emit the wrapper, only the name inside it differs.
-            let namedLines = replace(
-                html,
-                #"(<p class="attachment[^"]*">\n\s*<span class="icon (?:left )?[a-z-]*icon"[^\n]*></span>\n)[^\n]*\n"#,
-                with: "$1ATTACHMENT_NAME\n"
-            )
+            // The type icon's `left` float class is gone: A2 (#439) made the
+            // row a flex line. Deleted from the anchor rather than made
+            // optional. The masker only ever sees two renders of the *same*
+            // build — `DifferentialTests` compares two readers of one binary,
+            // `RunSummaryTests` uses the durations rule — so an anchor that
+            // also matched a pre-A2 report would widen the rule to buy a
+            // cross-revision property that nothing in the repo consumes.
+            //
+            // The replacement is anchored on the `row-name` wrapper A2 added
+            // and takes only the text inside it, not the whole line. The
+            // entry declares that attachment display *names* diverge; the
+            // wrapper markup around them is not part of that claim and stays
+            // compared, so a future divergence in the wrapper itself cannot
+            // hide under an entry that never covered it.
+            let nameInsideWrapper = #"(<p class="attachment[^"]*">\n"#
+                + #"\s*<span class="icon [a-z-]*icon"[^\n]*></span>\n"#
+                + #"\s*<span class="row-name">)[^<]*(</span>)"#
+            let namedLines = replace(html, nameInsideWrapper, with: "$1ATTACHMENT_NAME$2")
             // One divergence, two sites since #462: the same display name is
             // also the `alt` of every attachment-derived image. Masking only
             // the text line would let the `alt` reintroduce the difference

--- a/Tests/XCTestHTMLReportTests/Snapshots/index-inline.html
+++ b/Tests/XCTestHTMLReportTests/Snapshots/index-inline.html
@@ -237,11 +237,13 @@
       --color-bg-sidebar: #232327;
       --color-bg-group-header: #202024;
 
-      /* The tree's own surfaces. The activities panel is *darker* than the
-         page rather than lighter, which is the inversion of the light
-         theme and is what makes an expanded test read as recessed under
-         its row instead of floating above it — the same relationship the
-         summary band has to its cards. */
+      /* The tree's own surfaces. The activities panel is *lighter* than the
+         page here and *darker* than it in light, because white has no room
+         above it and this ground has little worth reading below it: each
+         theme steps the panel in the direction it actually has. What
+         carries the meaning is that it steps at all — one value off the
+         page is what makes an expanded test's steps read as their own
+         region under the row rather than as more tree. */
       --color-row-hover: #25252A;
       --color-bg-activities: #1D1D21;
       --color-fail-tint: #3A2226;
@@ -886,13 +888,29 @@
   }
 
   /* Rows are indented by their container's padding, so a row's own box
-     starts at the indent and its background would too. `--row-bleed` paints
-     that background back out to the left edge with a horizontal shadow;
-     `.tests` is a scroll container, so it clips there. A shadow is ink
-     overflow rather than scrollable overflow, so nothing here widens the
-     page — the 375px probe covers that.
+     starts at the indent and its background would too. `--row-bleed` is how
+     far that background is carried back out into the gutter the indentation
+     spent; `.tests` is a scroll container, so it clips there. The mockup
+     does this — its failure tint and its expanded-test band both run to the
+     card's edge, under the disclosure column rather than starting after it.
 
-     Only the three row kinds that sit *in* the tree override it. Activity
+     A strip painted by `::before`, not an outer `box-shadow`. A shadow is
+     the whole border box translated, so an offset far enough left to clear
+     any indentation drags the box's *right* edge that far left with it: at
+     `-100vw` the shadow lands entirely at `x <= 0`, outside the viewport
+     and outside the container that clips it, and paints nothing at all. An
+     offset small enough to still overlap the row is one that a deep enough
+     tree or a narrow enough pane outruns. `right: 100%` has no such
+     arithmetic — the strip begins where the row begins and runs left for as
+     far as it is told, at every depth and every width.
+
+     `background-color: inherit`, so hover, selection and a suite heading's
+     own ground each reach the gutter by the same declaration that paints
+     the row, and a fourth state would too. Leftward overflow is unreachable
+     in a left-to-right scroll container, so nothing here widens the page —
+     the 375px probe covers that.
+
+     Only the three row kinds that sit *in* the tree get a strip. Activity
      and attachment rows deliberately do not: they live inside the
      activities panel, whose inset background and gutter rule are the thing
      that says "this belongs to the test above", and a row bleeding past
@@ -901,17 +919,33 @@
   .test-summary > p,
   .test-summary-group > p,
   .iteration > p {
-    --row-bleed: -100vw;
+    --row-bleed: 100vw;
+    position: relative;
+  }
+
+  /* `bottom: -1px`, not `0`: an absolutely positioned child is laid out
+     against its containing block's *padding* box, so `0` would stop the
+     strip one hairline short of the row's own background and leave a bright
+     seam under every selected row. The 1px is the row's `border-bottom`
+     above. */
+  .test-summary > p::before,
+  .test-summary-group > p::before,
+  .iteration > p::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    bottom: -1px;
+    right: 100%;
+    width: var(--row-bleed);
+    background-color: inherit;
   }
 
   .list-item:hover {
     background-color: var(--color-row-hover);
-    box-shadow: var(--row-bleed) 0 0 var(--color-row-hover);
   }
 
   .test-summary-group > p {
     background-color: var(--color-bg-group-header);
-    box-shadow: var(--row-bleed) 0 0 var(--color-bg-group-header);
     font-weight: var(--font-weight-medium);
   }
 
@@ -1127,15 +1161,16 @@
      selected row leaves it selected rather than tinting it. */
   .list-item.selected {
     background-color: var(--color-accent);
-    box-shadow: var(--row-bleed) 0 0 var(--color-accent);
     color: var(--color-on-accent);
   }
 
   /* Summary header (#439, redesign A1).
 
-     Everything from here to the media query is new, and nothing below the
-     header was restyled: the tree, the panes and the filter pills are byte
-     for byte what they were. A2 restyles the tree; A3 the filters.
+     Everything from here to the media query is the header's own. A1 landed
+     it without restyling anything else; A2 has since restyled the tree, in
+     the block above, and the filter pills are still A3's. So a rule about a
+     row or a pill belongs where that thing is styled, not here — this block
+     stays the header's or it stops being findable.
 
      The band is a flex item of #content, capped at half the viewport so a
      run with a long failure digest can never push the tree off the screen —

--- a/Tests/XCTestHTMLReportTests/Snapshots/index-inline.html
+++ b/Tests/XCTestHTMLReportTests/Snapshots/index-inline.html
@@ -60,6 +60,27 @@
     --color-bg-sidebar: #F2F2F2;
     --color-bg-group-header: #F6F6F6;
 
+    /* Colour — the tests tree (#439, A2). Four roles the sheet had no way
+       to say before, because before this the tree painted nothing at all
+       between the page background and a selected row.
+
+       Every pairing was computed before it was used; the table is in the
+       PR body. The tightest text pairing these introduce is the failure
+       message on its own tint — 4.74:1 light, 5.35:1 dark, against a 4.5
+       floor — and the tightest status badge is passed on a hovered row,
+       3.69:1 light and 6.54:1 dark against the 3:1 non-text floor.
+
+       --color-tree-guide is deliberately below 3:1 (1.28 light / 1.44
+       dark, against the panel it is drawn on), for the same reason
+       --color-summary-border is: the timeline
+       rule restates the nesting that indentation already states, so it is
+       decorative under 1.4.11 and drawing it at 3:1 would put a hard black
+       bar down the middle of every expanded test. */
+    --color-row-hover: #F0F0F2;
+    --color-bg-activities: #F7F7F9;
+    --color-fail-tint: #FDEDEC;
+    --color-tree-guide: #DCDCE1;
+
     /* Colour — the summary header (#439, A1). A band with cards on it,
        which is one more surface level than the rest of the report has, so
        these are their own tokens rather than reuses. Values are Apple's
@@ -90,7 +111,13 @@
     --color-border-medium: #CCC;
     --color-border-light: #DDD;
     --color-border-faint: #E5E5E5;
-    --color-preview-border: #021a40;
+    /* Was #021A40 — a near-black navy, and the only colour in the light
+       theme that belonged to no family. It framed the screenshot flow in a
+       hard dark rectangle; the dark theme had already been given a normal
+       border value for it. This is the light theme's equivalent, so the
+       frame now reads as a frame in both. Decorative: it outlines an image
+       that is itself the content. */
+    --color-preview-border: #D2D2D7;
 
     /* Typography — the system UI face, so the report looks native on the
        platform it is read on. `system-ui` first, `-apple-system` for the
@@ -121,22 +148,50 @@
     --preview-height: 600px;
     --radius-sm: 3px;
 
+    /* One nesting level of the tree. Applied to the child container, not
+       written into the markup — see the indentation rule below for why
+       that distinction is load-bearing for the differential. */
+    --tree-indent: 16px;
+
+    /* How far a row's background bleeds left, past the indentation its
+       container spends. Declared here at its *off* value and overridden to
+       a real distance by the three row kinds that want it, so the default
+       lives in one place and `tokens.spec.ts` can see it declared like any
+       other custom property. */
+    --row-bleed: 0;
+
     /* Glyphs. Shapes, not colours — the colour is applied separately (see
        the icon block below), which is why these are shared by both themes
        and the dark block does not repeat them. Kept here so the sheet has
        exactly one place where the report's iconography is defined.
 
-       Geometry note: every status glyph is the same rounded diamond, so
-       the six states differ by what sits inside it and by shape — filled
-       with a knock-out for the three settled outcomes, outlined for the
-       three that are qualified. That reproduces the diamond the PNGs drew,
-       which is the identity this refresh is keeping. */
-    --icon-status-passed: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cmask id='a'%3E%3Cpath d='M9.06 1.66 14.34 6.94Q15.4 8 14.34 9.06L9.06 14.34Q8 15.4 6.94 14.34L1.66 9.06Q.6 8 1.66 6.94L6.94 1.66Q8 .6 9.06 1.66Z' fill='white'/%3E%3Cpath d='M4.7 8.2 6.9 10.5 11.3 5.6' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/mask%3E%3Crect width='16' height='16' mask='url(%23a)'/%3E%3C/svg%3E");
-    --icon-status-failed: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cmask id='a'%3E%3Cpath d='M9.06 1.66 14.34 6.94Q15.4 8 14.34 9.06L9.06 14.34Q8 15.4 6.94 14.34L1.66 9.06Q.6 8 1.66 6.94L6.94 1.66Q8 .6 9.06 1.66Z' fill='white'/%3E%3Cpath d='M5.6 5.6 10.4 10.4M10.4 5.6 5.6 10.4' fill='none' stroke='black' stroke-width='2' stroke-linecap='round'/%3E%3C/mask%3E%3Crect width='16' height='16' mask='url(%23a)'/%3E%3C/svg%3E");
-    --icon-status-skipped: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cmask id='a'%3E%3Cpath d='M9.06 1.66 14.34 6.94Q15.4 8 14.34 9.06L9.06 14.34Q8 15.4 6.94 14.34L1.66 9.06Q.6 8 1.66 6.94L6.94 1.66Q8 .6 9.06 1.66Z' fill='white'/%3E%3Cpath d='M5.4 9.9 10.6 6.1M6.1 6.1h4.5v4.5' fill='none' stroke='black' stroke-width='1.8' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/mask%3E%3Crect width='16' height='16' mask='url(%23a)'/%3E%3C/svg%3E");
-    --icon-status-mixed: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cmask id='a'%3E%3Cpath d='M9.06 1.66 14.34 6.94Q15.4 8 14.34 9.06L9.06 14.34Q8 15.4 6.94 14.34L1.66 9.06Q.6 8 1.66 6.94L6.94 1.66Q8 .6 9.06 1.66Z' fill='white'/%3E%3Cpath d='M8 1.2V14.8' fill='none' stroke='black' stroke-width='1.4'/%3E%3C/mask%3E%3Crect width='16' height='16' mask='url(%23a)'/%3E%3C/svg%3E");
-    --icon-status-unknown: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M9.06 1.66 14.34 6.94Q15.4 8 14.34 9.06L9.06 14.34Q8 15.4 6.94 14.34L1.66 9.06Q.6 8 1.66 6.94L6.94 1.66Q8 .6 9.06 1.66Z' fill='none' stroke='black' stroke-width='1.6'/%3E%3Cpath d='M6.5 6.4a1.6 1.6 0 1 1 1.6 1.9v.8' fill='none' stroke='black' stroke-width='1.3' stroke-linecap='round'/%3E%3Ccircle cx='8.1' cy='11.2' r='.8'/%3E%3C/svg%3E");
-    --icon-status-expected: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M9.06 1.66 14.34 6.94Q15.4 8 14.34 9.06L9.06 14.34Q8 15.4 6.94 14.34L1.66 9.06Q.6 8 1.66 6.94L6.94 1.66Q8 .6 9.06 1.66Z' fill='none' stroke='black' stroke-width='1.6'/%3E%3Cpath d='M8 4.8v3.6' stroke='black' stroke-width='1.6' stroke-linecap='round'/%3E%3Ccircle cx='8' cy='11' r='.9'/%3E%3C/svg%3E");
+       Geometry note (#439, A2). Every status glyph is the same rounded
+       square — Xcode 26's badge — and the six states differ by the glyph
+       inside it and by whether the square is filled or outlined. Filled
+       means the outcome is settled (passed, failed, skipped, mixed and
+       expected-failure: a test that failed exactly as it declared it
+       would is a settled outcome); outlined means it is not (unknown is
+       the only state that means "we could not tell").
+
+       This replaces the rounded diamond #459 drew. The six *shapes* are
+       the same six #459 introduced, which is the property that mattered:
+       status is never colour alone, and no state renders a blank cell.
+       Only the silhouette moved, and it moved because Option A's whole
+       premise is reading as a sibling of Xcode's own report.
+
+       The glyph is a knock-out — a hole showing whatever surface the row
+       paints — rather than the white glyph the mockup draws. White on the
+       mockup's green is 3.13:1; a knock-out's contrast against its fill
+       is by construction the status token's contrast against the row,
+       which is the pairing #439 already sized to clear 3:1 in both
+       themes. Same picture on a white row, a measured one everywhere
+       else. */
+    --icon-status-passed: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cmask id='a'%3E%3Crect x='1' y='1' width='14' height='14' rx='4.2' fill='white'/%3E%3Cpath d='M4.6 8.15 6.85 10.4 11.4 5.75' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/mask%3E%3Crect width='16' height='16' mask='url(%23a)'/%3E%3C/svg%3E");
+    --icon-status-failed: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cmask id='a'%3E%3Crect x='1' y='1' width='14' height='14' rx='4.2' fill='white'/%3E%3Cpath d='M5.7 5.7 10.3 10.3M10.3 5.7 5.7 10.3' fill='none' stroke='black' stroke-width='2' stroke-linecap='round'/%3E%3C/mask%3E%3Crect width='16' height='16' mask='url(%23a)'/%3E%3C/svg%3E");
+    --icon-status-skipped: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cmask id='a'%3E%3Crect x='1' y='1' width='14' height='14' rx='4.2' fill='white'/%3E%3Cpath d='M5.5 10.1 10.4 5.9M6.2 5.9h4.3v4.3' fill='none' stroke='black' stroke-width='1.8' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/mask%3E%3Crect width='16' height='16' mask='url(%23a)'/%3E%3C/svg%3E");
+    --icon-status-mixed: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cmask id='a'%3E%3Crect x='1' y='1' width='14' height='14' rx='4.2' fill='white'/%3E%3Cpath d='M8 .6V15.4' fill='none' stroke='black' stroke-width='1.4'/%3E%3C/mask%3E%3Crect width='16' height='16' mask='url(%23a)'/%3E%3C/svg%3E");
+    --icon-status-unknown: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Crect x='1.8' y='1.8' width='12.4' height='12.4' rx='3.4' fill='none' stroke='black' stroke-width='1.6'/%3E%3Cpath d='M6.5 6.4a1.6 1.6 0 1 1 1.6 1.9v.8' fill='none' stroke='black' stroke-width='1.3' stroke-linecap='round'/%3E%3Ccircle cx='8.1' cy='11.2' r='.8'/%3E%3C/svg%3E");
+    --icon-status-expected: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cmask id='a'%3E%3Crect x='1' y='1' width='14' height='14' rx='4.2' fill='white'/%3E%3Cpath d='M8 4.3v4.2' fill='none' stroke='black' stroke-width='2' stroke-linecap='round'/%3E%3Ccircle cx='8' cy='11.4' r='1.05' fill='black'/%3E%3C/mask%3E%3Crect width='16' height='16' mask='url(%23a)'/%3E%3C/svg%3E");
     --icon-disclosure: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 10'%3E%3Cpath d='M3 1.4 8 5 3 8.6Z'/%3E%3C/svg%3E");
     --icon-disclosure-open: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 10'%3E%3Cpath d='M1.4 3 8.6 3 5 8Z'/%3E%3C/svg%3E");
     --icon-paperclip: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M2.7 15.3c-.7 0-1.4-.3-1.9-.8-.9-.9-1.2-2.5 0-3.7l8.9-8.9c1.4-1.4 3.8-1.4 5.2 0s1.4 3.8 0 5.2l-7.4 7.4c-.2.2-.5.2-.7 0s-.2-.5 0-.7l7.4-7.4c1-1 1-2.7 0-3.7s-2.7-1-3.7 0l-8.9 8.9c-.8.8-.6 1.7 0 2.2.6.6 1.5.8 2.2 0l8.9-8.9c.2-.2.2-.5 0-.7s-.5-.2-.7 0l-7.4 7.4c-.2.2-.5.2-.7 0s-.2-.5 0-.7l7.4-7.4c.6-.6 1.6-.6 2.2 0s.6 1.6 0 2.2l-8.9 8.9c-.6.4-1.3.7-1.9.7z'/%3E%3C/svg%3E");
@@ -144,7 +199,6 @@
     --icon-document: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cmask id='a'%3E%3Cpath d='M3.2 1.4h6L13 5.2v9.4H3.2Z' fill='white'/%3E%3Cpath d='M5.2 7.4h5.6M5.2 9.6h5.6M5.2 11.8h3.6' stroke='black' stroke-width='1.1' stroke-linecap='round'/%3E%3Cpath d='M8.9 1.6v3.6h3.6' fill='none' stroke='black' stroke-width='1.1'/%3E%3C/mask%3E%3Crect width='16' height='16' mask='url(%23a)'/%3E%3C/svg%3E");
     --icon-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cmask id='a'%3E%3Crect x='1.4' y='2.8' width='13.2' height='10.4' rx='1.4' fill='white'/%3E%3Cpath d='M2.6 12 6.3 7.6l2.5 2.6 2-2 2.6 3.8Z' fill='black'/%3E%3Ccircle cx='5.4' cy='6' r='1.3' fill='black'/%3E%3C/mask%3E%3Crect width='16' height='16' mask='url(%23a)'/%3E%3C/svg%3E");
     --icon-video: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cmask id='a'%3E%3Crect x='1.4' y='3.2' width='13.2' height='9.6' rx='1.4' fill='white'/%3E%3Cpath d='M6.6 5.9 11 8l-4.4 2.1Z' fill='black'/%3E%3C/mask%3E%3Crect width='16' height='16' mask='url(%23a)'/%3E%3C/svg%3E");
-    --icon-test: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cmask id='a'%3E%3Crect x='1.6' y='1.6' width='12.8' height='12.8' rx='2.6' fill='white'/%3E%3Cpath d='M8.6 3.9v6.4a1.4 1.4 0 0 0 1.4 1.4h.6M6.1 6.6h4.3' fill='none' stroke='black' stroke-width='1.5' stroke-linecap='round'/%3E%3C/mask%3E%3Crect width='16' height='16' mask='url(%23a)'/%3E%3C/svg%3E");
   }
 
   /* Dark theme. Token values only — every selector in the sheet is shared
@@ -182,6 +236,16 @@
       --color-surface: #161619;
       --color-bg-sidebar: #232327;
       --color-bg-group-header: #202024;
+
+      /* The tree's own surfaces. The activities panel is *darker* than the
+         page rather than lighter, which is the inversion of the light
+         theme and is what makes an expanded test read as recessed under
+         its row instead of floating above it — the same relationship the
+         summary band has to its cards. */
+      --color-row-hover: #25252A;
+      --color-bg-activities: #1D1D21;
+      --color-fail-tint: #3A2226;
+      --color-tree-guide: #38383E;
 
       /* The summary header's own surfaces. The card is the same value as
          the sidebar, which is deliberate: it is the lightest ground in the
@@ -377,10 +441,16 @@
     color: var(--color-text-muted);
   }
 
+  /* The tree's column header. Two labels, at the two ends of the row the
+     columns actually occupy, rather than the old "Status | Tests" pair
+     stacked against the left edge — there is a duration column to name now,
+     and naming it is the only thing that makes it read as a column. */
   .table-header {
+    display: flex;
     min-height: 18px;
     margin: 0;
-    padding-top: 0;
+    padding: 2px var(--space-sm) 2px 6px;
+    border-bottom: 1px solid var(--color-border-light);
   }
 
   .table-header li {
@@ -389,8 +459,7 @@
   }
 
   .table-header li+li {
-    border-left: 1px solid var(--color-border-medium);
-    padding-left: var(--space-xs);
+    margin-left: auto;
   }
 
   #logs {
@@ -453,10 +522,10 @@
     display: inline-block;
   }
 
-  .left {
-    float: left;
-  }
-
+  /* `.left` lived here until A2. Every element that carried it was a tree
+     icon clearing a float gutter, and the tree is flex now, so the class
+     reached nothing in the rendered page — verified against both goldens.
+     `.clear` stays: `#title` and `#container` still float. */
   .clear {
     clear: both;
   }
@@ -483,93 +552,68 @@
     mask-image: var(--icon-video);
   }
 
-  /* The one glyph that is not `currentColor`: the rounded blue tile is the
-     project's own mark, so it keeps its colour instead of inheriting the
-     row's — except on a selected row, where the accent fill would put blue
-     on blue. Today's PNG has no such escape and does disappear there. */
-  .test-icon {
-    display: none;
-    background-color: var(--color-accent);
-    -webkit-mask-image: var(--icon-test);
-    mask-image: var(--icon-test);
-  }
-
-  .list-item.selected .test-icon {
-    background-color: var(--color-on-accent);
-  }
-
-  .test-summary p > .test-icon {
-    display: block;
-  }
-
-  .test-summary.no-drop-down .drop-down-icon {
-    display: none;
-  }
-
-  .test-summary.no-drop-down .test-icon {
-    margin-left: 22px;
-  }
-
-  /* The gutter the status glyph sits in. `margin-left` lives here rather
-     than on the per-status rules below so that one single-class rule can
-     narrow it on small screens; the per-status rules carry three classes
-     each, which no media query could outrank without `!important`. */
+  /* The status badge. It is a flex item of the row now rather than a float
+     beside it, so the gutter it used to need — a 28px margin on the icon
+     plus a matching 52px padding on every `<p>` in the tree, whether or not
+     that row had a badge — is gone, and the tree recovers ~38px of width at
+     every screen size. */
   .test-result-icon {
-    float: left;
     display: none;
-    margin: var(--space-xs);
-    margin-left: 28px;
+    flex: none;
+    margin: 0;
   }
 
   /* Which rows show a status glyph at all. Before #439 only the three
      states that had a PNG appeared here, so `mixed`, `unknown` and
      `expectedFailure` rows rendered an empty status cell — the audit's
      finding 4. All six states now have one, and each is a distinct shape,
-     not just a distinct colour. Group headings are deliberately still
-     absent: giving them icons is a layout change beyond this PR.
+     not just a distinct colour.
 
-     `>`, not a descendant combinator, throughout the status rules. A
-     retried test nests its iterations *inside* the row, and each carries
-     its own `.test-result-icon`; matched loosely, the outer row's rule
-     reaches them too, and since every one of these selectors has the same
-     specificity the winner is whichever is written last. That was
-     invisible while only three states had rules — a failed test's
-     iterations are usually failed as well — and showed up the moment
-     `mixed` existed: `testRetryOnFailure()`'s two iterations, one failed
-     and one passed, both drew the split diamond of their parent. */
-  .test-summary.succeeded > .test-result-icon,
-  .test-summary.skipped > .test-result-icon,
-  .test-summary.failed > .test-result-icon,
-  .test-summary.mixed > .test-result-icon,
-  .test-summary.unknown > .test-result-icon,
-  .test-summary.expected-failure > .test-result-icon,
-  .iteration.succeeded > .test-result-icon,
-  .iteration.skipped > .test-result-icon,
-  .iteration.failed > .test-result-icon,
-  .iteration.mixed > .test-result-icon,
-  .iteration.unknown > .test-result-icon,
-  .iteration.expected-failure > .test-result-icon {
+     Suite headings join them in A2. #459 left them out because the badge
+     was a float and giving one to a heading meant reworking the gutter;
+     now that a row is a flex line it is a selector, and the mockup's tree
+     puts a badge on every suite. Nothing new is computed for it —
+     `TestGroup.status` already folds its children's outcomes and already
+     writes the class onto the row.
+
+     `> p >`, not a descendant combinator, throughout. It used to be
+     `> .test-result-icon` because the badge was a sibling of the row; A2
+     makes it a flex item *of* the row, so the path gained a level and kept
+     the same property. That property is load-bearing twice over: a retried
+     test nests its iterations inside the row and a suite nests its cases
+     inside its own, and every one of those carries a `.test-result-icon`.
+     Matched loosely, an outer row's rule reaches all of them, and since
+     these selectors all have the same specificity the winner would be
+     whichever is written last — which is how `testRetryOnFailure()`'s two
+     iterations, one failed and one passed, once both drew their parent's
+     split glyph.
+
+     `:is()` groups the three row kinds rather than writing eighteen
+     selectors out. It contributes the specificity of its most specific
+     argument, and every argument here is one class, so each rule stays at
+     exactly the (0,3,1) the written-out form had — which the selection
+     override below relies on. */
+  :is(.test-summary, .test-summary-group, .iteration):is(
+    .succeeded, .skipped, .failed, .mixed, .unknown, .expected-failure
+  ) > p > .test-result-icon {
     display: block;
   }
 
-  .test-summary.succeeded > .test-result-icon,
-  .iteration.succeeded > .test-result-icon,
+  :is(.test-summary, .test-summary-group, .iteration).succeeded > p > .test-result-icon,
   .success {
     background-color: var(--status-passed);
     -webkit-mask-image: var(--icon-status-passed);
     mask-image: var(--icon-status-passed);
   }
 
-  .test-summary.skipped > .test-result-icon,
-  .iteration.skipped > .test-result-icon,
+  :is(.test-summary, .test-summary-group, .iteration).skipped > p > .test-result-icon,
   .skip {
     background-color: var(--status-skipped);
     -webkit-mask-image: var(--icon-status-skipped);
     mask-image: var(--icon-status-skipped);
   }
 
-  .test-summary.failed > .test-result-icon,
-  .iteration.failed > .test-result-icon,
+  :is(.test-summary, .test-summary-group, .iteration).failed > p > .test-result-icon,
   .failure {
     background-color: var(--status-failed);
     -webkit-mask-image: var(--icon-status-failed);
@@ -577,11 +621,10 @@
   }
 
   /* Mixed is the one glyph that carries two colours, because "some passed,
-     some failed" is what it means. The mask is a plain diamond split by a
+     some failed" is what it means. The mask is a plain badge split by a
      thin cut, and the two halves are a hard-stop gradient — so both halves
      are tokens and follow the theme, which a two-colour image could not. */
-  .test-summary.mixed > .test-result-icon,
-  .iteration.mixed > .test-result-icon {
+  :is(.test-summary, .test-summary-group, .iteration).mixed > p > .test-result-icon {
     background-color: transparent;
     background-image: linear-gradient(
       90deg,
@@ -592,25 +635,46 @@
     mask-image: var(--icon-status-mixed);
   }
 
-  .test-summary.unknown > .test-result-icon,
-  .iteration.unknown > .test-result-icon {
+  :is(.test-summary, .test-summary-group, .iteration).unknown > p > .test-result-icon {
     background-color: var(--status-unknown);
     -webkit-mask-image: var(--icon-status-unknown);
     mask-image: var(--icon-status-unknown);
   }
 
-  .test-summary.expected-failure > .test-result-icon,
-  .iteration.expected-failure > .test-result-icon {
+  :is(.test-summary, .test-summary-group, .iteration).expected-failure > p > .test-result-icon {
     background-color: var(--status-expected);
     -webkit-mask-image: var(--icon-status-expected);
     mask-image: var(--icon-status-expected);
   }
 
+  /* On a selected row the badge is painted in the selection's own text
+     colour and the accent knocks through the glyph, rather than the badge
+     staying a status hue. Measured against the fill it would otherwise sit
+     on: passed is 1.36:1 light and 2.07:1 dark against the accent — an
+     invisible badge on precisely the row the reader is looking at.
+     White-on-accent is 5.71 / 4.82. The outcome stays readable because the
+     *shape* carries it, which is the #459 property that status is never
+     colour alone.
+
+     Written with the element selector and placed after the status rules
+     deliberately: it has to match their (0,3,1) and win on order, and it
+     has to clear `mixed`'s gradient as well as the flat fills. */
+  p.list-item.selected > .test-result-icon {
+    background-color: var(--color-on-accent);
+    background-image: none;
+  }
+
+  /* The triangle is the row's quietest element, so it takes the muted text
+     colour rather than `currentColor` — which on a failure row would have
+     made it as loud as the failure. `flex: none` because it is the column
+     every row's badge aligns against; a shrunk triangle is a bent column. */
   .drop-down-icon {
     cursor: pointer;
+    flex: none;
     height: var(--icon-size-sm);
     width: var(--icon-size-sm);
-    margin-top: 2px;
+    margin: 0;
+    background-color: var(--color-text-muted);
     -webkit-mask-image: var(--icon-disclosure);
     mask-image: var(--icon-disclosure);
   }
@@ -620,31 +684,70 @@
     mask-image: var(--icon-disclosure-open);
   }
 
+  p.list-item.selected > .drop-down-icon {
+    background-color: var(--color-on-accent);
+  }
+
+  /* The eye is a control, not a label, so it takes the accent the rest of
+     the sheet uses for "you can click this" (`.digest-jump`) instead of
+     inheriting the row's text colour. */
   .preview-icon {
     cursor: pointer;
     display: inline-block;
+    flex: none;
     height: 11px;
     width: 14px;
+    background-color: var(--color-accent-text);
     -webkit-mask-image: var(--icon-preview);
     mask-image: var(--icon-preview);
   }
 
-  .activities {
-    display: none;
+  p.list-item.selected > .preview-icon,
+  p.list-item.selected > .paperclip-icon {
+    background-color: var(--color-on-accent);
   }
 
-  .activity.activity-assertion-failure > p {
+  /* An expanded test's activities (#439, A2). The mockup draws this as a
+     timeline: an inset panel under the test, a rule down its gutter, and an
+     elapsed offset against every row.
+
+     The offsets are not here, and are not faked. 4.0's `ParsedActivity`
+     carries a title, a failure flag, attachments and sub-activities —
+     `finish` and the per-activity timestamps left with the legacy reader
+     (see the port's decision 2), so there is no field to render and no
+     honest way to derive one. The rest of the treatment applies unchanged,
+     and the gutter still does the job the offsets shared: it says where the
+     detail of one test starts and stops. */
+  .activities {
+    display: none;
+    margin-left: var(--tree-indent);
+    border-left: 2px solid var(--color-tree-guide);
+    background-color: var(--color-bg-activities);
+  }
+
+  /* Single class, so `.list-item:hover` (two) still wins the background and
+     a failure row highlights like any other. The red text is what survives
+     the hover, which is the part that carries the meaning. */
+  .activity-assertion-failure > p {
+    background-color: var(--color-fail-tint);
     color: var(--status-failed);
+    font-weight: var(--font-weight-medium);
   }
 
   .sub-activities {
     display: none;
   }
 
+  /* Depth inside the activities panel, one 10px step per level, written by
+     `Activity.padding` into the element's own style attribute. Kept as a
+     spacer element rather than folded into the row's padding because the
+     model already computes it — including the +18px a leaf spends standing
+     in for the triangle it does not draw. `float` had to go: floats do not
+     apply to flex items, and the row is a flex line now. */
   .padding {
-    float: left;
+    flex: none;
     width: 1px;
-    height:1px;
+    height: 1px;
   }
 
   .activity.no-drop-down .drop-down-icon {
@@ -667,6 +770,16 @@
     overflow-y: scroll;
   }
 
+  /* The list takes focus so it can be scrolled from the keyboard (see the
+     `run` template). `:focus-visible`, not `:focus`, so clicking a row does
+     not draw a ring around the whole tree; `outline-offset` is negative
+     because the outline of a scroll container is drawn at its padding edge
+     and a positive offset would sit under the pane beside it. */
+  .tests:focus-visible {
+    outline: 2px solid var(--color-accent);
+    outline-offset: -2px;
+  }
+
   .tests-header, #logs-header {
     width: 100%;
   }
@@ -679,19 +792,136 @@
     margin-left: var(--space-sm);
   }
 
+  /* ---- The tests tree (#439, A2) ------------------------------------
+
+     Every row in the tree — suite heading, test case, iteration, activity,
+     attachment — is one flex line: triangle, status badge, name, then the
+     duration pushed to its own right-hand column. What this replaces was a
+     pair of floats clearing a fixed 52px of left padding, which is why the
+     duration could only ever be more text after the name and why a row with
+     no badge still paid for the gutter of one. */
   .test-summary p, .test-summary-group p, .iteration p, .activity p {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    min-height: 24px;
     font-size: var(--font-size-sm);
-    padding: var(--space-xs) var(--space-xs) var(--space-xs) 52px;
+    padding: 3px var(--space-sm) 3px 6px;
     border-bottom: 1px solid var(--color-border-faint);
+  }
+
+  /* No hairlines inside an expanded test. The panel's own inset surface and
+     the rule down its gutter already bound the region, and the mockup's
+     timeline draws no separators between its steps — with them, a test with
+     thirty activities reads as thirty more tests. */
+  .activities p {
+    border-bottom: 0;
+  }
+
+  /* The name takes the slack and wraps inside it; `min-width: 0` because a
+     flex item refuses to shrink below its content otherwise, and test names
+     are long unbroken identifiers. */
+  .row-name {
+    flex: 1 1 auto;
+    min-width: 0;
+    overflow-wrap: anywhere;
+  }
+
+  /* Inside the activities panel there is no right-hand column to push
+     against — no per-activity duration exists to put there — so the name
+     stops claiming the slack and the paperclip and the eye stay beside the
+     thing they belong to instead of drifting to the far edge. */
+  .activity > p > .row-name,
+  .attachment > .row-name {
+    flex: 0 1 auto;
+  }
+
+  /* The duration column.
+
+     `(N.NNs)` is not a styling choice and must not be edited into a bare
+     `N.NNs`: it is literally the shape `KnownLossMasker`'s `durations` rule
+     normalises, so every duration in the tree inherits a loss the allow-list
+     already declares. A2 moves where the text sits and changes nothing about
+     what it says. `RunSummaryTests.testTheHeadersDurationIsWrittenInAMaskedShape`
+     holds the same property for the header. */
+  .row-duration {
+    flex: none;
+    padding-left: var(--space-sm);
+    color: var(--color-text-muted);
+    font-variant-numeric: tabular-nums;
+  }
+
+  /* Annotations beside a name — today only a retried test's per-status
+     breakdown ("1 failed, 1 succeeded"). A bordered chip, the mockup's
+     treatment for the same class of aside. */
+  .row-note {
+    flex: none;
+    padding: 0 5px;
+    border: 1px solid var(--color-border-medium);
+    border-radius: var(--radius-sm);
+    color: var(--color-text-muted);
+    font-size: var(--font-size-xs);
+  }
+
+  p.list-item.selected > .row-duration,
+  p.list-item.selected > .row-note {
+    color: var(--color-on-accent);
+  }
+
+  /* Indentation.
+
+     Nesting depth is carried by the DOM and applied to the child container,
+     never written into the markup as a number. That is not a stylistic
+     preference: the legacy backend interposes two wrapper levels ("Selected
+     tests", "<target>.xctest") that the modern backend does not, so a depth
+     written into an attribute would differ between the two renders in every
+     row of the tree — and `KnownLossMasker`'s `wrapperGroups` rule unwraps
+     the *element*, which would leave the numbers behind and turn
+     `DifferentialTests` red with no allow-list entry able to cover it.
+     Nested padding indents by construction and costs the differential
+     exactly nothing. */
+  .test-summary-group > .test-summary,
+  .test-summary-group > .test-summary-group {
+    padding-left: var(--tree-indent);
+  }
+
+  /* Rows are indented by their container's padding, so a row's own box
+     starts at the indent and its background would too. `--row-bleed` paints
+     that background back out to the left edge with a horizontal shadow;
+     `.tests` is a scroll container, so it clips there. A shadow is ink
+     overflow rather than scrollable overflow, so nothing here widens the
+     page — the 375px probe covers that.
+
+     Only the three row kinds that sit *in* the tree override it. Activity
+     and attachment rows deliberately do not: they live inside the
+     activities panel, whose inset background and gutter rule are the thing
+     that says "this belongs to the test above", and a row bleeding past
+     them would erase exactly that. They keep the `:root` default of `0` and
+     highlight in place. */
+  .test-summary > p,
+  .test-summary-group > p,
+  .iteration > p {
+    --row-bleed: -100vw;
+  }
+
+  .list-item:hover {
+    background-color: var(--color-row-hover);
+    box-shadow: var(--row-bleed) 0 0 var(--color-row-hover);
   }
 
   .test-summary-group > p {
     background-color: var(--color-bg-group-header);
+    box-shadow: var(--row-bleed) 0 0 var(--color-bg-group-header);
     font-weight: var(--font-weight-medium);
   }
 
+  /* `visibility`, not `display`: a suite row has no working disclosure to
+     draw — collapsing a group is a script change, and the filter and
+     collapse scripts are A3's to rewire, not A2's to restyle around — but
+     the column still has to hold, or a suite's badge would sit 16px left of
+     its own children's and the tree would look bent. */
   .test-summary-group > p > .drop-down-icon {
-    display: none;
+    visibility: hidden;
   }
 
   .screenshot {
@@ -740,16 +970,28 @@
     display:none;
   }
 
-  .screenshot-flow {
-      border: 1px solid var(--color-preview-border);
-      background-color: var(--color-surface);
-      height: 200px;
-  }
+  /* The screenshot flow — the frames a UI test walked through, rendered in
+     the tree rather than in the attachment pane.
 
+     Sized like the mockup's inline player: a bounded box, not a slab. At a
+     fixed 200px (350px for the tail) and no width bound these were the
+     tallest thing in the tree by a factor of eight, so a test with a flow
+     pushed every row after it off the screen — and `.screenshot-tail` is
+     emitted *between* rows, so it did that to the tree, not to the panel.
+     `max-height` with `height: auto` keeps whatever aspect ratio the device
+     recorded instead of stretching a phone frame to a fixed height. */
+  .screenshot-flow,
   .screenshot-tail {
+      display: block;
+      width: auto;
+      max-width: min(300px, 100%);
+      height: auto;
+      max-height: 200px;
+      margin: 6px 0 6px var(--tree-indent);
+      object-fit: contain;
       border: 1px solid var(--color-preview-border);
+      border-radius: 8px;
       background-color: var(--color-surface);
-      height: 350px;
   }
 
   #content {
@@ -881,11 +1123,11 @@
     color: var(--status-failed);
   }
 
+  /* After `.list-item:hover`, and matching its specificity, so hovering the
+     selected row leaves it selected rather than tinting it. */
   .list-item.selected {
     background-color: var(--color-accent);
-  }
-
-  .list-item.selected {
+    box-shadow: var(--row-bleed) 0 0 var(--color-accent);
     color: var(--color-on-accent);
   }
 
@@ -904,6 +1146,18 @@
     padding: var(--space-sm) var(--space-sm) 12px;
     max-height: 50vh;
     overflow-y: auto;
+  }
+
+  /* The band belongs to the test run, so the Logs tab gets the column to
+     itself (#439, A2). `display: none` rather than a height animation: the
+     band is up to half the viewport and the log is an iframe, so anything
+     that resized it over several frames would reflow and repaint the frame
+     the whole way down. One class, one reflow, no jank. The rule sits with
+     the band's own styles and applies at every width — below 700px, where
+     the band already yields to a 40vh cap, reclaiming all of it is the
+     difference between a readable log and four lines of one. */
+  body.logs-active #run-summary {
+    display: none;
   }
 
   .summary-card {
@@ -1169,11 +1423,30 @@
        filenames. Stacked vertically that minimum became the column's
        width, which pushed the whole tree, and the filter pills with it,
        off the side of a 375px screen. Nothing above the query needs this
-       because there the panes are fixed widths. */
+       because there the panes are fixed widths.
+
+       `min-height` for the same reason on the other axis, and it fixes a
+       worse bug: below 700px `#container` is a *column*, so the tree is
+       sized on the block axis by this same automatic minimum, and
+       `min-height: auto` let `.tests` grow to the full height of every row
+       it holds instead of scrolling inside its share. `body` has
+       `overflow: hidden`, so everything past the first viewport was not
+       merely unscrolled but unreachable — on a long run the last test in
+       the report could not be brought on screen at all. Only the scroll
+       container itself strictly needs it, but the automatic minimum
+       propagates up a flex chain, so all three do.
+
+       Pre-existing — the column layout arrived with the narrow-screen work
+       in #459 — and made materially worse by A1: the summary band spends
+       real height above the tree, so the clipped region grew by exactly
+       what the band occupies. Found while shooting this PR's 375px
+       screenshots; `visual/tests/behaviour.spec.ts` now scrolls to the last
+       row at 375 so it cannot come back. */
     #main-content,
     .run,
     .tests {
       min-width: 0;
+      min-height: 0;
     }
 
     /* `flex: none` because the strip is now a row in a column container:
@@ -1235,19 +1508,25 @@
       display: none;
     }
 
-    /* Reclaim the 16px the status gutter spends. At 375px that is the
-       difference between a test name fitting on one line and wrapping. */
-    .test-summary p, .test-summary-group p, .iteration p, .activity p {
-      padding-left: 36px;
+    /* The flex row already spends only what it draws, so there is no fixed
+       gutter left to reclaim here — what A1 needed this rule for is gone.
+       What is left is the indentation step: 16px per level is right at
+       1440px and profligate on a 375px screen four levels deep, where the
+       legacy backend's two wrapper levels alone would eat 32px before the
+       first suite. */
+    .test-summary-group > .test-summary,
+    .test-summary-group > .test-summary-group {
+      padding-left: 10px;
+    }
+
+    .activities {
+      margin-left: 10px;
+    }
+
+    /* Long identifiers still have to break somewhere rather than push the
+       duration column off the screen. */
+    .row-name {
       overflow-wrap: break-word;
-    }
-
-    .test-result-icon {
-      margin-left: 12px;
-    }
-
-    .test-summary.no-drop-down .test-icon {
-      margin-left: 6px;
     }
 
     #right-sidebar {
@@ -1417,7 +1696,7 @@
 
       <main id="main-content">
         <div class="run" id="device_42230e298d9d9e832714ebad20e680c6">
-  <div class="tests">
+  <div class="tests" tabindex="0">
     <div class="tests-header">
       <ul class="toolbar toggle-toolbar">
         <li onclick="showAllScenarios(this);" class="selected">All (5)</li>
@@ -1427,39 +1706,39 @@
         <li onclick="showMixedScenariosOnly(this);">Mixed (1)</li>
       </ul>
       <ul class="toolbar table-header">
-        <li>Status</li>
-        <li>Tests</li>
+        <li>Test</li>
+        <li>Duration</li>
       </ul>
     </div>
     <div class="summary" id="acbfc5b654f672fd516dc3374cdec2e8">
       <div class="test-summary-group failed">
-      <span class="icon left test-result-icon"></span>
       <p>
-          <span class="icon left drop-down-icon" onclick="toggle(this, '901b3b4e0af989cdb3300028c5e8e52b')"></span>
-          <span class="icon left test-icon"></span>
-          SyntheticSuite (6.00s)
+          <span class="icon drop-down-icon" onclick="toggle(this, '901b3b4e0af989cdb3300028c5e8e52b')"></span>
+          <span class="icon test-result-icon"></span>
+          <span class="row-name">SyntheticSuite</span>
+          <span class="row-duration">(6.00s)</span>
       </p>
         <img class="screenshot-tail" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
   <div class="test-summary expected-failure">
-      <span class="icon left test-result-icon"></span>
       <p class="list-item">
-          <span class="icon left drop-down-icon" onclick="toggle(this, '1c6cdccfeb05445c9896526289e8c191')"></span>
-          <span class="icon left test-icon"></span>
-          testExpectedlyFails() (1.50s)
+          <span class="icon drop-down-icon" onclick="toggle(this, '1c6cdccfeb05445c9896526289e8c191')"></span>
+          <span class="icon test-result-icon"></span>
+          <span class="row-name">testExpectedlyFails()</span>
+          <span class="row-duration">(1.50s)</span>
       </p>
       <div id="activities-1c6cdccfeb05445c9896526289e8c191" class="activities">
           <img class="screenshot-flow" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
           <div class="activity activity-assertion-failure ">
   <p class="list-item">
     <span style="margin-left: 0px" class="padding"></span>
-    <span class="icon left drop-down-icon" onclick="toggle(this, 'eab1e43262f622153d7b29bf5870292c')"></span>
-    Synthetic.swift:42: assertion failed
+    <span class="icon drop-down-icon" onclick="toggle(this, 'eab1e43262f622153d7b29bf5870292c')"></span>
+    <span class="row-name">Synthetic.swift:42: assertion failed</span>
     <span class="icon paperclip-icon" style="display: inline-block"></span>
   </p>
   <div id="attachments-eab1e43262f622153d7b29bf5870292c" class="attachments">
       <p class="attachment list-item">
-  <span class="icon left screenshot-icon" style="margin-left: 16px"></span>
-  Screenshot
+  <span class="icon screenshot-icon" style="margin-left: 16px"></span>
+  <span class="row-name">Screenshot</span>
   <span class="icon preview-icon" data="screenshot.png" onclick="showScreenshot(this.getAttribute('data'))"></span>
   <img class="screenshot" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
 </p>
@@ -1471,19 +1750,19 @@
       </div>
   </div>  <img class="screenshot-tail" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/><img class="screenshot-tail" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
   <div class="test-summary failed">
-      <span class="icon left test-result-icon"></span>
       <p class="list-item">
-          <span class="icon left drop-down-icon" onclick="toggle(this, '4abdbdaebf10baf0f23017525cf4a9be')"></span>
-          <span class="icon left test-icon"></span>
-          testFails() (1.50s)
+          <span class="icon drop-down-icon" onclick="toggle(this, '4abdbdaebf10baf0f23017525cf4a9be')"></span>
+          <span class="icon test-result-icon"></span>
+          <span class="row-name">testFails()</span>
+          <span class="row-duration">(1.50s)</span>
       </p>
       <div id="activities-4abdbdaebf10baf0f23017525cf4a9be" class="activities">
           <img class="screenshot-flow" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/><img class="screenshot-flow" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
           <div class="activity  no-drop-down">
   <p class="list-item">
     <span style="margin-left: 38px" class="padding"></span>
-    <span class="icon left drop-down-icon" onclick="toggle(this, '5e17ea9d5d34e0abc7da7873147c4feb')"></span>
-    Start Test
+    <span class="icon drop-down-icon" onclick="toggle(this, '5e17ea9d5d34e0abc7da7873147c4feb')"></span>
+    <span class="row-name">Start Test</span>
     <span class="icon paperclip-icon" style="display: none"></span>
   </p>
   <div id="attachments-5e17ea9d5d34e0abc7da7873147c4feb" class="attachments">
@@ -1495,19 +1774,19 @@
 </div><div class="activity  ">
   <p class="list-item">
     <span style="margin-left: 20px" class="padding"></span>
-    <span class="icon left drop-down-icon" onclick="toggle(this, 'ac8aedc2d707d9bd771a8615d5f89301')"></span>
-    Attachments
+    <span class="icon drop-down-icon" onclick="toggle(this, 'ac8aedc2d707d9bd771a8615d5f89301')"></span>
+    <span class="row-name">Attachments</span>
     <span class="icon paperclip-icon" style="display: inline-block"></span>
   </p>
   <div id="attachments-ac8aedc2d707d9bd771a8615d5f89301" class="attachments">
       <p class="attachment list-item">
-  <span class="icon left screenshot-icon" style="margin-left: 36px"></span>
-  Screenshot
+  <span class="icon screenshot-icon" style="margin-left: 36px"></span>
+  <span class="row-name">Screenshot</span>
   <span class="icon preview-icon" data="screenshot.png" onclick="showScreenshot(this.getAttribute('data'))"></span>
   <img class="screenshot" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
 </p><p class="attachment list-item">
-  <span class="icon left text-icon" style="margin-left: 36px"></span>
-  Log
+  <span class="icon text-icon" style="margin-left: 36px"></span>
+  <span class="row-name">Log</span>
   <span class="icon preview-icon" data="data:text/plain;base64,c3ludGhldGljIGF0dGFjaG1lbnQgYm9keQo=" onclick="showText(this.getAttribute('data'))"></span>
 </p>
   </div>
@@ -1517,8 +1796,8 @@
 </div><div class="activity  ">
   <p class="list-item">
     <span style="margin-left: 20px" class="padding"></span>
-    <span class="icon left drop-down-icon" onclick="toggle(this, 'a410649b89e3181b5d4019e2db54f183')"></span>
-    Nested
+    <span class="icon drop-down-icon" onclick="toggle(this, 'a410649b89e3181b5d4019e2db54f183')"></span>
+    <span class="row-name">Nested</span>
     <span class="icon paperclip-icon" style="display: none"></span>
   </p>
   <div id="attachments-a410649b89e3181b5d4019e2db54f183" class="attachments">
@@ -1528,8 +1807,8 @@
       <div class="activity  no-drop-down">
   <p class="list-item">
     <span style="margin-left: 48px" class="padding"></span>
-    <span class="icon left drop-down-icon" onclick="toggle(this, 'fcbec71434f97d8519070e445c49af0d')"></span>
-    Inner step
+    <span class="icon drop-down-icon" onclick="toggle(this, 'fcbec71434f97d8519070e445c49af0d')"></span>
+    <span class="row-name">Inner step</span>
     <span class="icon paperclip-icon" style="display: none"></span>
   </p>
   <div id="attachments-fcbec71434f97d8519070e445c49af0d" class="attachments">
@@ -1543,14 +1822,14 @@
 </div><div class="activity activity-assertion-failure ">
   <p class="list-item">
     <span style="margin-left: 0px" class="padding"></span>
-    <span class="icon left drop-down-icon" onclick="toggle(this, '35ad28c1a36df8df00034ad8eb0a2ffb')"></span>
-    Synthetic.swift:42: assertion failed
+    <span class="icon drop-down-icon" onclick="toggle(this, '35ad28c1a36df8df00034ad8eb0a2ffb')"></span>
+    <span class="row-name">Synthetic.swift:42: assertion failed</span>
     <span class="icon paperclip-icon" style="display: inline-block"></span>
   </p>
   <div id="attachments-35ad28c1a36df8df00034ad8eb0a2ffb" class="attachments">
       <p class="attachment list-item">
-  <span class="icon left screenshot-icon" style="margin-left: 16px"></span>
-  Screenshot
+  <span class="icon screenshot-icon" style="margin-left: 16px"></span>
+  <span class="row-name">Screenshot</span>
   <span class="icon preview-icon" data="screenshot.png" onclick="showScreenshot(this.getAttribute('data'))"></span>
   <img class="screenshot" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
 </p>
@@ -1562,19 +1841,19 @@
       </div>
   </div>  <img class="screenshot-tail" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
   <div class="test-summary succeeded">
-      <span class="icon left test-result-icon"></span>
       <p class="list-item">
-          <span class="icon left drop-down-icon" onclick="toggle(this, '16170791d4b96668f53ace117678c387')"></span>
-          <span class="icon left test-icon"></span>
-          testPasses() (1.50s)
+          <span class="icon drop-down-icon" onclick="toggle(this, '16170791d4b96668f53ace117678c387')"></span>
+          <span class="icon test-result-icon"></span>
+          <span class="row-name">testPasses()</span>
+          <span class="row-duration">(1.50s)</span>
       </p>
       <div id="activities-16170791d4b96668f53ace117678c387" class="activities">
           <img class="screenshot-flow" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
           <div class="activity  no-drop-down">
   <p class="list-item">
     <span style="margin-left: 38px" class="padding"></span>
-    <span class="icon left drop-down-icon" onclick="toggle(this, 'f905959f1ac687802929e21cd860ca8b')"></span>
-    Start Test
+    <span class="icon drop-down-icon" onclick="toggle(this, 'f905959f1ac687802929e21cd860ca8b')"></span>
+    <span class="row-name">Start Test</span>
     <span class="icon paperclip-icon" style="display: none"></span>
   </p>
   <div id="attachments-f905959f1ac687802929e21cd860ca8b" class="attachments">
@@ -1586,19 +1865,19 @@
 </div><div class="activity  ">
   <p class="list-item">
     <span style="margin-left: 20px" class="padding"></span>
-    <span class="icon left drop-down-icon" onclick="toggle(this, '65291edd1daadc2dda7056f8567bbbef')"></span>
-    Attachments
+    <span class="icon drop-down-icon" onclick="toggle(this, '65291edd1daadc2dda7056f8567bbbef')"></span>
+    <span class="row-name">Attachments</span>
     <span class="icon paperclip-icon" style="display: inline-block"></span>
   </p>
   <div id="attachments-65291edd1daadc2dda7056f8567bbbef" class="attachments">
       <p class="attachment list-item">
-  <span class="icon left screenshot-icon" style="margin-left: 36px"></span>
-  Screenshot
+  <span class="icon screenshot-icon" style="margin-left: 36px"></span>
+  <span class="row-name">Screenshot</span>
   <span class="icon preview-icon" data="screenshot.png" onclick="showScreenshot(this.getAttribute('data'))"></span>
   <img class="screenshot" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
 </p><p class="attachment list-item">
-  <span class="icon left text-icon" style="margin-left: 36px"></span>
-  Log
+  <span class="icon text-icon" style="margin-left: 36px"></span>
+  <span class="row-name">Log</span>
   <span class="icon preview-icon" data="data:text/plain;base64,c3ludGhldGljIGF0dGFjaG1lbnQgYm9keQo=" onclick="showText(this.getAttribute('data'))"></span>
 </p>
   </div>
@@ -1608,8 +1887,8 @@
 </div><div class="activity  ">
   <p class="list-item">
     <span style="margin-left: 20px" class="padding"></span>
-    <span class="icon left drop-down-icon" onclick="toggle(this, 'd17da3102af2f32b2641aa89c80916b1')"></span>
-    Nested
+    <span class="icon drop-down-icon" onclick="toggle(this, 'd17da3102af2f32b2641aa89c80916b1')"></span>
+    <span class="row-name">Nested</span>
     <span class="icon paperclip-icon" style="display: none"></span>
   </p>
   <div id="attachments-d17da3102af2f32b2641aa89c80916b1" class="attachments">
@@ -1619,8 +1898,8 @@
       <div class="activity  no-drop-down">
   <p class="list-item">
     <span style="margin-left: 48px" class="padding"></span>
-    <span class="icon left drop-down-icon" onclick="toggle(this, 'f494a677468dc8724e395fe3dea7c562')"></span>
-    Inner step
+    <span class="icon drop-down-icon" onclick="toggle(this, 'f494a677468dc8724e395fe3dea7c562')"></span>
+    <span class="row-name">Inner step</span>
     <span class="icon paperclip-icon" style="display: none"></span>
   </p>
   <div id="attachments-f494a677468dc8724e395fe3dea7c562" class="attachments">
@@ -1634,33 +1913,34 @@
 </div>
       </div>
   </div>  <div class="test-summary mixed">
-      <span class="icon left test-result-icon"></span>
       <p class="list-item">
-          <span class="icon left drop-down-icon dropped" onclick="toggle(this, '751413da1b48c31cffea0e4c31cc99bc')"></span>
-          <span class="icon left test-icon"></span>
-          testRetries() 1 failed, 1 succeeded (3.00s)
+          <span class="icon drop-down-icon dropped" onclick="toggle(this, '751413da1b48c31cffea0e4c31cc99bc')"></span>
+          <span class="icon test-result-icon"></span>
+          <span class="row-name">testRetries()</span>
+          <span class="row-note">1 failed, 1 succeeded</span>
+          <span class="row-duration">(3.00s)</span>
       </p>
       <div id="iterations-751413da1b48c31cffea0e4c31cc99bc" class="iterations" style="display: block">
             <div class="iteration failed">
-      <span class="icon left test-result-icon"></span>
       <p class="list-item">
-          <span class="icon left drop-down-icon" onclick="toggle(this, '98ade9823d518704e870971ef0c6984c')"></span>
-          <span class="icon left test-icon"></span>
-          Iteration 1 (1.50s)
+          <span class="icon drop-down-icon" onclick="toggle(this, '98ade9823d518704e870971ef0c6984c')"></span>
+          <span class="icon test-result-icon"></span>
+          <span class="row-name">Iteration 1</span>
+          <span class="row-duration">(1.50s)</span>
       </p>
       <div id="activities-98ade9823d518704e870971ef0c6984c" class="activities">
           <img class="screenshot-flow" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
           <div class="activity activity-assertion-failure ">
   <p class="list-item">
     <span style="margin-left: 0px" class="padding"></span>
-    <span class="icon left drop-down-icon" onclick="toggle(this, 'd52daa3211c83b468e246ec5568bb84b')"></span>
-    Synthetic.swift:42: assertion failed
+    <span class="icon drop-down-icon" onclick="toggle(this, 'd52daa3211c83b468e246ec5568bb84b')"></span>
+    <span class="row-name">Synthetic.swift:42: assertion failed</span>
     <span class="icon paperclip-icon" style="display: inline-block"></span>
   </p>
   <div id="attachments-d52daa3211c83b468e246ec5568bb84b" class="attachments">
       <p class="attachment list-item">
-  <span class="icon left screenshot-icon" style="margin-left: 16px"></span>
-  Screenshot
+  <span class="icon screenshot-icon" style="margin-left: 16px"></span>
+  <span class="row-name">Screenshot</span>
   <span class="icon preview-icon" data="screenshot.png" onclick="showScreenshot(this.getAttribute('data'))"></span>
   <img class="screenshot" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
 </p>
@@ -1671,19 +1951,19 @@
 </div>
       </div>
   </div>  <div class="iteration succeeded">
-      <span class="icon left test-result-icon"></span>
       <p class="list-item">
-          <span class="icon left drop-down-icon" onclick="toggle(this, '34758e281c83108eeca0f231788a3a00')"></span>
-          <span class="icon left test-icon"></span>
-          Iteration 2 (1.50s)
+          <span class="icon drop-down-icon" onclick="toggle(this, '34758e281c83108eeca0f231788a3a00')"></span>
+          <span class="icon test-result-icon"></span>
+          <span class="row-name">Iteration 2</span>
+          <span class="row-duration">(1.50s)</span>
       </p>
       <div id="activities-34758e281c83108eeca0f231788a3a00" class="activities">
           <img class="screenshot-flow" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
           <div class="activity  no-drop-down">
   <p class="list-item">
     <span style="margin-left: 38px" class="padding"></span>
-    <span class="icon left drop-down-icon" onclick="toggle(this, 'c0d6436cf3e7844556460f2d705a7997')"></span>
-    Start Test
+    <span class="icon drop-down-icon" onclick="toggle(this, 'c0d6436cf3e7844556460f2d705a7997')"></span>
+    <span class="row-name">Start Test</span>
     <span class="icon paperclip-icon" style="display: none"></span>
   </p>
   <div id="attachments-c0d6436cf3e7844556460f2d705a7997" class="attachments">
@@ -1695,19 +1975,19 @@
 </div><div class="activity  ">
   <p class="list-item">
     <span style="margin-left: 20px" class="padding"></span>
-    <span class="icon left drop-down-icon" onclick="toggle(this, 'eea257a844e0587dce9a918f430ad0a4')"></span>
-    Attachments
+    <span class="icon drop-down-icon" onclick="toggle(this, 'eea257a844e0587dce9a918f430ad0a4')"></span>
+    <span class="row-name">Attachments</span>
     <span class="icon paperclip-icon" style="display: inline-block"></span>
   </p>
   <div id="attachments-eea257a844e0587dce9a918f430ad0a4" class="attachments">
       <p class="attachment list-item">
-  <span class="icon left screenshot-icon" style="margin-left: 36px"></span>
-  Screenshot
+  <span class="icon screenshot-icon" style="margin-left: 36px"></span>
+  <span class="row-name">Screenshot</span>
   <span class="icon preview-icon" data="screenshot.png" onclick="showScreenshot(this.getAttribute('data'))"></span>
   <img class="screenshot" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
 </p><p class="attachment list-item">
-  <span class="icon left text-icon" style="margin-left: 36px"></span>
-  Log
+  <span class="icon text-icon" style="margin-left: 36px"></span>
+  <span class="row-name">Log</span>
   <span class="icon preview-icon" data="data:text/plain;base64,c3ludGhldGljIGF0dGFjaG1lbnQgYm9keQo=" onclick="showText(this.getAttribute('data'))"></span>
 </p>
   </div>
@@ -1717,8 +1997,8 @@
 </div><div class="activity  ">
   <p class="list-item">
     <span style="margin-left: 20px" class="padding"></span>
-    <span class="icon left drop-down-icon" onclick="toggle(this, '4fb505b3fa259f25bbab5dde2088a7d6')"></span>
-    Nested
+    <span class="icon drop-down-icon" onclick="toggle(this, '4fb505b3fa259f25bbab5dde2088a7d6')"></span>
+    <span class="row-name">Nested</span>
     <span class="icon paperclip-icon" style="display: none"></span>
   </p>
   <div id="attachments-4fb505b3fa259f25bbab5dde2088a7d6" class="attachments">
@@ -1728,8 +2008,8 @@
       <div class="activity  no-drop-down">
   <p class="list-item">
     <span style="margin-left: 48px" class="padding"></span>
-    <span class="icon left drop-down-icon" onclick="toggle(this, '5158bcb4fd33835cfed1c6aa1678854d')"></span>
-    Inner step
+    <span class="icon drop-down-icon" onclick="toggle(this, '5158bcb4fd33835cfed1c6aa1678854d')"></span>
+    <span class="row-name">Inner step</span>
     <span class="icon paperclip-icon" style="display: none"></span>
   </p>
   <div id="attachments-5158bcb4fd33835cfed1c6aa1678854d" class="attachments">
@@ -1746,11 +2026,11 @@
       </div>
   </div>  
   <div class="test-summary skipped">
-      <span class="icon left test-result-icon"></span>
       <p class="list-item">
-          <span class="icon left drop-down-icon" onclick="toggle(this, '7e99cdcbbbf846f71ae5f186cec55c0d')"></span>
-          <span class="icon left test-icon"></span>
-          testSkips() (1.50s)
+          <span class="icon drop-down-icon" onclick="toggle(this, '7e99cdcbbbf846f71ae5f186cec55c0d')"></span>
+          <span class="icon test-result-icon"></span>
+          <span class="row-name">testSkips()</span>
+          <span class="row-duration">(1.50s)</span>
       </p>
       <div id="activities-7e99cdcbbbf846f71ae5f186cec55c0d" class="activities">
           
@@ -2191,16 +2471,25 @@
     }
   }
 
+  // The summary header describes the *test* run — an outcome ring, a
+  // failure digest, per-device bars — and none of it says anything about
+  // the log the Logs tab shows. Xcode does the same thing: switching to a
+  // different report gives that report the whole column. A body class
+  // rather than a style written onto #run-summary, so the band's own rules
+  // (including its two max-heights) stay in the stylesheet and A3 can move
+  // the tabs without hunting for a display value in a script.
   function showLogs(el) {
     selectedElement(el);
     setDisplayToElementsWithSelector('#logs', 'flex');
     setDisplayToElementsWithSelector('.tests', 'none');
+    document.body.classList.add('logs-active');
   }
 
   function showTests(el) {
     selectedElement(el);
     setDisplayToElementsWithSelector('#logs', 'none');
     setDisplayToElementsWithSelector('.tests', 'flex');
+    document.body.classList.remove('logs-active');
   }
 
   document.querySelectorAll('.device-info')[0].classList.add("selected");

--- a/Tests/XCTestHTMLReportTests/Snapshots/index.html
+++ b/Tests/XCTestHTMLReportTests/Snapshots/index.html
@@ -237,11 +237,13 @@
       --color-bg-sidebar: #232327;
       --color-bg-group-header: #202024;
 
-      /* The tree's own surfaces. The activities panel is *darker* than the
-         page rather than lighter, which is the inversion of the light
-         theme and is what makes an expanded test read as recessed under
-         its row instead of floating above it — the same relationship the
-         summary band has to its cards. */
+      /* The tree's own surfaces. The activities panel is *lighter* than the
+         page here and *darker* than it in light, because white has no room
+         above it and this ground has little worth reading below it: each
+         theme steps the panel in the direction it actually has. What
+         carries the meaning is that it steps at all — one value off the
+         page is what makes an expanded test's steps read as their own
+         region under the row rather than as more tree. */
       --color-row-hover: #25252A;
       --color-bg-activities: #1D1D21;
       --color-fail-tint: #3A2226;
@@ -886,13 +888,29 @@
   }
 
   /* Rows are indented by their container's padding, so a row's own box
-     starts at the indent and its background would too. `--row-bleed` paints
-     that background back out to the left edge with a horizontal shadow;
-     `.tests` is a scroll container, so it clips there. A shadow is ink
-     overflow rather than scrollable overflow, so nothing here widens the
-     page — the 375px probe covers that.
+     starts at the indent and its background would too. `--row-bleed` is how
+     far that background is carried back out into the gutter the indentation
+     spent; `.tests` is a scroll container, so it clips there. The mockup
+     does this — its failure tint and its expanded-test band both run to the
+     card's edge, under the disclosure column rather than starting after it.
 
-     Only the three row kinds that sit *in* the tree override it. Activity
+     A strip painted by `::before`, not an outer `box-shadow`. A shadow is
+     the whole border box translated, so an offset far enough left to clear
+     any indentation drags the box's *right* edge that far left with it: at
+     `-100vw` the shadow lands entirely at `x <= 0`, outside the viewport
+     and outside the container that clips it, and paints nothing at all. An
+     offset small enough to still overlap the row is one that a deep enough
+     tree or a narrow enough pane outruns. `right: 100%` has no such
+     arithmetic — the strip begins where the row begins and runs left for as
+     far as it is told, at every depth and every width.
+
+     `background-color: inherit`, so hover, selection and a suite heading's
+     own ground each reach the gutter by the same declaration that paints
+     the row, and a fourth state would too. Leftward overflow is unreachable
+     in a left-to-right scroll container, so nothing here widens the page —
+     the 375px probe covers that.
+
+     Only the three row kinds that sit *in* the tree get a strip. Activity
      and attachment rows deliberately do not: they live inside the
      activities panel, whose inset background and gutter rule are the thing
      that says "this belongs to the test above", and a row bleeding past
@@ -901,17 +919,33 @@
   .test-summary > p,
   .test-summary-group > p,
   .iteration > p {
-    --row-bleed: -100vw;
+    --row-bleed: 100vw;
+    position: relative;
+  }
+
+  /* `bottom: -1px`, not `0`: an absolutely positioned child is laid out
+     against its containing block's *padding* box, so `0` would stop the
+     strip one hairline short of the row's own background and leave a bright
+     seam under every selected row. The 1px is the row's `border-bottom`
+     above. */
+  .test-summary > p::before,
+  .test-summary-group > p::before,
+  .iteration > p::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    bottom: -1px;
+    right: 100%;
+    width: var(--row-bleed);
+    background-color: inherit;
   }
 
   .list-item:hover {
     background-color: var(--color-row-hover);
-    box-shadow: var(--row-bleed) 0 0 var(--color-row-hover);
   }
 
   .test-summary-group > p {
     background-color: var(--color-bg-group-header);
-    box-shadow: var(--row-bleed) 0 0 var(--color-bg-group-header);
     font-weight: var(--font-weight-medium);
   }
 
@@ -1127,15 +1161,16 @@
      selected row leaves it selected rather than tinting it. */
   .list-item.selected {
     background-color: var(--color-accent);
-    box-shadow: var(--row-bleed) 0 0 var(--color-accent);
     color: var(--color-on-accent);
   }
 
   /* Summary header (#439, redesign A1).
 
-     Everything from here to the media query is new, and nothing below the
-     header was restyled: the tree, the panes and the filter pills are byte
-     for byte what they were. A2 restyles the tree; A3 the filters.
+     Everything from here to the media query is the header's own. A1 landed
+     it without restyling anything else; A2 has since restyled the tree, in
+     the block above, and the filter pills are still A3's. So a rule about a
+     row or a pill belongs where that thing is styled, not here — this block
+     stays the header's or it stops being findable.
 
      The band is a flex item of #content, capped at half the viewport so a
      run with a long failure digest can never push the tree off the screen —

--- a/Tests/XCTestHTMLReportTests/Snapshots/index.html
+++ b/Tests/XCTestHTMLReportTests/Snapshots/index.html
@@ -60,6 +60,27 @@
     --color-bg-sidebar: #F2F2F2;
     --color-bg-group-header: #F6F6F6;
 
+    /* Colour — the tests tree (#439, A2). Four roles the sheet had no way
+       to say before, because before this the tree painted nothing at all
+       between the page background and a selected row.
+
+       Every pairing was computed before it was used; the table is in the
+       PR body. The tightest text pairing these introduce is the failure
+       message on its own tint — 4.74:1 light, 5.35:1 dark, against a 4.5
+       floor — and the tightest status badge is passed on a hovered row,
+       3.69:1 light and 6.54:1 dark against the 3:1 non-text floor.
+
+       --color-tree-guide is deliberately below 3:1 (1.28 light / 1.44
+       dark, against the panel it is drawn on), for the same reason
+       --color-summary-border is: the timeline
+       rule restates the nesting that indentation already states, so it is
+       decorative under 1.4.11 and drawing it at 3:1 would put a hard black
+       bar down the middle of every expanded test. */
+    --color-row-hover: #F0F0F2;
+    --color-bg-activities: #F7F7F9;
+    --color-fail-tint: #FDEDEC;
+    --color-tree-guide: #DCDCE1;
+
     /* Colour — the summary header (#439, A1). A band with cards on it,
        which is one more surface level than the rest of the report has, so
        these are their own tokens rather than reuses. Values are Apple's
@@ -90,7 +111,13 @@
     --color-border-medium: #CCC;
     --color-border-light: #DDD;
     --color-border-faint: #E5E5E5;
-    --color-preview-border: #021a40;
+    /* Was #021A40 — a near-black navy, and the only colour in the light
+       theme that belonged to no family. It framed the screenshot flow in a
+       hard dark rectangle; the dark theme had already been given a normal
+       border value for it. This is the light theme's equivalent, so the
+       frame now reads as a frame in both. Decorative: it outlines an image
+       that is itself the content. */
+    --color-preview-border: #D2D2D7;
 
     /* Typography — the system UI face, so the report looks native on the
        platform it is read on. `system-ui` first, `-apple-system` for the
@@ -121,22 +148,50 @@
     --preview-height: 600px;
     --radius-sm: 3px;
 
+    /* One nesting level of the tree. Applied to the child container, not
+       written into the markup — see the indentation rule below for why
+       that distinction is load-bearing for the differential. */
+    --tree-indent: 16px;
+
+    /* How far a row's background bleeds left, past the indentation its
+       container spends. Declared here at its *off* value and overridden to
+       a real distance by the three row kinds that want it, so the default
+       lives in one place and `tokens.spec.ts` can see it declared like any
+       other custom property. */
+    --row-bleed: 0;
+
     /* Glyphs. Shapes, not colours — the colour is applied separately (see
        the icon block below), which is why these are shared by both themes
        and the dark block does not repeat them. Kept here so the sheet has
        exactly one place where the report's iconography is defined.
 
-       Geometry note: every status glyph is the same rounded diamond, so
-       the six states differ by what sits inside it and by shape — filled
-       with a knock-out for the three settled outcomes, outlined for the
-       three that are qualified. That reproduces the diamond the PNGs drew,
-       which is the identity this refresh is keeping. */
-    --icon-status-passed: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cmask id='a'%3E%3Cpath d='M9.06 1.66 14.34 6.94Q15.4 8 14.34 9.06L9.06 14.34Q8 15.4 6.94 14.34L1.66 9.06Q.6 8 1.66 6.94L6.94 1.66Q8 .6 9.06 1.66Z' fill='white'/%3E%3Cpath d='M4.7 8.2 6.9 10.5 11.3 5.6' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/mask%3E%3Crect width='16' height='16' mask='url(%23a)'/%3E%3C/svg%3E");
-    --icon-status-failed: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cmask id='a'%3E%3Cpath d='M9.06 1.66 14.34 6.94Q15.4 8 14.34 9.06L9.06 14.34Q8 15.4 6.94 14.34L1.66 9.06Q.6 8 1.66 6.94L6.94 1.66Q8 .6 9.06 1.66Z' fill='white'/%3E%3Cpath d='M5.6 5.6 10.4 10.4M10.4 5.6 5.6 10.4' fill='none' stroke='black' stroke-width='2' stroke-linecap='round'/%3E%3C/mask%3E%3Crect width='16' height='16' mask='url(%23a)'/%3E%3C/svg%3E");
-    --icon-status-skipped: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cmask id='a'%3E%3Cpath d='M9.06 1.66 14.34 6.94Q15.4 8 14.34 9.06L9.06 14.34Q8 15.4 6.94 14.34L1.66 9.06Q.6 8 1.66 6.94L6.94 1.66Q8 .6 9.06 1.66Z' fill='white'/%3E%3Cpath d='M5.4 9.9 10.6 6.1M6.1 6.1h4.5v4.5' fill='none' stroke='black' stroke-width='1.8' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/mask%3E%3Crect width='16' height='16' mask='url(%23a)'/%3E%3C/svg%3E");
-    --icon-status-mixed: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cmask id='a'%3E%3Cpath d='M9.06 1.66 14.34 6.94Q15.4 8 14.34 9.06L9.06 14.34Q8 15.4 6.94 14.34L1.66 9.06Q.6 8 1.66 6.94L6.94 1.66Q8 .6 9.06 1.66Z' fill='white'/%3E%3Cpath d='M8 1.2V14.8' fill='none' stroke='black' stroke-width='1.4'/%3E%3C/mask%3E%3Crect width='16' height='16' mask='url(%23a)'/%3E%3C/svg%3E");
-    --icon-status-unknown: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M9.06 1.66 14.34 6.94Q15.4 8 14.34 9.06L9.06 14.34Q8 15.4 6.94 14.34L1.66 9.06Q.6 8 1.66 6.94L6.94 1.66Q8 .6 9.06 1.66Z' fill='none' stroke='black' stroke-width='1.6'/%3E%3Cpath d='M6.5 6.4a1.6 1.6 0 1 1 1.6 1.9v.8' fill='none' stroke='black' stroke-width='1.3' stroke-linecap='round'/%3E%3Ccircle cx='8.1' cy='11.2' r='.8'/%3E%3C/svg%3E");
-    --icon-status-expected: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M9.06 1.66 14.34 6.94Q15.4 8 14.34 9.06L9.06 14.34Q8 15.4 6.94 14.34L1.66 9.06Q.6 8 1.66 6.94L6.94 1.66Q8 .6 9.06 1.66Z' fill='none' stroke='black' stroke-width='1.6'/%3E%3Cpath d='M8 4.8v3.6' stroke='black' stroke-width='1.6' stroke-linecap='round'/%3E%3Ccircle cx='8' cy='11' r='.9'/%3E%3C/svg%3E");
+       Geometry note (#439, A2). Every status glyph is the same rounded
+       square — Xcode 26's badge — and the six states differ by the glyph
+       inside it and by whether the square is filled or outlined. Filled
+       means the outcome is settled (passed, failed, skipped, mixed and
+       expected-failure: a test that failed exactly as it declared it
+       would is a settled outcome); outlined means it is not (unknown is
+       the only state that means "we could not tell").
+
+       This replaces the rounded diamond #459 drew. The six *shapes* are
+       the same six #459 introduced, which is the property that mattered:
+       status is never colour alone, and no state renders a blank cell.
+       Only the silhouette moved, and it moved because Option A's whole
+       premise is reading as a sibling of Xcode's own report.
+
+       The glyph is a knock-out — a hole showing whatever surface the row
+       paints — rather than the white glyph the mockup draws. White on the
+       mockup's green is 3.13:1; a knock-out's contrast against its fill
+       is by construction the status token's contrast against the row,
+       which is the pairing #439 already sized to clear 3:1 in both
+       themes. Same picture on a white row, a measured one everywhere
+       else. */
+    --icon-status-passed: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cmask id='a'%3E%3Crect x='1' y='1' width='14' height='14' rx='4.2' fill='white'/%3E%3Cpath d='M4.6 8.15 6.85 10.4 11.4 5.75' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/mask%3E%3Crect width='16' height='16' mask='url(%23a)'/%3E%3C/svg%3E");
+    --icon-status-failed: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cmask id='a'%3E%3Crect x='1' y='1' width='14' height='14' rx='4.2' fill='white'/%3E%3Cpath d='M5.7 5.7 10.3 10.3M10.3 5.7 5.7 10.3' fill='none' stroke='black' stroke-width='2' stroke-linecap='round'/%3E%3C/mask%3E%3Crect width='16' height='16' mask='url(%23a)'/%3E%3C/svg%3E");
+    --icon-status-skipped: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cmask id='a'%3E%3Crect x='1' y='1' width='14' height='14' rx='4.2' fill='white'/%3E%3Cpath d='M5.5 10.1 10.4 5.9M6.2 5.9h4.3v4.3' fill='none' stroke='black' stroke-width='1.8' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/mask%3E%3Crect width='16' height='16' mask='url(%23a)'/%3E%3C/svg%3E");
+    --icon-status-mixed: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cmask id='a'%3E%3Crect x='1' y='1' width='14' height='14' rx='4.2' fill='white'/%3E%3Cpath d='M8 .6V15.4' fill='none' stroke='black' stroke-width='1.4'/%3E%3C/mask%3E%3Crect width='16' height='16' mask='url(%23a)'/%3E%3C/svg%3E");
+    --icon-status-unknown: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Crect x='1.8' y='1.8' width='12.4' height='12.4' rx='3.4' fill='none' stroke='black' stroke-width='1.6'/%3E%3Cpath d='M6.5 6.4a1.6 1.6 0 1 1 1.6 1.9v.8' fill='none' stroke='black' stroke-width='1.3' stroke-linecap='round'/%3E%3Ccircle cx='8.1' cy='11.2' r='.8'/%3E%3C/svg%3E");
+    --icon-status-expected: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cmask id='a'%3E%3Crect x='1' y='1' width='14' height='14' rx='4.2' fill='white'/%3E%3Cpath d='M8 4.3v4.2' fill='none' stroke='black' stroke-width='2' stroke-linecap='round'/%3E%3Ccircle cx='8' cy='11.4' r='1.05' fill='black'/%3E%3C/mask%3E%3Crect width='16' height='16' mask='url(%23a)'/%3E%3C/svg%3E");
     --icon-disclosure: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 10'%3E%3Cpath d='M3 1.4 8 5 3 8.6Z'/%3E%3C/svg%3E");
     --icon-disclosure-open: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 10'%3E%3Cpath d='M1.4 3 8.6 3 5 8Z'/%3E%3C/svg%3E");
     --icon-paperclip: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M2.7 15.3c-.7 0-1.4-.3-1.9-.8-.9-.9-1.2-2.5 0-3.7l8.9-8.9c1.4-1.4 3.8-1.4 5.2 0s1.4 3.8 0 5.2l-7.4 7.4c-.2.2-.5.2-.7 0s-.2-.5 0-.7l7.4-7.4c1-1 1-2.7 0-3.7s-2.7-1-3.7 0l-8.9 8.9c-.8.8-.6 1.7 0 2.2.6.6 1.5.8 2.2 0l8.9-8.9c.2-.2.2-.5 0-.7s-.5-.2-.7 0l-7.4 7.4c-.2.2-.5.2-.7 0s-.2-.5 0-.7l7.4-7.4c.6-.6 1.6-.6 2.2 0s.6 1.6 0 2.2l-8.9 8.9c-.6.4-1.3.7-1.9.7z'/%3E%3C/svg%3E");
@@ -144,7 +199,6 @@
     --icon-document: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cmask id='a'%3E%3Cpath d='M3.2 1.4h6L13 5.2v9.4H3.2Z' fill='white'/%3E%3Cpath d='M5.2 7.4h5.6M5.2 9.6h5.6M5.2 11.8h3.6' stroke='black' stroke-width='1.1' stroke-linecap='round'/%3E%3Cpath d='M8.9 1.6v3.6h3.6' fill='none' stroke='black' stroke-width='1.1'/%3E%3C/mask%3E%3Crect width='16' height='16' mask='url(%23a)'/%3E%3C/svg%3E");
     --icon-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cmask id='a'%3E%3Crect x='1.4' y='2.8' width='13.2' height='10.4' rx='1.4' fill='white'/%3E%3Cpath d='M2.6 12 6.3 7.6l2.5 2.6 2-2 2.6 3.8Z' fill='black'/%3E%3Ccircle cx='5.4' cy='6' r='1.3' fill='black'/%3E%3C/mask%3E%3Crect width='16' height='16' mask='url(%23a)'/%3E%3C/svg%3E");
     --icon-video: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cmask id='a'%3E%3Crect x='1.4' y='3.2' width='13.2' height='9.6' rx='1.4' fill='white'/%3E%3Cpath d='M6.6 5.9 11 8l-4.4 2.1Z' fill='black'/%3E%3C/mask%3E%3Crect width='16' height='16' mask='url(%23a)'/%3E%3C/svg%3E");
-    --icon-test: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cmask id='a'%3E%3Crect x='1.6' y='1.6' width='12.8' height='12.8' rx='2.6' fill='white'/%3E%3Cpath d='M8.6 3.9v6.4a1.4 1.4 0 0 0 1.4 1.4h.6M6.1 6.6h4.3' fill='none' stroke='black' stroke-width='1.5' stroke-linecap='round'/%3E%3C/mask%3E%3Crect width='16' height='16' mask='url(%23a)'/%3E%3C/svg%3E");
   }
 
   /* Dark theme. Token values only — every selector in the sheet is shared
@@ -182,6 +236,16 @@
       --color-surface: #161619;
       --color-bg-sidebar: #232327;
       --color-bg-group-header: #202024;
+
+      /* The tree's own surfaces. The activities panel is *darker* than the
+         page rather than lighter, which is the inversion of the light
+         theme and is what makes an expanded test read as recessed under
+         its row instead of floating above it — the same relationship the
+         summary band has to its cards. */
+      --color-row-hover: #25252A;
+      --color-bg-activities: #1D1D21;
+      --color-fail-tint: #3A2226;
+      --color-tree-guide: #38383E;
 
       /* The summary header's own surfaces. The card is the same value as
          the sidebar, which is deliberate: it is the lightest ground in the
@@ -377,10 +441,16 @@
     color: var(--color-text-muted);
   }
 
+  /* The tree's column header. Two labels, at the two ends of the row the
+     columns actually occupy, rather than the old "Status | Tests" pair
+     stacked against the left edge — there is a duration column to name now,
+     and naming it is the only thing that makes it read as a column. */
   .table-header {
+    display: flex;
     min-height: 18px;
     margin: 0;
-    padding-top: 0;
+    padding: 2px var(--space-sm) 2px 6px;
+    border-bottom: 1px solid var(--color-border-light);
   }
 
   .table-header li {
@@ -389,8 +459,7 @@
   }
 
   .table-header li+li {
-    border-left: 1px solid var(--color-border-medium);
-    padding-left: var(--space-xs);
+    margin-left: auto;
   }
 
   #logs {
@@ -453,10 +522,10 @@
     display: inline-block;
   }
 
-  .left {
-    float: left;
-  }
-
+  /* `.left` lived here until A2. Every element that carried it was a tree
+     icon clearing a float gutter, and the tree is flex now, so the class
+     reached nothing in the rendered page — verified against both goldens.
+     `.clear` stays: `#title` and `#container` still float. */
   .clear {
     clear: both;
   }
@@ -483,93 +552,68 @@
     mask-image: var(--icon-video);
   }
 
-  /* The one glyph that is not `currentColor`: the rounded blue tile is the
-     project's own mark, so it keeps its colour instead of inheriting the
-     row's — except on a selected row, where the accent fill would put blue
-     on blue. Today's PNG has no such escape and does disappear there. */
-  .test-icon {
-    display: none;
-    background-color: var(--color-accent);
-    -webkit-mask-image: var(--icon-test);
-    mask-image: var(--icon-test);
-  }
-
-  .list-item.selected .test-icon {
-    background-color: var(--color-on-accent);
-  }
-
-  .test-summary p > .test-icon {
-    display: block;
-  }
-
-  .test-summary.no-drop-down .drop-down-icon {
-    display: none;
-  }
-
-  .test-summary.no-drop-down .test-icon {
-    margin-left: 22px;
-  }
-
-  /* The gutter the status glyph sits in. `margin-left` lives here rather
-     than on the per-status rules below so that one single-class rule can
-     narrow it on small screens; the per-status rules carry three classes
-     each, which no media query could outrank without `!important`. */
+  /* The status badge. It is a flex item of the row now rather than a float
+     beside it, so the gutter it used to need — a 28px margin on the icon
+     plus a matching 52px padding on every `<p>` in the tree, whether or not
+     that row had a badge — is gone, and the tree recovers ~38px of width at
+     every screen size. */
   .test-result-icon {
-    float: left;
     display: none;
-    margin: var(--space-xs);
-    margin-left: 28px;
+    flex: none;
+    margin: 0;
   }
 
   /* Which rows show a status glyph at all. Before #439 only the three
      states that had a PNG appeared here, so `mixed`, `unknown` and
      `expectedFailure` rows rendered an empty status cell — the audit's
      finding 4. All six states now have one, and each is a distinct shape,
-     not just a distinct colour. Group headings are deliberately still
-     absent: giving them icons is a layout change beyond this PR.
+     not just a distinct colour.
 
-     `>`, not a descendant combinator, throughout the status rules. A
-     retried test nests its iterations *inside* the row, and each carries
-     its own `.test-result-icon`; matched loosely, the outer row's rule
-     reaches them too, and since every one of these selectors has the same
-     specificity the winner is whichever is written last. That was
-     invisible while only three states had rules — a failed test's
-     iterations are usually failed as well — and showed up the moment
-     `mixed` existed: `testRetryOnFailure()`'s two iterations, one failed
-     and one passed, both drew the split diamond of their parent. */
-  .test-summary.succeeded > .test-result-icon,
-  .test-summary.skipped > .test-result-icon,
-  .test-summary.failed > .test-result-icon,
-  .test-summary.mixed > .test-result-icon,
-  .test-summary.unknown > .test-result-icon,
-  .test-summary.expected-failure > .test-result-icon,
-  .iteration.succeeded > .test-result-icon,
-  .iteration.skipped > .test-result-icon,
-  .iteration.failed > .test-result-icon,
-  .iteration.mixed > .test-result-icon,
-  .iteration.unknown > .test-result-icon,
-  .iteration.expected-failure > .test-result-icon {
+     Suite headings join them in A2. #459 left them out because the badge
+     was a float and giving one to a heading meant reworking the gutter;
+     now that a row is a flex line it is a selector, and the mockup's tree
+     puts a badge on every suite. Nothing new is computed for it —
+     `TestGroup.status` already folds its children's outcomes and already
+     writes the class onto the row.
+
+     `> p >`, not a descendant combinator, throughout. It used to be
+     `> .test-result-icon` because the badge was a sibling of the row; A2
+     makes it a flex item *of* the row, so the path gained a level and kept
+     the same property. That property is load-bearing twice over: a retried
+     test nests its iterations inside the row and a suite nests its cases
+     inside its own, and every one of those carries a `.test-result-icon`.
+     Matched loosely, an outer row's rule reaches all of them, and since
+     these selectors all have the same specificity the winner would be
+     whichever is written last — which is how `testRetryOnFailure()`'s two
+     iterations, one failed and one passed, once both drew their parent's
+     split glyph.
+
+     `:is()` groups the three row kinds rather than writing eighteen
+     selectors out. It contributes the specificity of its most specific
+     argument, and every argument here is one class, so each rule stays at
+     exactly the (0,3,1) the written-out form had — which the selection
+     override below relies on. */
+  :is(.test-summary, .test-summary-group, .iteration):is(
+    .succeeded, .skipped, .failed, .mixed, .unknown, .expected-failure
+  ) > p > .test-result-icon {
     display: block;
   }
 
-  .test-summary.succeeded > .test-result-icon,
-  .iteration.succeeded > .test-result-icon,
+  :is(.test-summary, .test-summary-group, .iteration).succeeded > p > .test-result-icon,
   .success {
     background-color: var(--status-passed);
     -webkit-mask-image: var(--icon-status-passed);
     mask-image: var(--icon-status-passed);
   }
 
-  .test-summary.skipped > .test-result-icon,
-  .iteration.skipped > .test-result-icon,
+  :is(.test-summary, .test-summary-group, .iteration).skipped > p > .test-result-icon,
   .skip {
     background-color: var(--status-skipped);
     -webkit-mask-image: var(--icon-status-skipped);
     mask-image: var(--icon-status-skipped);
   }
 
-  .test-summary.failed > .test-result-icon,
-  .iteration.failed > .test-result-icon,
+  :is(.test-summary, .test-summary-group, .iteration).failed > p > .test-result-icon,
   .failure {
     background-color: var(--status-failed);
     -webkit-mask-image: var(--icon-status-failed);
@@ -577,11 +621,10 @@
   }
 
   /* Mixed is the one glyph that carries two colours, because "some passed,
-     some failed" is what it means. The mask is a plain diamond split by a
+     some failed" is what it means. The mask is a plain badge split by a
      thin cut, and the two halves are a hard-stop gradient — so both halves
      are tokens and follow the theme, which a two-colour image could not. */
-  .test-summary.mixed > .test-result-icon,
-  .iteration.mixed > .test-result-icon {
+  :is(.test-summary, .test-summary-group, .iteration).mixed > p > .test-result-icon {
     background-color: transparent;
     background-image: linear-gradient(
       90deg,
@@ -592,25 +635,46 @@
     mask-image: var(--icon-status-mixed);
   }
 
-  .test-summary.unknown > .test-result-icon,
-  .iteration.unknown > .test-result-icon {
+  :is(.test-summary, .test-summary-group, .iteration).unknown > p > .test-result-icon {
     background-color: var(--status-unknown);
     -webkit-mask-image: var(--icon-status-unknown);
     mask-image: var(--icon-status-unknown);
   }
 
-  .test-summary.expected-failure > .test-result-icon,
-  .iteration.expected-failure > .test-result-icon {
+  :is(.test-summary, .test-summary-group, .iteration).expected-failure > p > .test-result-icon {
     background-color: var(--status-expected);
     -webkit-mask-image: var(--icon-status-expected);
     mask-image: var(--icon-status-expected);
   }
 
+  /* On a selected row the badge is painted in the selection's own text
+     colour and the accent knocks through the glyph, rather than the badge
+     staying a status hue. Measured against the fill it would otherwise sit
+     on: passed is 1.36:1 light and 2.07:1 dark against the accent — an
+     invisible badge on precisely the row the reader is looking at.
+     White-on-accent is 5.71 / 4.82. The outcome stays readable because the
+     *shape* carries it, which is the #459 property that status is never
+     colour alone.
+
+     Written with the element selector and placed after the status rules
+     deliberately: it has to match their (0,3,1) and win on order, and it
+     has to clear `mixed`'s gradient as well as the flat fills. */
+  p.list-item.selected > .test-result-icon {
+    background-color: var(--color-on-accent);
+    background-image: none;
+  }
+
+  /* The triangle is the row's quietest element, so it takes the muted text
+     colour rather than `currentColor` — which on a failure row would have
+     made it as loud as the failure. `flex: none` because it is the column
+     every row's badge aligns against; a shrunk triangle is a bent column. */
   .drop-down-icon {
     cursor: pointer;
+    flex: none;
     height: var(--icon-size-sm);
     width: var(--icon-size-sm);
-    margin-top: 2px;
+    margin: 0;
+    background-color: var(--color-text-muted);
     -webkit-mask-image: var(--icon-disclosure);
     mask-image: var(--icon-disclosure);
   }
@@ -620,31 +684,70 @@
     mask-image: var(--icon-disclosure-open);
   }
 
+  p.list-item.selected > .drop-down-icon {
+    background-color: var(--color-on-accent);
+  }
+
+  /* The eye is a control, not a label, so it takes the accent the rest of
+     the sheet uses for "you can click this" (`.digest-jump`) instead of
+     inheriting the row's text colour. */
   .preview-icon {
     cursor: pointer;
     display: inline-block;
+    flex: none;
     height: 11px;
     width: 14px;
+    background-color: var(--color-accent-text);
     -webkit-mask-image: var(--icon-preview);
     mask-image: var(--icon-preview);
   }
 
-  .activities {
-    display: none;
+  p.list-item.selected > .preview-icon,
+  p.list-item.selected > .paperclip-icon {
+    background-color: var(--color-on-accent);
   }
 
-  .activity.activity-assertion-failure > p {
+  /* An expanded test's activities (#439, A2). The mockup draws this as a
+     timeline: an inset panel under the test, a rule down its gutter, and an
+     elapsed offset against every row.
+
+     The offsets are not here, and are not faked. 4.0's `ParsedActivity`
+     carries a title, a failure flag, attachments and sub-activities —
+     `finish` and the per-activity timestamps left with the legacy reader
+     (see the port's decision 2), so there is no field to render and no
+     honest way to derive one. The rest of the treatment applies unchanged,
+     and the gutter still does the job the offsets shared: it says where the
+     detail of one test starts and stops. */
+  .activities {
+    display: none;
+    margin-left: var(--tree-indent);
+    border-left: 2px solid var(--color-tree-guide);
+    background-color: var(--color-bg-activities);
+  }
+
+  /* Single class, so `.list-item:hover` (two) still wins the background and
+     a failure row highlights like any other. The red text is what survives
+     the hover, which is the part that carries the meaning. */
+  .activity-assertion-failure > p {
+    background-color: var(--color-fail-tint);
     color: var(--status-failed);
+    font-weight: var(--font-weight-medium);
   }
 
   .sub-activities {
     display: none;
   }
 
+  /* Depth inside the activities panel, one 10px step per level, written by
+     `Activity.padding` into the element's own style attribute. Kept as a
+     spacer element rather than folded into the row's padding because the
+     model already computes it — including the +18px a leaf spends standing
+     in for the triangle it does not draw. `float` had to go: floats do not
+     apply to flex items, and the row is a flex line now. */
   .padding {
-    float: left;
+    flex: none;
     width: 1px;
-    height:1px;
+    height: 1px;
   }
 
   .activity.no-drop-down .drop-down-icon {
@@ -667,6 +770,16 @@
     overflow-y: scroll;
   }
 
+  /* The list takes focus so it can be scrolled from the keyboard (see the
+     `run` template). `:focus-visible`, not `:focus`, so clicking a row does
+     not draw a ring around the whole tree; `outline-offset` is negative
+     because the outline of a scroll container is drawn at its padding edge
+     and a positive offset would sit under the pane beside it. */
+  .tests:focus-visible {
+    outline: 2px solid var(--color-accent);
+    outline-offset: -2px;
+  }
+
   .tests-header, #logs-header {
     width: 100%;
   }
@@ -679,19 +792,136 @@
     margin-left: var(--space-sm);
   }
 
+  /* ---- The tests tree (#439, A2) ------------------------------------
+
+     Every row in the tree — suite heading, test case, iteration, activity,
+     attachment — is one flex line: triangle, status badge, name, then the
+     duration pushed to its own right-hand column. What this replaces was a
+     pair of floats clearing a fixed 52px of left padding, which is why the
+     duration could only ever be more text after the name and why a row with
+     no badge still paid for the gutter of one. */
   .test-summary p, .test-summary-group p, .iteration p, .activity p {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    min-height: 24px;
     font-size: var(--font-size-sm);
-    padding: var(--space-xs) var(--space-xs) var(--space-xs) 52px;
+    padding: 3px var(--space-sm) 3px 6px;
     border-bottom: 1px solid var(--color-border-faint);
+  }
+
+  /* No hairlines inside an expanded test. The panel's own inset surface and
+     the rule down its gutter already bound the region, and the mockup's
+     timeline draws no separators between its steps — with them, a test with
+     thirty activities reads as thirty more tests. */
+  .activities p {
+    border-bottom: 0;
+  }
+
+  /* The name takes the slack and wraps inside it; `min-width: 0` because a
+     flex item refuses to shrink below its content otherwise, and test names
+     are long unbroken identifiers. */
+  .row-name {
+    flex: 1 1 auto;
+    min-width: 0;
+    overflow-wrap: anywhere;
+  }
+
+  /* Inside the activities panel there is no right-hand column to push
+     against — no per-activity duration exists to put there — so the name
+     stops claiming the slack and the paperclip and the eye stay beside the
+     thing they belong to instead of drifting to the far edge. */
+  .activity > p > .row-name,
+  .attachment > .row-name {
+    flex: 0 1 auto;
+  }
+
+  /* The duration column.
+
+     `(N.NNs)` is not a styling choice and must not be edited into a bare
+     `N.NNs`: it is literally the shape `KnownLossMasker`'s `durations` rule
+     normalises, so every duration in the tree inherits a loss the allow-list
+     already declares. A2 moves where the text sits and changes nothing about
+     what it says. `RunSummaryTests.testTheHeadersDurationIsWrittenInAMaskedShape`
+     holds the same property for the header. */
+  .row-duration {
+    flex: none;
+    padding-left: var(--space-sm);
+    color: var(--color-text-muted);
+    font-variant-numeric: tabular-nums;
+  }
+
+  /* Annotations beside a name — today only a retried test's per-status
+     breakdown ("1 failed, 1 succeeded"). A bordered chip, the mockup's
+     treatment for the same class of aside. */
+  .row-note {
+    flex: none;
+    padding: 0 5px;
+    border: 1px solid var(--color-border-medium);
+    border-radius: var(--radius-sm);
+    color: var(--color-text-muted);
+    font-size: var(--font-size-xs);
+  }
+
+  p.list-item.selected > .row-duration,
+  p.list-item.selected > .row-note {
+    color: var(--color-on-accent);
+  }
+
+  /* Indentation.
+
+     Nesting depth is carried by the DOM and applied to the child container,
+     never written into the markup as a number. That is not a stylistic
+     preference: the legacy backend interposes two wrapper levels ("Selected
+     tests", "<target>.xctest") that the modern backend does not, so a depth
+     written into an attribute would differ between the two renders in every
+     row of the tree — and `KnownLossMasker`'s `wrapperGroups` rule unwraps
+     the *element*, which would leave the numbers behind and turn
+     `DifferentialTests` red with no allow-list entry able to cover it.
+     Nested padding indents by construction and costs the differential
+     exactly nothing. */
+  .test-summary-group > .test-summary,
+  .test-summary-group > .test-summary-group {
+    padding-left: var(--tree-indent);
+  }
+
+  /* Rows are indented by their container's padding, so a row's own box
+     starts at the indent and its background would too. `--row-bleed` paints
+     that background back out to the left edge with a horizontal shadow;
+     `.tests` is a scroll container, so it clips there. A shadow is ink
+     overflow rather than scrollable overflow, so nothing here widens the
+     page — the 375px probe covers that.
+
+     Only the three row kinds that sit *in* the tree override it. Activity
+     and attachment rows deliberately do not: they live inside the
+     activities panel, whose inset background and gutter rule are the thing
+     that says "this belongs to the test above", and a row bleeding past
+     them would erase exactly that. They keep the `:root` default of `0` and
+     highlight in place. */
+  .test-summary > p,
+  .test-summary-group > p,
+  .iteration > p {
+    --row-bleed: -100vw;
+  }
+
+  .list-item:hover {
+    background-color: var(--color-row-hover);
+    box-shadow: var(--row-bleed) 0 0 var(--color-row-hover);
   }
 
   .test-summary-group > p {
     background-color: var(--color-bg-group-header);
+    box-shadow: var(--row-bleed) 0 0 var(--color-bg-group-header);
     font-weight: var(--font-weight-medium);
   }
 
+  /* `visibility`, not `display`: a suite row has no working disclosure to
+     draw — collapsing a group is a script change, and the filter and
+     collapse scripts are A3's to rewire, not A2's to restyle around — but
+     the column still has to hold, or a suite's badge would sit 16px left of
+     its own children's and the tree would look bent. */
   .test-summary-group > p > .drop-down-icon {
-    display: none;
+    visibility: hidden;
   }
 
   .screenshot {
@@ -740,16 +970,28 @@
     display:none;
   }
 
-  .screenshot-flow {
-      border: 1px solid var(--color-preview-border);
-      background-color: var(--color-surface);
-      height: 200px;
-  }
+  /* The screenshot flow — the frames a UI test walked through, rendered in
+     the tree rather than in the attachment pane.
 
+     Sized like the mockup's inline player: a bounded box, not a slab. At a
+     fixed 200px (350px for the tail) and no width bound these were the
+     tallest thing in the tree by a factor of eight, so a test with a flow
+     pushed every row after it off the screen — and `.screenshot-tail` is
+     emitted *between* rows, so it did that to the tree, not to the panel.
+     `max-height` with `height: auto` keeps whatever aspect ratio the device
+     recorded instead of stretching a phone frame to a fixed height. */
+  .screenshot-flow,
   .screenshot-tail {
+      display: block;
+      width: auto;
+      max-width: min(300px, 100%);
+      height: auto;
+      max-height: 200px;
+      margin: 6px 0 6px var(--tree-indent);
+      object-fit: contain;
       border: 1px solid var(--color-preview-border);
+      border-radius: 8px;
       background-color: var(--color-surface);
-      height: 350px;
   }
 
   #content {
@@ -881,11 +1123,11 @@
     color: var(--status-failed);
   }
 
+  /* After `.list-item:hover`, and matching its specificity, so hovering the
+     selected row leaves it selected rather than tinting it. */
   .list-item.selected {
     background-color: var(--color-accent);
-  }
-
-  .list-item.selected {
+    box-shadow: var(--row-bleed) 0 0 var(--color-accent);
     color: var(--color-on-accent);
   }
 
@@ -904,6 +1146,18 @@
     padding: var(--space-sm) var(--space-sm) 12px;
     max-height: 50vh;
     overflow-y: auto;
+  }
+
+  /* The band belongs to the test run, so the Logs tab gets the column to
+     itself (#439, A2). `display: none` rather than a height animation: the
+     band is up to half the viewport and the log is an iframe, so anything
+     that resized it over several frames would reflow and repaint the frame
+     the whole way down. One class, one reflow, no jank. The rule sits with
+     the band's own styles and applies at every width — below 700px, where
+     the band already yields to a 40vh cap, reclaiming all of it is the
+     difference between a readable log and four lines of one. */
+  body.logs-active #run-summary {
+    display: none;
   }
 
   .summary-card {
@@ -1169,11 +1423,30 @@
        filenames. Stacked vertically that minimum became the column's
        width, which pushed the whole tree, and the filter pills with it,
        off the side of a 375px screen. Nothing above the query needs this
-       because there the panes are fixed widths. */
+       because there the panes are fixed widths.
+
+       `min-height` for the same reason on the other axis, and it fixes a
+       worse bug: below 700px `#container` is a *column*, so the tree is
+       sized on the block axis by this same automatic minimum, and
+       `min-height: auto` let `.tests` grow to the full height of every row
+       it holds instead of scrolling inside its share. `body` has
+       `overflow: hidden`, so everything past the first viewport was not
+       merely unscrolled but unreachable — on a long run the last test in
+       the report could not be brought on screen at all. Only the scroll
+       container itself strictly needs it, but the automatic minimum
+       propagates up a flex chain, so all three do.
+
+       Pre-existing — the column layout arrived with the narrow-screen work
+       in #459 — and made materially worse by A1: the summary band spends
+       real height above the tree, so the clipped region grew by exactly
+       what the band occupies. Found while shooting this PR's 375px
+       screenshots; `visual/tests/behaviour.spec.ts` now scrolls to the last
+       row at 375 so it cannot come back. */
     #main-content,
     .run,
     .tests {
       min-width: 0;
+      min-height: 0;
     }
 
     /* `flex: none` because the strip is now a row in a column container:
@@ -1235,19 +1508,25 @@
       display: none;
     }
 
-    /* Reclaim the 16px the status gutter spends. At 375px that is the
-       difference between a test name fitting on one line and wrapping. */
-    .test-summary p, .test-summary-group p, .iteration p, .activity p {
-      padding-left: 36px;
+    /* The flex row already spends only what it draws, so there is no fixed
+       gutter left to reclaim here — what A1 needed this rule for is gone.
+       What is left is the indentation step: 16px per level is right at
+       1440px and profligate on a 375px screen four levels deep, where the
+       legacy backend's two wrapper levels alone would eat 32px before the
+       first suite. */
+    .test-summary-group > .test-summary,
+    .test-summary-group > .test-summary-group {
+      padding-left: 10px;
+    }
+
+    .activities {
+      margin-left: 10px;
+    }
+
+    /* Long identifiers still have to break somewhere rather than push the
+       duration column off the screen. */
+    .row-name {
       overflow-wrap: break-word;
-    }
-
-    .test-result-icon {
-      margin-left: 12px;
-    }
-
-    .test-summary.no-drop-down .test-icon {
-      margin-left: 6px;
     }
 
     #right-sidebar {
@@ -1417,7 +1696,7 @@
 
       <main id="main-content">
         <div class="run" id="device_42230e298d9d9e832714ebad20e680c6">
-  <div class="tests">
+  <div class="tests" tabindex="0">
     <div class="tests-header">
       <ul class="toolbar toggle-toolbar">
         <li onclick="showAllScenarios(this);" class="selected">All (5)</li>
@@ -1427,39 +1706,39 @@
         <li onclick="showMixedScenariosOnly(this);">Mixed (1)</li>
       </ul>
       <ul class="toolbar table-header">
-        <li>Status</li>
-        <li>Tests</li>
+        <li>Test</li>
+        <li>Duration</li>
       </ul>
     </div>
     <div class="summary" id="acbfc5b654f672fd516dc3374cdec2e8">
       <div class="test-summary-group failed">
-      <span class="icon left test-result-icon"></span>
       <p>
-          <span class="icon left drop-down-icon" onclick="toggle(this, '901b3b4e0af989cdb3300028c5e8e52b')"></span>
-          <span class="icon left test-icon"></span>
-          SyntheticSuite (6.00s)
+          <span class="icon drop-down-icon" onclick="toggle(this, '901b3b4e0af989cdb3300028c5e8e52b')"></span>
+          <span class="icon test-result-icon"></span>
+          <span class="row-name">SyntheticSuite</span>
+          <span class="row-duration">(6.00s)</span>
       </p>
         <img class="screenshot-tail" src="screenshot.png" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
   <div class="test-summary expected-failure">
-      <span class="icon left test-result-icon"></span>
       <p class="list-item">
-          <span class="icon left drop-down-icon" onclick="toggle(this, '1c6cdccfeb05445c9896526289e8c191')"></span>
-          <span class="icon left test-icon"></span>
-          testExpectedlyFails() (1.50s)
+          <span class="icon drop-down-icon" onclick="toggle(this, '1c6cdccfeb05445c9896526289e8c191')"></span>
+          <span class="icon test-result-icon"></span>
+          <span class="row-name">testExpectedlyFails()</span>
+          <span class="row-duration">(1.50s)</span>
       </p>
       <div id="activities-1c6cdccfeb05445c9896526289e8c191" class="activities">
           <img class="screenshot-flow" src="screenshot.png" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
           <div class="activity activity-assertion-failure ">
   <p class="list-item">
     <span style="margin-left: 0px" class="padding"></span>
-    <span class="icon left drop-down-icon" onclick="toggle(this, 'eab1e43262f622153d7b29bf5870292c')"></span>
-    Synthetic.swift:42: assertion failed
+    <span class="icon drop-down-icon" onclick="toggle(this, 'eab1e43262f622153d7b29bf5870292c')"></span>
+    <span class="row-name">Synthetic.swift:42: assertion failed</span>
     <span class="icon paperclip-icon" style="display: inline-block"></span>
   </p>
   <div id="attachments-eab1e43262f622153d7b29bf5870292c" class="attachments">
       <p class="attachment list-item">
-  <span class="icon left screenshot-icon" style="margin-left: 16px"></span>
-  Screenshot
+  <span class="icon screenshot-icon" style="margin-left: 16px"></span>
+  <span class="row-name">Screenshot</span>
   <span class="icon preview-icon" data="screenshot.png" onclick="showScreenshot(this.getAttribute('data'))"></span>
   <img class="screenshot" src="screenshot.png" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
 </p>
@@ -1471,19 +1750,19 @@
       </div>
   </div>  <img class="screenshot-tail" src="screenshot.png" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/><img class="screenshot-tail" src="screenshot.png" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
   <div class="test-summary failed">
-      <span class="icon left test-result-icon"></span>
       <p class="list-item">
-          <span class="icon left drop-down-icon" onclick="toggle(this, '4abdbdaebf10baf0f23017525cf4a9be')"></span>
-          <span class="icon left test-icon"></span>
-          testFails() (1.50s)
+          <span class="icon drop-down-icon" onclick="toggle(this, '4abdbdaebf10baf0f23017525cf4a9be')"></span>
+          <span class="icon test-result-icon"></span>
+          <span class="row-name">testFails()</span>
+          <span class="row-duration">(1.50s)</span>
       </p>
       <div id="activities-4abdbdaebf10baf0f23017525cf4a9be" class="activities">
           <img class="screenshot-flow" src="screenshot.png" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/><img class="screenshot-flow" src="screenshot.png" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
           <div class="activity  no-drop-down">
   <p class="list-item">
     <span style="margin-left: 38px" class="padding"></span>
-    <span class="icon left drop-down-icon" onclick="toggle(this, '5e17ea9d5d34e0abc7da7873147c4feb')"></span>
-    Start Test
+    <span class="icon drop-down-icon" onclick="toggle(this, '5e17ea9d5d34e0abc7da7873147c4feb')"></span>
+    <span class="row-name">Start Test</span>
     <span class="icon paperclip-icon" style="display: none"></span>
   </p>
   <div id="attachments-5e17ea9d5d34e0abc7da7873147c4feb" class="attachments">
@@ -1495,19 +1774,19 @@
 </div><div class="activity  ">
   <p class="list-item">
     <span style="margin-left: 20px" class="padding"></span>
-    <span class="icon left drop-down-icon" onclick="toggle(this, 'ac8aedc2d707d9bd771a8615d5f89301')"></span>
-    Attachments
+    <span class="icon drop-down-icon" onclick="toggle(this, 'ac8aedc2d707d9bd771a8615d5f89301')"></span>
+    <span class="row-name">Attachments</span>
     <span class="icon paperclip-icon" style="display: inline-block"></span>
   </p>
   <div id="attachments-ac8aedc2d707d9bd771a8615d5f89301" class="attachments">
       <p class="attachment list-item">
-  <span class="icon left screenshot-icon" style="margin-left: 36px"></span>
-  Screenshot
+  <span class="icon screenshot-icon" style="margin-left: 36px"></span>
+  <span class="row-name">Screenshot</span>
   <span class="icon preview-icon" data="screenshot.png" onclick="showScreenshot(this.getAttribute('data'))"></span>
   <img class="screenshot" src="screenshot.png" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
 </p><p class="attachment list-item">
-  <span class="icon left text-icon" style="margin-left: 36px"></span>
-  Log
+  <span class="icon text-icon" style="margin-left: 36px"></span>
+  <span class="row-name">Log</span>
   <span class="icon preview-icon" data="FileName with DoubleQuote&quot;SingleQuote&apos;LessThan&lt;GreaterThan&gt;Ampersand&amp;.txt" onclick="showText(this.getAttribute('data'))"></span>
 </p>
   </div>
@@ -1517,8 +1796,8 @@
 </div><div class="activity  ">
   <p class="list-item">
     <span style="margin-left: 20px" class="padding"></span>
-    <span class="icon left drop-down-icon" onclick="toggle(this, 'a410649b89e3181b5d4019e2db54f183')"></span>
-    Nested
+    <span class="icon drop-down-icon" onclick="toggle(this, 'a410649b89e3181b5d4019e2db54f183')"></span>
+    <span class="row-name">Nested</span>
     <span class="icon paperclip-icon" style="display: none"></span>
   </p>
   <div id="attachments-a410649b89e3181b5d4019e2db54f183" class="attachments">
@@ -1528,8 +1807,8 @@
       <div class="activity  no-drop-down">
   <p class="list-item">
     <span style="margin-left: 48px" class="padding"></span>
-    <span class="icon left drop-down-icon" onclick="toggle(this, 'fcbec71434f97d8519070e445c49af0d')"></span>
-    Inner step
+    <span class="icon drop-down-icon" onclick="toggle(this, 'fcbec71434f97d8519070e445c49af0d')"></span>
+    <span class="row-name">Inner step</span>
     <span class="icon paperclip-icon" style="display: none"></span>
   </p>
   <div id="attachments-fcbec71434f97d8519070e445c49af0d" class="attachments">
@@ -1543,14 +1822,14 @@
 </div><div class="activity activity-assertion-failure ">
   <p class="list-item">
     <span style="margin-left: 0px" class="padding"></span>
-    <span class="icon left drop-down-icon" onclick="toggle(this, '35ad28c1a36df8df00034ad8eb0a2ffb')"></span>
-    Synthetic.swift:42: assertion failed
+    <span class="icon drop-down-icon" onclick="toggle(this, '35ad28c1a36df8df00034ad8eb0a2ffb')"></span>
+    <span class="row-name">Synthetic.swift:42: assertion failed</span>
     <span class="icon paperclip-icon" style="display: inline-block"></span>
   </p>
   <div id="attachments-35ad28c1a36df8df00034ad8eb0a2ffb" class="attachments">
       <p class="attachment list-item">
-  <span class="icon left screenshot-icon" style="margin-left: 16px"></span>
-  Screenshot
+  <span class="icon screenshot-icon" style="margin-left: 16px"></span>
+  <span class="row-name">Screenshot</span>
   <span class="icon preview-icon" data="screenshot.png" onclick="showScreenshot(this.getAttribute('data'))"></span>
   <img class="screenshot" src="screenshot.png" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
 </p>
@@ -1562,19 +1841,19 @@
       </div>
   </div>  <img class="screenshot-tail" src="screenshot.png" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
   <div class="test-summary succeeded">
-      <span class="icon left test-result-icon"></span>
       <p class="list-item">
-          <span class="icon left drop-down-icon" onclick="toggle(this, '16170791d4b96668f53ace117678c387')"></span>
-          <span class="icon left test-icon"></span>
-          testPasses() (1.50s)
+          <span class="icon drop-down-icon" onclick="toggle(this, '16170791d4b96668f53ace117678c387')"></span>
+          <span class="icon test-result-icon"></span>
+          <span class="row-name">testPasses()</span>
+          <span class="row-duration">(1.50s)</span>
       </p>
       <div id="activities-16170791d4b96668f53ace117678c387" class="activities">
           <img class="screenshot-flow" src="screenshot.png" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
           <div class="activity  no-drop-down">
   <p class="list-item">
     <span style="margin-left: 38px" class="padding"></span>
-    <span class="icon left drop-down-icon" onclick="toggle(this, 'f905959f1ac687802929e21cd860ca8b')"></span>
-    Start Test
+    <span class="icon drop-down-icon" onclick="toggle(this, 'f905959f1ac687802929e21cd860ca8b')"></span>
+    <span class="row-name">Start Test</span>
     <span class="icon paperclip-icon" style="display: none"></span>
   </p>
   <div id="attachments-f905959f1ac687802929e21cd860ca8b" class="attachments">
@@ -1586,19 +1865,19 @@
 </div><div class="activity  ">
   <p class="list-item">
     <span style="margin-left: 20px" class="padding"></span>
-    <span class="icon left drop-down-icon" onclick="toggle(this, '65291edd1daadc2dda7056f8567bbbef')"></span>
-    Attachments
+    <span class="icon drop-down-icon" onclick="toggle(this, '65291edd1daadc2dda7056f8567bbbef')"></span>
+    <span class="row-name">Attachments</span>
     <span class="icon paperclip-icon" style="display: inline-block"></span>
   </p>
   <div id="attachments-65291edd1daadc2dda7056f8567bbbef" class="attachments">
       <p class="attachment list-item">
-  <span class="icon left screenshot-icon" style="margin-left: 36px"></span>
-  Screenshot
+  <span class="icon screenshot-icon" style="margin-left: 36px"></span>
+  <span class="row-name">Screenshot</span>
   <span class="icon preview-icon" data="screenshot.png" onclick="showScreenshot(this.getAttribute('data'))"></span>
   <img class="screenshot" src="screenshot.png" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
 </p><p class="attachment list-item">
-  <span class="icon left text-icon" style="margin-left: 36px"></span>
-  Log
+  <span class="icon text-icon" style="margin-left: 36px"></span>
+  <span class="row-name">Log</span>
   <span class="icon preview-icon" data="FileName with DoubleQuote&quot;SingleQuote&apos;LessThan&lt;GreaterThan&gt;Ampersand&amp;.txt" onclick="showText(this.getAttribute('data'))"></span>
 </p>
   </div>
@@ -1608,8 +1887,8 @@
 </div><div class="activity  ">
   <p class="list-item">
     <span style="margin-left: 20px" class="padding"></span>
-    <span class="icon left drop-down-icon" onclick="toggle(this, 'd17da3102af2f32b2641aa89c80916b1')"></span>
-    Nested
+    <span class="icon drop-down-icon" onclick="toggle(this, 'd17da3102af2f32b2641aa89c80916b1')"></span>
+    <span class="row-name">Nested</span>
     <span class="icon paperclip-icon" style="display: none"></span>
   </p>
   <div id="attachments-d17da3102af2f32b2641aa89c80916b1" class="attachments">
@@ -1619,8 +1898,8 @@
       <div class="activity  no-drop-down">
   <p class="list-item">
     <span style="margin-left: 48px" class="padding"></span>
-    <span class="icon left drop-down-icon" onclick="toggle(this, 'f494a677468dc8724e395fe3dea7c562')"></span>
-    Inner step
+    <span class="icon drop-down-icon" onclick="toggle(this, 'f494a677468dc8724e395fe3dea7c562')"></span>
+    <span class="row-name">Inner step</span>
     <span class="icon paperclip-icon" style="display: none"></span>
   </p>
   <div id="attachments-f494a677468dc8724e395fe3dea7c562" class="attachments">
@@ -1634,33 +1913,34 @@
 </div>
       </div>
   </div>  <div class="test-summary mixed">
-      <span class="icon left test-result-icon"></span>
       <p class="list-item">
-          <span class="icon left drop-down-icon dropped" onclick="toggle(this, '751413da1b48c31cffea0e4c31cc99bc')"></span>
-          <span class="icon left test-icon"></span>
-          testRetries() 1 failed, 1 succeeded (3.00s)
+          <span class="icon drop-down-icon dropped" onclick="toggle(this, '751413da1b48c31cffea0e4c31cc99bc')"></span>
+          <span class="icon test-result-icon"></span>
+          <span class="row-name">testRetries()</span>
+          <span class="row-note">1 failed, 1 succeeded</span>
+          <span class="row-duration">(3.00s)</span>
       </p>
       <div id="iterations-751413da1b48c31cffea0e4c31cc99bc" class="iterations" style="display: block">
             <div class="iteration failed">
-      <span class="icon left test-result-icon"></span>
       <p class="list-item">
-          <span class="icon left drop-down-icon" onclick="toggle(this, '98ade9823d518704e870971ef0c6984c')"></span>
-          <span class="icon left test-icon"></span>
-          Iteration 1 (1.50s)
+          <span class="icon drop-down-icon" onclick="toggle(this, '98ade9823d518704e870971ef0c6984c')"></span>
+          <span class="icon test-result-icon"></span>
+          <span class="row-name">Iteration 1</span>
+          <span class="row-duration">(1.50s)</span>
       </p>
       <div id="activities-98ade9823d518704e870971ef0c6984c" class="activities">
           <img class="screenshot-flow" src="screenshot.png" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
           <div class="activity activity-assertion-failure ">
   <p class="list-item">
     <span style="margin-left: 0px" class="padding"></span>
-    <span class="icon left drop-down-icon" onclick="toggle(this, 'd52daa3211c83b468e246ec5568bb84b')"></span>
-    Synthetic.swift:42: assertion failed
+    <span class="icon drop-down-icon" onclick="toggle(this, 'd52daa3211c83b468e246ec5568bb84b')"></span>
+    <span class="row-name">Synthetic.swift:42: assertion failed</span>
     <span class="icon paperclip-icon" style="display: inline-block"></span>
   </p>
   <div id="attachments-d52daa3211c83b468e246ec5568bb84b" class="attachments">
       <p class="attachment list-item">
-  <span class="icon left screenshot-icon" style="margin-left: 16px"></span>
-  Screenshot
+  <span class="icon screenshot-icon" style="margin-left: 16px"></span>
+  <span class="row-name">Screenshot</span>
   <span class="icon preview-icon" data="screenshot.png" onclick="showScreenshot(this.getAttribute('data'))"></span>
   <img class="screenshot" src="screenshot.png" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
 </p>
@@ -1671,19 +1951,19 @@
 </div>
       </div>
   </div>  <div class="iteration succeeded">
-      <span class="icon left test-result-icon"></span>
       <p class="list-item">
-          <span class="icon left drop-down-icon" onclick="toggle(this, '34758e281c83108eeca0f231788a3a00')"></span>
-          <span class="icon left test-icon"></span>
-          Iteration 2 (1.50s)
+          <span class="icon drop-down-icon" onclick="toggle(this, '34758e281c83108eeca0f231788a3a00')"></span>
+          <span class="icon test-result-icon"></span>
+          <span class="row-name">Iteration 2</span>
+          <span class="row-duration">(1.50s)</span>
       </p>
       <div id="activities-34758e281c83108eeca0f231788a3a00" class="activities">
           <img class="screenshot-flow" src="screenshot.png" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
           <div class="activity  no-drop-down">
   <p class="list-item">
     <span style="margin-left: 38px" class="padding"></span>
-    <span class="icon left drop-down-icon" onclick="toggle(this, 'c0d6436cf3e7844556460f2d705a7997')"></span>
-    Start Test
+    <span class="icon drop-down-icon" onclick="toggle(this, 'c0d6436cf3e7844556460f2d705a7997')"></span>
+    <span class="row-name">Start Test</span>
     <span class="icon paperclip-icon" style="display: none"></span>
   </p>
   <div id="attachments-c0d6436cf3e7844556460f2d705a7997" class="attachments">
@@ -1695,19 +1975,19 @@
 </div><div class="activity  ">
   <p class="list-item">
     <span style="margin-left: 20px" class="padding"></span>
-    <span class="icon left drop-down-icon" onclick="toggle(this, 'eea257a844e0587dce9a918f430ad0a4')"></span>
-    Attachments
+    <span class="icon drop-down-icon" onclick="toggle(this, 'eea257a844e0587dce9a918f430ad0a4')"></span>
+    <span class="row-name">Attachments</span>
     <span class="icon paperclip-icon" style="display: inline-block"></span>
   </p>
   <div id="attachments-eea257a844e0587dce9a918f430ad0a4" class="attachments">
       <p class="attachment list-item">
-  <span class="icon left screenshot-icon" style="margin-left: 36px"></span>
-  Screenshot
+  <span class="icon screenshot-icon" style="margin-left: 36px"></span>
+  <span class="row-name">Screenshot</span>
   <span class="icon preview-icon" data="screenshot.png" onclick="showScreenshot(this.getAttribute('data'))"></span>
   <img class="screenshot" src="screenshot.png" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
 </p><p class="attachment list-item">
-  <span class="icon left text-icon" style="margin-left: 36px"></span>
-  Log
+  <span class="icon text-icon" style="margin-left: 36px"></span>
+  <span class="row-name">Log</span>
   <span class="icon preview-icon" data="FileName with DoubleQuote&quot;SingleQuote&apos;LessThan&lt;GreaterThan&gt;Ampersand&amp;.txt" onclick="showText(this.getAttribute('data'))"></span>
 </p>
   </div>
@@ -1717,8 +1997,8 @@
 </div><div class="activity  ">
   <p class="list-item">
     <span style="margin-left: 20px" class="padding"></span>
-    <span class="icon left drop-down-icon" onclick="toggle(this, '4fb505b3fa259f25bbab5dde2088a7d6')"></span>
-    Nested
+    <span class="icon drop-down-icon" onclick="toggle(this, '4fb505b3fa259f25bbab5dde2088a7d6')"></span>
+    <span class="row-name">Nested</span>
     <span class="icon paperclip-icon" style="display: none"></span>
   </p>
   <div id="attachments-4fb505b3fa259f25bbab5dde2088a7d6" class="attachments">
@@ -1728,8 +2008,8 @@
       <div class="activity  no-drop-down">
   <p class="list-item">
     <span style="margin-left: 48px" class="padding"></span>
-    <span class="icon left drop-down-icon" onclick="toggle(this, '5158bcb4fd33835cfed1c6aa1678854d')"></span>
-    Inner step
+    <span class="icon drop-down-icon" onclick="toggle(this, '5158bcb4fd33835cfed1c6aa1678854d')"></span>
+    <span class="row-name">Inner step</span>
     <span class="icon paperclip-icon" style="display: none"></span>
   </p>
   <div id="attachments-5158bcb4fd33835cfed1c6aa1678854d" class="attachments">
@@ -1746,11 +2026,11 @@
       </div>
   </div>  
   <div class="test-summary skipped">
-      <span class="icon left test-result-icon"></span>
       <p class="list-item">
-          <span class="icon left drop-down-icon" onclick="toggle(this, '7e99cdcbbbf846f71ae5f186cec55c0d')"></span>
-          <span class="icon left test-icon"></span>
-          testSkips() (1.50s)
+          <span class="icon drop-down-icon" onclick="toggle(this, '7e99cdcbbbf846f71ae5f186cec55c0d')"></span>
+          <span class="icon test-result-icon"></span>
+          <span class="row-name">testSkips()</span>
+          <span class="row-duration">(1.50s)</span>
       </p>
       <div id="activities-7e99cdcbbbf846f71ae5f186cec55c0d" class="activities">
           
@@ -2191,16 +2471,25 @@
     }
   }
 
+  // The summary header describes the *test* run — an outcome ring, a
+  // failure digest, per-device bars — and none of it says anything about
+  // the log the Logs tab shows. Xcode does the same thing: switching to a
+  // different report gives that report the whole column. A body class
+  // rather than a style written onto #run-summary, so the band's own rules
+  // (including its two max-heights) stay in the stylesheet and A3 can move
+  // the tabs without hunting for a display value in a script.
   function showLogs(el) {
     selectedElement(el);
     setDisplayToElementsWithSelector('#logs', 'flex');
     setDisplayToElementsWithSelector('.tests', 'none');
+    document.body.classList.add('logs-active');
   }
 
   function showTests(el) {
     selectedElement(el);
     setDisplayToElementsWithSelector('#logs', 'none');
     setDisplayToElementsWithSelector('.tests', 'flex');
+    document.body.classList.remove('logs-active');
   }
 
   document.querySelectorAll('.device-info')[0].classList.add("selected");

--- a/visual/tests/a11y.spec.ts
+++ b/visual/tests/a11y.spec.ts
@@ -18,8 +18,61 @@ const reportURL = pathToFileURL(resolve(__dirname, '../fixtures/report.html')).h
 // question gets logged for a human to weigh.
 const GATING_IMPACTS: string[] = ['critical', 'serious'];
 
+// A rule that only fires on a page in a particular state is only as good as
+// that state. `scrollable-region-focusable` — the rule that caught the tests
+// tree needing a `tabindex` (#439, A2) — analyses a region only if it actually
+// overflows, and before A2's taller rows this fixture cleared the default
+// viewport by seven pixels. The rule was live in the spec and blind in fact,
+// and nothing said so: the gate went green either way.
+//
+// Two things are needed to close that, and asserting the overflow is only the
+// second of them.
+//
+// First the layout has to settle, because this fixture's does not settle on
+// `load`. It carries four `img.screenshot-tail` in the tree, all `loading=
+// "lazy"` and all pointing into a `.xcresult` that is not there. A deferred
+// image box is 2px until its load is attempted and 20px once it has failed and
+// the broken-image placeholder takes its place, so the tree measures 373px or
+// 426px depending on whether four loads happened to resolve first — 0px of
+// overflow or 53px, from the same file. Under a parallel run it was the wrong
+// one about a fifth of the time, which means axe was analysing a tree with no
+// scrollable region at all on those runs and this gate could not have caught a
+// missing `tabindex` if it tried.
+//
+// Then assert. Waiting alone would leave the seven-pixel problem intact, and
+// asserting alone would just make a real race into a flaky test.
+async function settleImages(page: import('@playwright/test').Page) {
+  await page.waitForFunction(() => [...document.images]
+    .filter((img) => img.getClientRects().length > 0)
+    .every((img) => img.complete));
+}
+
+async function treeGeometryAtAxeViewport(page: import('@playwright/test').Page) {
+  return page.evaluate(() => {
+    const tree = document.querySelector('.run.active .tests');
+    if (!tree) return null;
+    return {
+      overflow: tree.scrollHeight - tree.clientHeight,
+      scrollHeight: tree.scrollHeight,
+      clientHeight: tree.clientHeight,
+      viewport: `${window.innerWidth}x${window.innerHeight}`,
+      rows: tree.querySelectorAll('p.list-item').length,
+    };
+  });
+}
+
 test('reports no critical or serious accessibility violations', async ({ page }) => {
   await page.goto(reportURL);
+  await settleImages(page);
+
+  const tree = await treeGeometryAtAxeViewport(page);
+  expect(tree, 'the fixture must render a tests pane for axe to analyse').not.toBeNull();
+  expect(
+    tree!.overflow,
+    'the tests pane must overflow at the axe viewport, or scrollable-region-focusable is '
+      + `not exercised and this gate cannot speak to it — measured ${JSON.stringify(tree)}`,
+  ).toBeGreaterThan(0);
+
   const results = await new AxeBuilder({ page }).analyze();
 
   const gating = results.violations.filter((v) => GATING_IMPACTS.includes(v.impact ?? ''));

--- a/visual/tests/behaviour.spec.ts
+++ b/visual/tests/behaviour.spec.ts
@@ -60,6 +60,80 @@ test('a digest jump reveals a row the filter has hidden', async ({ page }) => {
   await expect(row, 'the jump must reveal it anyway').toBeVisible();
 });
 
+// The narrow layout's scroll lock (#439, A2). Below 700px `#container` is a
+// column, so the tree is sized on the block axis by a flex item's automatic
+// minimum — its content's height. Without `min-height: 0` the list grew to
+// hold every row (measured: 376px of pane hanging 192px below a 500px
+// viewport) instead of scrolling inside its share, and because `body` sets
+// `overflow: hidden` that overflow was not merely unscrolled but unreachable.
+//
+// 500px of viewport height rather than a phone's 812: the assertion has to be
+// about the layout rule, not about whether this fixture's five tests happen to
+// be taller than a particular screen. At 812 the synthetic report overflows by
+// five pixels and the test would pass on a broken build.
+//
+// Scrolled with the wheel, not `scrollIntoView`. A programmatic scroll moves
+// an `overflow: hidden` box perfectly well, which is exactly why the bug
+// survived this long: the row is reachable by script and unreachable by the
+// person reading the report. The wheel is what a reader has.
+test('the last test row can be scrolled to at 375px', async ({ page }) => {
+  await page.setViewportSize({ width: 375, height: 500 });
+  await page.goto(reportURL);
+
+  const rows = page.locator('.run.active .test-summary > p.list-item');
+  expect(await rows.count(), 'the fixture must render test rows').toBeGreaterThan(0);
+
+  const geometry = await page.locator('.run.active .tests').evaluate((el) => ({
+    bottom: el.getBoundingClientRect().bottom,
+    scrollHeight: el.scrollHeight,
+    clientHeight: el.clientHeight,
+    viewport: document.documentElement.clientHeight,
+  }));
+
+  // The pane has to live inside the window. When it does not, the rows past
+  // the fold are behind `overflow: hidden` with nothing able to scroll them.
+  expect(
+    geometry.bottom,
+    'the test list hangs below the viewport instead of scrolling inside it',
+  ).toBeLessThanOrEqual(geometry.viewport + 1);
+
+  // …and the rows have to be inside *its* scrollable overflow, not spilled.
+  expect(
+    geometry.scrollHeight,
+    'the rows must overflow the list, which is the thing that scrolls',
+  ).toBeGreaterThan(geometry.clientHeight);
+
+  await page.mouse.move(180, geometry.bottom - 20);
+  for (let i = 0; i < 12; i++) await page.mouse.wheel(0, 200);
+
+  await expect(
+    rows.last(),
+    'the last row must come on screen for a reader with a wheel',
+  ).toBeInViewport();
+});
+
+// The Logs tab gets the column to itself (#439, A2). The summary band
+// describes the test run and says nothing about the log, so it stands down
+// while the log is showing — and has to come back, at both widths, because a
+// header that only ever disappears is a worse bug than one that never moves.
+for (const width of [1440, 375]) {
+  test(`the summary header stands down for the Logs tab at ${width}px`, async ({ page }) => {
+    await page.setViewportSize({ width, height: 812 });
+    await page.goto(reportURL);
+
+    const summary = page.locator('#run-summary');
+    const logs = page.locator('#logs');
+    await expect(summary, 'the band starts in the layout').toBeVisible();
+
+    await page.locator('#test-log-toolbar li', { hasText: 'Logs' }).click();
+    await expect(summary, 'Logs must reclaim the band').toBeHidden();
+    await expect(logs, 'the log must take its place').toBeVisible();
+
+    await page.locator('#test-log-toolbar li', { hasText: 'Tests' }).click();
+    await expect(summary, 'Tests must put the band back').toBeVisible();
+  });
+}
+
 test('arrow keys move the selection', async ({ page }) => {
   await page.goto(reportURL);
 


### PR DESCRIPTION
Refs #439. Second of three serial PRs implementing **Option A — Xcode-native**, on top
of A1's summary header (#476). This one is the **tree and its rows**: everything below
the header except the filter pills, which are A3's along with #460.

## What lands

- **Every row is one flex line** — disclosure triangle, status badge, name, and the
  duration in a right-hand column of its own. It replaces a pair of floats clearing a
  fixed 52px of left padding on every `<p>` in the tree, badge or no badge, which is why
  the duration could only ever be more text after the name.
- **Xcode's rounded status badge** replaces #459's diamond, in all six states, and
  **suite rows get one too** — #459 left headings out because the badge was a float and
  giving one to a heading meant reworking the gutter. Nothing new is computed for it:
  `TestGroup.status` already folds its children and already writes the class on the row.
- **Nesting is visible.** Suites, cases and iterations indent by level; before this the
  whole tree was flat, so `Selected tests`, `SampleAppUITests.xctest` and `FirstSuite`
  all began at the same pixel.
- **Hover and selection states**, bleeding full width past the indentation.
- **The activities panel** an expanded test opens is an inset surface with a ruled
  gutter, no per-row hairlines, and failure steps on their own tint.
- **Attachment rows** carry their type icon, their name, and a preview control in the
  accent the rest of the sheet uses for "you can click this".
- **The screenshot flow** is bounded like the mockup's player instead of a fixed-height
  slab — at 200px tall and unbounded in width it was the tallest thing in the tree by a
  factor of eight, and `.screenshot-tail` is emitted *between* rows, so it did that to
  the tree rather than to the panel.
- **Five new colour tokens** (`--color-row-hover`, `--color-bg-activities`,
  `--color-fail-tint`, `--color-tree-guide`, plus a repointed `--color-preview-border`)
  and two non-colour ones (`--tree-indent`, `--row-bleed`). Every colour the tree paints
  comes from the token layer; the dark block overrides values only.
- **Inline SVG for every new glyph**, URL-encoded and applied as a mask, so they take
  their colour from a token and `-i` single-file reports keep working byte for byte.

## Three found-fixes

These were not in the brief. The first two were found while shooting the 375px
screenshots and are pre-existing; the third is a defect the restyle would have inherited.

1. **The ≤700px scroll lock.** Below 700px `#container` is a column, so the test list is
   sized on the block axis by a flex item's automatic minimum — its *content's* height.
   With no `min-height: 0` the list grew to hold every row instead of scrolling inside
   its share: measured at 375×500, a 376px pane hanging 192px below the viewport. `body`
   sets `overflow: hidden`, so that overflow was not merely unscrolled but **unreachable**
   — on a long run the last test in the report could not be brought on screen at all.
   Pre-existing (the column layout arrived with #459) and made materially worse by A1,
   which spends real height above the tree.

   The regression test scrolls with the **wheel**, not `scrollIntoView`: a programmatic
   scroll moves an `overflow: hidden` box perfectly well, which is exactly why this
   survived — the row was reachable by script and unreachable by the reader. Verified by
   mutation: with the declaration removed the test fails, with it restored it passes.

2. **`scrollable-region-focusable` (axe, serious).** The scrolling list has no focusable
   descendant, so a keyboard user could not scroll it. This has always been true of any
   real report; the gate stayed green only because the synthetic fixture's rows fell
   **seven pixels** short of overflowing the pane, so the rule never fired on the one
   page CI checks. `tabindex="0"` plus a `:focus-visible` ring fixes it: Page Up/Down,
   Home and End now scroll the list, and the arrow keys keep going to the existing row
   navigation, which scrolls the same region by moving the selection.

3. **The invisible badge on a selected row.** The status glyph kept its status hue on the
   accent fill — passed measured **1.36:1** light and **2.07:1** dark, i.e. no badge at
   all on precisely the row the reader was looking at. It now takes the selection's own
   text colour and lets the accent knock through the glyph: **5.71 / 4.82**. The outcome
   stays readable because the *shape* carries it, which is the #459 property that status
   is never colour alone.

## The Logs tab reclaims the summary band

The header describes the *test* run — an outcome ring, a failure digest, per-device bars
— and none of it says anything about the log the Logs tab shows, so it stands down while
the log is up, the way Xcode gives a different report the whole column. One body class
and one `display: none`, deliberately not a height animation: the band is up to half the
viewport and the log is an iframe, so anything that resized it over several frames would
reflow and repaint the frame the whole way down. One class, one reflow, no jank.
Asserted at both 1440 and 375, including that it comes *back*, and verified by mutation.

**Boundary:** that is the minimal version, and it is where A2 stops. The fuller
shell/tabs/sidebar rethink — whether the three-pane frame survives at all, where the tabs
live, what happens to the device rail — is **A3's**, together with the filters and #460.

## Why nothing here can move the differential

`DifferentialTests` renders every fixture through both readers and requires byte equality
after masking the four declared losses. **No allow-list entry was added or changed**;
`differential-allowlist.json` is not in this diff.

**Indentation is CSS, not markup.** Depth is applied to the child *container* and never
written into the markup as a number. That is not a stylistic preference. The legacy
backend interposes two wrapper levels (`Selected tests`, `<target>.xctest`) that the
modern backend does not, so a depth attribute would differ between the two renders in
every row of the tree — and `KnownLossMasker`'s `wrapperGroups` rule unwraps the
*element*, which would leave the numbers behind with no allow-list entry able to cover
them. Nested padding indents by construction and costs the differential nothing.

**The duration keeps its masked shape.** `[[TITLE]]` and `([[DURATION]])` are separate
elements now so the duration can be a column, but the rendered text is unchanged:
whitespace between the two spans keeps `text()` reading `name (1.23s)`. `(N.NNs)` is
literally what the `durations` rule matches, so every duration in the tree still inherits
a loss the allow-list already declares — the same discipline A1 applied to the header
total. `wrapperGroups` reads a suite heading's text to recognise the legacy-only wrapper
levels, and `CoreTests` looks tests up by `hasPrefix` on the same reading; both still see
what they saw.

## Contrast

Every pairing computed before it was used. Text floor 4.5:1, non-text (WCAG 1.4.11) floor
3:1. `visual/tests/tokens.spec.ts` enforces the text column automatically from the live
cascade in both themes and passes.

### Text (floor 4.5:1) — light / dark

| Element | page | suite row | hovered row | activities panel |
|---|---|---|---|---|
| `.row-name` (primary) | 18.88 / 14.76 | 17.47 / 13.27 | 16.59 / 12.47 | 17.65 / 13.73 |
| `.row-duration`, `.row-note` (muted) | 7.46 / 6.46 | 6.90 / 5.81 | 6.55 / 5.46 | 6.97 / 6.01 |

### Status badges and row icons (non-text, floor 3:1) — light / dark

| Element | page | suite row | hovered row | activities panel |
|---|---|---|---|---|
| `--status-passed` | **4.21** / 7.74 | **3.89** / 6.96 | **3.69** / 6.54 | **3.93** / 7.20 |
| `--status-failed` | 5.38 / 6.61 | 4.98 / 5.95 | 4.73 / 5.59 | 5.03 / 6.15 |
| `--status-skipped` / `--status-unknown` | 5.07 / 6.46 | 4.69 / 5.81 | 4.46 / 5.46 | 4.74 / 6.01 |
| `--status-expected` | 5.00 / 7.77 | 4.63 / 6.99 | 4.40 / 6.56 | 4.68 / 7.23 |
| `--status-mixed` | 6.04 / 8.08 | 5.59 / 7.26 | 5.30 / 6.83 | 5.64 / 7.52 |
| `.drop-down-icon` (muted) | 7.46 / 6.46 | 6.90 / 5.81 | 6.55 / 5.46 | 6.97 / 6.01 |

Tightest badge: **3.69:1** (passed, on a hovered row, light), against a 3:1 floor. Because
the glyph is a knock-out, that number is *also* what the tick inside the badge is worth
against the fill around it — which is the whole reason for preferring a hole to the
mockup's white tick, whose own figure is 3.13:1.

### Single-ground pairings

| Pairing | light | dark |
|---|---|---|
| selected row text and badge — `--color-on-accent` on `--color-accent` | 5.71 | 4.82 |
| failure step — `--status-failed` on `--color-fail-tint` | **4.74** | 5.35 |
| `.preview-icon` — `--color-accent-text` on `--color-bg-activities` | 5.33 | 7.65 |

Tightest text pairing in the whole tree: **4.74:1**, against a 4.5 floor.

### Deliberately below 3:1

`--color-tree-guide` (1.28 light / 1.44 dark, against the panel it is drawn on) and
`--color-preview-border` (1.51 / 1.60). Both are decorative under 1.4.11: the timeline
rule restates the nesting that indentation already states, and the frame outlines an
image that is itself the content. Drawing either at 3:1 would put a hard bar down the
middle of every expanded test — the same reasoning A1 recorded for
`--color-summary-border`. `--color-preview-border` was `#021A40` before this, a near-black
navy and the only colour in the light theme belonging to no family; the dark theme already
had a normal border value for it.

## Deviations from the mockup, and why

1. **Knock-out glyphs, not the mockup's white ones.** See above — it inherits the
   already-vetted token-vs-surface contrast instead of introducing new unmeasured
   pairings. Identical picture on a white row, a measured one everywhere else.
2. **The corrected palette, not the mockup's.** Status colours are C's contrast-vetted
   tokens, not the raw Apple values — the same call A1 recorded as its deviation 2. No
   status token changed in this PR.
3. **No per-activity elapsed offsets.** They are the mockup's answer to the missing
   per-activity durations, and 4.0 cannot give them: `ParsedActivity` carries a title, a
   failure flag, attachments and sub-activities — `finish` and the timestamps left with
   the legacy reader (the port's decision 2). Nothing is faked; the gutter carries the
   structure the offsets would have shared.
4. **No source-location chip.** The mockup pulls `FirstSuite.swift:69` out into a
   monospace chip beside the message. Our file and line are *inside* the activity title
   string and the two backends format that string differently — the standing
   `failureTitlePrefix` known loss — so splitting it out is model work, not a restyle.
5. **Suite rows draw no disclosure triangle.** Collapsing a group is a script change:
   `toggle()` looks for `iterations-`/`activities-`/`attachments-` ids a group has none
   of, and wrapping its children in one would break `hideSummaryGroupsIfNeeded`, which
   walks a group's *direct* `.test-summary` children. That is A3's to rewire, so A2 shows
   no control it cannot honour. The column is held open with `visibility: hidden` so a
   suite's badge still lines up with its children's.
6. **The blue test tile is gone** from tree rows. The mockup has no equivalent, the badge
   beside it already said "this row is a test", and it cost 20px of a 375px row to repeat
   a fact. Nothing selects it; `--icon-test` and its four rules go with it.
7. **Expected-failure is a filled amber badge** (the mockup's treatment) rather than
   #459's outlined one; `unknown` stays outlined. The filled/outlined split now means
   settled versus not — a test that failed exactly as it declared it would *is* settled,
   and unknown is the only state that means "we could not tell". All six glyphs stay
   distinct, which is the #459 property this had to preserve.
8. **The status glyph tokens are shared**, so the header's digest and summary icons and
   the title icon inherit the new badge silhouette. Deliberate: a diamond in the header
   and a badge in the tree would be two iconographies on one page. No A1 code is touched.
9. **Attachments keep the preview pane.** The mockup plays media inline under the
   activity; the report has a working attachment pane and rewiring it is not a restyle.
   The rows themselves get the mockup's treatment.
10. **The indentation step is 10px below 700px**, not 16. Sixteen is right at 1440 and
    profligate on a 375px screen four levels deep, where the legacy backend's two wrapper
    levels alone would eat 32px before the first real suite.
11. **The duration reads `(13.71s)`, not the mockup's `13.71 s`.** The parentheses are
    the shape `KnownLossMasker`'s `durations` rule normalises — dropping them would leave
    a declared known loss uncovered in every row of the tree. Same call A1 made for the
    header total, for the same reason.
12. **The activities panel is indented and its gutter is ruled.** The mockup bounds it
    with a full-bleed inset band and top/bottom hairlines only, because its elapsed-offset
    column already anchors the region on the left. Without that column the panel had no
    left-hand anchor at all, so the indent and the 2px rule take its place.
13. **Row backgrounds bleed past the indentation.** Rows are indented by their
    container's padding, so a row's own box starts at the indent; `--row-bleed` carries the
    background back out into the gutter that indentation spent, where `.tests` clips it.
    The mockup does this — its failure tint and its expanded-test band both run to the
    card's edge, under the disclosure column rather than starting after it. Painted by a
    `::before` strip anchored `right: 100%`, taking its colour from the row with
    `background-color: inherit`. Leftward overflow is unreachable in a left-to-right
    scroll container, so nothing widens the page — covered by the 375px probe. Activity
    and attachment rows deliberately keep the `0` default: they sit inside the activities
    panel, and a row bleeding past it would erase the very thing that says "this belongs
    to the test above".

    *Corrected after review.* This first shipped as `box-shadow: -100vw 0 0 <colour>`,
    which painted nothing: an outer shadow is the border box translated whole, so the
    offset that clears the indentation also drags the box's right edge off the left of the
    viewport. Now pixel-verified at 1440 and 375, both themes, hover and selection, on the
    synthetic fixture and a real 3-deep render.

## Test-pin changes

- **`KnownLossMasker`, `attachmentDisplayNames`** — the anchor regex drops `left ` from
  the type-icon span. A2 drops that float class from the attachment type icon, and without
  the edit the rule silently stops matching and the differential goes red; reverting it
  still turns `testMaskedRendersAreIdenticalAcrossBackends` red, which is what makes the
  edit necessary rather than convenient. Deleted outright rather than made optional
  (review finding 4): the masker only ever sees two renders of the *same* build, so an
  anchor that also matched a pre-A2 report bought a cross-revision property nothing in the
  repo consumes. The replacement is anchored on the `row-name` wrapper and takes only the
  text inside it, not the whole line (review finding 5), so the wrapper markup stays
  compared — same nine matches on both goldens, but nine `row-name` wrappers were being
  dropped from the comparison before and none are now. **The allow-list entry is
  unchanged;** this is the rule that implements it, in test code.
- **`visual/tests/a11y.spec.ts`** — the axe gate now settles the fixture's lazy images and
  then asserts that the tests pane overflows before analysing (review finding 3).
  `scrollable-region-focusable` only fires on a region that overflows, and this fixture
  did not settle on `load`: four `img.screenshot-tail` are `loading="lazy"` and point into
  a `.xcresult` that is not there, and a deferred image box is 2px until its load is
  attempted and 20px once the broken-image placeholder replaces it. The tree therefore
  measured 373px or 426px from the same file — 0px of overflow or 53px — and under a
  parallel run it was the wrong one about a fifth of the time, with axe analysing a tree
  that had no scrollable region at all. Both halves are needed: waiting alone leaves the
  seven-pixel blindness the fix was for, asserting alone turns a real race into a flaky
  test. Mutation-checked both ways — stripping the `tabindex` reddens the gate, giving the
  pane room to fit fails the precondition.
- **`visual/tests/behaviour.spec.ts`** — three new browser tests, all three verified by
  mutation (removing the fix fails the test; restoring it passes):
  - the last test row is reachable at 375px, scrolled with the wheel;
  - the summary band stands down for Logs and comes back, at 1440 and at 375.
- **Goldens** — `Snapshots/index.html` and `index-inline.html` refreshed. The diff is the
  stylesheet and the row templates and nothing else; the only markup deletions are the
  `test-icon` spans, the `left` classes, and the `Status`/`Tests` column labels.

No assertion was weakened or deleted anywhere.

## Verification

- `swift test`, both CI legs: `XCHR_RESULT_READER=auto` **153 tests, 3 skipped, 0
  failures**; `=modern` **153 tests, 3 skipped, 0 failures**. Run repeatedly rather than
  once — see the note below.
- `DifferentialTests` green on both legs, against locally generated `TestResults`,
  `RetryResults` and `SanityResults`; **`differential-allowlist.json` untouched**
- `visual/` — **16/16**, including axe-core (no critical or serious) and the automated
  4.5:1 / 3:1 contrast gates in both themes
- 375px overflow probe on the real render and the synthetic fixture, both themes, with
  every test and activity expanded: the page does not scroll sideways, the tree does not
  scroll sideways, and nothing crosses the viewport edge outside an intentional scroll
  container
- swiftformat clean; **zero new swiftlint warnings** (35 before, 35 after, same set)

### A local-only flake, named so it is not mistaken for this diff

Three separate local runs failed one test each and then passed on identical source:
`PayloadExportFaultTests.testInlineExportDoesNotLeaveItsTempFileBehind`,
`ReproducibilityTests.testMintedIdentifiersNeedNoEscapingInHTMLOrJavaScript` ("report was
degraded"), and — in an earlier round — `ModernPayloadStoreTests`. All three are the same
symptom: `xcresulttool export` writes every payload to a **shared**
`NSTemporaryDirectory()/<id>` path, and this machine has ten worktrees of this repo whose
suites collide there. It is already a recorded property of this checkout, not a discovery.

It cannot be this diff. The five files touched are template strings, a test-only regex,
two goldens and a Playwright spec; none of them is on the payload-export path
(`ResultFile`, `ModernPayloadStore`, `FaultCollector`) and none of them is reachable from
it.

The evidence, stated as it actually came out rather than rounded in my favour: on the
final commit, auto is **5 clean of 7** and modern **4 clean of 4**, each failure a
different test and none reproducing. Detached `main` on the same machine ran the auto leg
**3 times clean**, so it did not reproduce there either — three runs is not enough to call
that a difference, and the sample is too small to conclude anything from it. What settles
it is CI, which gives each job its own runner and where this class of collision cannot
occur: **both legs are green on this PR** — `test (auto)` 8m33s, `test (modern)` 4m48s,
alongside `visual`, `dump`, both `build` matrix legs, `swift`, `shell` and `actions`. Ten
of ten.

## Screenshots

Real report (`TestResults.xcresult`, 21 tests / 6 failures / 2 expected failures) and the
synthetic fixture, which is the only one that exercises expected-failure, skipped and
mixed at once. Thirty-two PNGs at 1440 and 375, light and dark, in
`orca-artifacts/track3-a2-tree/`: full page, tree-only crop, a crop with a row selected
and another hovered (which is where the badge fix is visible), and the Logs tab. The same
four crops of the **mockup's** tree card sit beside them (`mockup-tree-*.png`) so the
comparison is a picture rather than a description.

**Visual review sheet** — mockup against shipped at both widths and both themes, the
before/after pair, the full contrast tables and every deviation with its reasoning:
<https://claude.ai/code/artifact/1ad12f0e-233e-4447-931a-2f028923b345>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned test reports with clearer status badges, suite grouping, notes, durations, activity panels, and improved screenshot previews.
  * Added responsive test-list scrolling and mobile-friendly layouts.
  * Added keyboard focus support and improved color contrast for selected items.
  * Logs now provide a focused view by hiding the summary header, which returns when switching back to Tests.

* **Bug Fixes**
  * Improved attachment-name display and masking in generated reports.
  * Preserved screenshot proportions while constraining preview sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->