### PR TITLE
Give every status a filter, and the log something to filter it with (fixes #460)

### DIFF
--- a/Sources/XCTestHTMLReportCore/Classes/HTMLTemplates.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/HTMLTemplates.swift
@@ -2621,14 +2621,20 @@ struct HTMLTemplates
       for (var i = 0; i < rows.length; i++) {
         var shown = rowMatches(rows[i], status, query);
         rows[i].style.display = shown ? 'block' : 'none';
-        // A test's tail screenshot is emitted *between* rows rather than
-        // inside one (A2), so it is a sibling the row's own `display` does not
-        // reach. Left behind, a filtered-out test leaves its screenshot in the
-        // tree with no row to belong to — a 200px picture of a test the reader
-        // asked not to see.
+        // A test's tail screenshots are emitted *between* rows rather than
+        // inside one (A2), so they are siblings the row's own `display` does
+        // not reach. Left behind, a filtered-out test leaves its screenshots in
+        // the tree with no row to belong to — 200px pictures of a test the
+        // reader asked not to see.
+        //
+        // A loop, not one sibling: `TestScreenshotFlow` emits the *last three*
+        // screenshots of a test (`suffix(tailCount)`), so a test with several
+        // is preceded by several. The synthetic fixture has such a row, which
+        // is why the gate on this counts every tail rather than the first.
         var tail = rows[i].previousElementSibling;
-        if (tail && tail.classList.contains('screenshot-tail')) {
+        while (tail && tail.classList.contains('screenshot-tail')) {
           tail.style.display = shown ? 'block' : 'none';
+          tail = tail.previousElementSibling;
         }
         if (shown) {
           executions += executionsOf(rows[i]);

--- a/Sources/XCTestHTMLReportCore/Classes/HTMLTemplates.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/HTMLTemplates.swift
@@ -2616,8 +2616,7 @@ struct HTMLTemplates
       }
       var status = statusOf(view),
           query = queryOf(view),
-          rows = filterableRows(view),
-          executions = 0;
+          rows = filterableRows(view);
       for (var i = 0; i < rows.length; i++) {
         var shown = rowMatches(rows[i], status, query);
         rows[i].style.display = shown ? 'block' : 'none';
@@ -2636,11 +2635,27 @@ struct HTMLTemplates
           tail.style.display = shown ? 'block' : 'none';
           tail = tail.previousElementSibling;
         }
-        if (shown) {
+      }
+      hideSummaryGroupsIfNeeded(view);
+      countExecutionsOnScreen(view);
+    }
+
+    // Counted off the rows rather than accumulated while deciding them, so
+    // that anything which changes what is on screen can restate the figure by
+    // calling this — the digest jump reveals a row the filter hid, and a count
+    // that only the filter could write would keep announcing the filter's
+    // number at a pane that no longer holds it.
+    function countExecutionsOnScreen(view) {
+      if (!view) {
+        return;
+      }
+      var rows = filterableRows(view),
+          executions = 0;
+      for (var i = 0; i < rows.length; i++) {
+        if (rows[i].style.display !== 'none') {
           executions += executionsOf(rows[i]);
         }
       }
-      hideSummaryGroupsIfNeeded(view);
       setCount(view, executions === 1 ? '1 execution' : executions + ' executions');
     }
 
@@ -2845,6 +2860,12 @@ struct HTMLTemplates
         }
         ancestor = ancestor.parentElement;
       }
+
+      // A row appearing is a change to what the pane holds, so the toolbar
+      // restates its figure through the same writer the filter uses. The count
+      // is `aria-live`: silence here is a reader being told nothing while a
+      // test they did not filter for arrives on screen.
+      countExecutionsOnScreen(row.closest('.run-view'));
 
       disclosure.style.display = 'block';
       var chevron = row.querySelector('.drop-down-icon');

--- a/Sources/XCTestHTMLReportCore/Classes/HTMLTemplates.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/HTMLTemplates.swift
@@ -2562,6 +2562,16 @@ struct HTMLTemplates
     }
 
     // A group's visibility is otherwise derived from its rows, below.
+    //
+    // The name is matched against the row *and every suite above it*, because
+    // a filter over a tree that only ever reads its leaves is one a reader
+    // finds out about the hard way: typing the name of a suite they can see
+    // would empty the pane. Matching an ancestor keeps that suite and the
+    // tests inside it, which is what the same query does in Xcode's outline.
+    //
+    // The status is a leaf question either way — a suite's own status is
+    // folded from its children, so filtering on it would put rows of every
+    // outcome under a heading claiming one.
     function rowMatches(row, status, query) {
       if (status !== 'all' && !row.classList.contains(status)) {
         return false;
@@ -2569,8 +2579,21 @@ struct HTMLTemplates
       if (!query) {
         return true;
       }
-      var name = row.querySelector('.row-name');
-      return !!name && name.textContent.toLowerCase().indexOf(query) >= 0;
+      var node = row;
+      while (node && !node.classList.contains('tests')) {
+        if (node.classList.contains('test-summary')
+          || node.classList.contains('test-summary-group')) {
+          // The first `.row-name` inside a row is its own: a suite's heading
+          // precedes its children, and a retried test's precedes its
+          // iterations.
+          var name = node.querySelector('.row-name');
+          if (name && name.textContent.toLowerCase().indexOf(query) >= 0) {
+            return true;
+          }
+        }
+        node = node.parentElement;
+      }
+      return false;
     }
 
     // How many times the run executed what a row stands for: the `data-runs`

--- a/Sources/XCTestHTMLReportCore/Classes/HTMLTemplates.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/HTMLTemplates.swift
@@ -153,6 +153,13 @@ struct HTMLTemplates
          Safari versions that predate it, then named fallbacks, and a
          generic family last so the chain can always terminate. */
       --font-family-base: system-ui, -apple-system, \"Segoe UI\", Roboto, \"Helvetica Neue\", Helvetica, Arial, sans-serif;
+      /* The run log is the one thing in the report that is a *document* rather
+         than a layout, and its structure is columns of `-------- title
+         --------` rules and indentation — which only a monospace face keeps
+         aligned. `ui-monospace` first, so it is the platform's own coding
+         face where there is one, with the named fallbacks for browsers that
+         do not know the generic yet (#439, A3b). */
+      --font-family-mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
       --font-size-xs: 11px;
       --font-size-sm: 12px;
       --font-size-md: 13px;
@@ -787,7 +794,7 @@ struct HTMLTemplates
       overflow: auto;
       background-color: var(--color-surface);
       color: var(--color-text-primary);
-      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-family: var(--font-family-mono);
       font-size: var(--font-size-xs);
       line-height: 1.5;
       white-space: pre-wrap;

--- a/Sources/XCTestHTMLReportCore/Classes/HTMLTemplates.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/HTMLTemplates.swift
@@ -633,9 +633,8 @@ struct HTMLTemplates
     }
 
     /* The per-view toolbar. Left group is the view's own controls; the
-       trailing group is deliberately empty and deliberately present — it is
-       where A3b's text filter and its dropdowns land (#460), and reserving it
-       here is what keeps that from being a re-layout. */
+       trailing group holds the Filter field, which is where A3a reserved the
+       slot for it and where Xcode's own test report puts one. */
     .view-toolbar {
       display: flex;
       flex-wrap: wrap;
@@ -655,23 +654,63 @@ struct HTMLTemplates
       gap: var(--space-xs);
     }
 
-    /* A label, not a control. The Logs view has one scope and no way to change
-       it, and the shipped markup said otherwise: `<li class="selected">All
-       Messages</li>` in a `toggle-toolbar`, wearing a selected pill's fill and
-       hover with nothing bound to it. Dressing an inert string as the chosen
-       one of several options is the kind of thing a keyboard user finds out
-       the hard way. Real log filters are #460's, and land in the trailing slot
-       beside this. */
-    .view-toolbar-label {
+    /* A count, and a live one (#439, A3b).
+
+       This is the slot A3a's inert "All Messages" label occupied. That label
+       was a placeholder for a control the Logs view could not have — nothing
+       in the page can filter a document on another origin — and the honest
+       replacement is not a better-dressed label but a real filter beside a
+       figure that answers to it: `23 executions` on Tests, `312 lines` on
+       Logs, both recomputed whenever a filter changes what is showing.
+
+       Styled as text rather than as a pill on purpose: the pills beside it are
+       controls, and something that looks like the chosen one of several
+       options while being unclickable is exactly what the label it replaces
+       got wrong. */
+    .view-toolbar-count {
       padding: 2px var(--space-sm);
       color: var(--color-text-muted);
       font-size: var(--font-size-xs);
+      font-variant-numeric: tabular-nums;
+    }
+
+    /* The Filter field. One control shape for both views, because they are the
+       same question asked of different content — which rows, which lines.
+
+       `type="search"` for the browser's own clear affordance and for the
+       Escape-clears behaviour a reader already has in every other search
+       field; nothing here re-implements either. The width is capped rather
+       than fixed so the field gives way first at 375px, where the pills are
+       what a reader cannot do without. */
+    .view-filter {
+      width: 100%;
+      max-width: 180px;
+      min-width: 0;
+      padding: 2px var(--space-sm);
+      border: 1px solid var(--color-border-control);
+      border-radius: var(--radius-sm);
+      background-color: var(--color-surface);
+      color: var(--color-text-primary);
+      font: inherit;
+      font-size: var(--font-size-xs);
+    }
+
+    .view-filter::placeholder {
+      color: var(--color-text-muted);
+      /* Chrome renders a placeholder at the UA's own opacity, which would put
+         an already-muted token below the 4.5:1 the token was sized for. */
+      opacity: 1;
+    }
+
+    .view-filter:focus-visible {
+      outline: 2px solid var(--color-accent);
+      outline-offset: 1px;
     }
 
     /* The status filters. Buttons in a radiogroup, because they are mutually
        exclusive and only one can be in effect — `aria-checked` says which,
-       where the old `<li class="selected">` said nothing at all. A3b upgrades
-       what they filter; the five functions behind them are unchanged. */
+       where the old `<li class="selected">` said nothing at all. A3b renders
+       them from the run's own tally: see `Run.filterPillsHTML`. */
     .filter-pills {
       display: flex;
       flex-wrap: wrap;
@@ -731,10 +770,34 @@ struct HTMLTemplates
       margin-left: auto;
     }
 
-    .logs-iframe {
-      border: 0;
+    /* The run log (#439, A3b), in the document rather than behind an iframe.
+
+       `white-space: pre-wrap` rather than `pre`: the log carries indented
+       section headers whose leading tabs are the structure, so the whitespace
+       has to survive — but a line that runs past the window has to wrap rather
+       than push the page sideways, which is what `pre` would do inside a
+       `body` that is `overflow: hidden`. `overflow-wrap: anywhere` covers the
+       one shape wrapping cannot otherwise break: the absolute paths the log
+       prints, which have no spaces in them. */
+    .log-body {
       flex: 1;
       min-height: 0;
+      margin: 0;
+      padding: var(--space-sm);
+      overflow: auto;
+      background-color: var(--color-surface);
+      color: var(--color-text-primary);
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: var(--font-size-xs);
+      line-height: 1.5;
+      white-space: pre-wrap;
+      overflow-wrap: anywhere;
+      tab-size: 2;
+    }
+
+    .log-body:focus-visible {
+      outline: 2px solid var(--color-accent);
+      outline-offset: -2px;
     }
 
     /* Icons (#439).
@@ -1978,11 +2041,6 @@ struct HTMLTemplates
       return view ? view.querySelector('.tests') : null;
     }
 
-    function inActiveTests(selector) {
-      var view = activeTestsView();
-      return view ? view.querySelectorAll(selector) : [];
-    }
-
     // ---- Roving focus --------------------------------------------------
     //
     // Shared by the view tabs and the status filters, which are the two
@@ -2454,26 +2512,109 @@ struct HTMLTemplates
       }
     }
 
-    // ---- Status filters ------------------------------------------------
+    // ---- Filters (#439, A3b; #460) -------------------------------------
     //
-    // The five functions A3b upgrades, unchanged in what they do. What
-    // changed is only what they are scoped to: `.run.active` named the shell's
-    // per-run pane, which the per-view split replaced with one slice per view.
-    // Everything downstream of the scope — which classes are shown, which are
-    // hidden, and the group-collapsing pass — is the same code it was.
+    // What A3a left here was five functions, one per pill, each naming the
+    // four row classes it shows or hides. That shape is why #460 existed: an
+    // expected failure carries none of those four classes, so no function
+    // mentioned it, so \"Passed\" left it on screen and \"All\" — which sets
+    // `display: block` on the four it knows — left it at whatever it already
+    // was. The group pass below then read it as hidden, and a suite whose every
+    // test was an expected failure disappeared from a report the moment the
+    // reader touched any filter, including \"All\".
+    //
+    // One function replaces the five. A row is shown when it matches *both* of
+    // the view's filters, and the status one is a class comparison against
+    // `data-filter` rather than a list of classes written out here — so a
+    // status added to `Status` gets a pill and gets filtered, with nothing in
+    // this file to update. `unknown` is filtered today for exactly that
+    // reason, having had the same gap as `expectedFailure` and no issue.
+    //
+    // State lives on the view, not in a variable: a report holds one tests
+    // slice per destination and each keeps its own filters, so switching
+    // destination and switching back does not silently reset what the reader
+    // chose.
 
-    function setDisplayToElementsWithSelector(sel, display) {
-      [].forEach.call(inActiveTests(sel), function (el) {
-        el.style.display = display;
+    function statusOf(view) {
+      return view.getAttribute('data-filter-status') || 'all';
+    }
+
+    function queryOf(view) {
+      return view.getAttribute('data-filter-text') || '';
+    }
+
+    // What the filter treats as a row, which is what the *report* treats as a
+    // test: every `.test-summary`, plus a suite heading with nothing inside
+    // it. `Run.allTests` flattens the tree to its leaves and a childless group
+    // is one of them — the shape a crashed target leaves behind, which
+    // `TruncationFaultTests` is built out of — so it is counted in the pills
+    // and has to be filtered by them. It also had the same defect #460 names:
+    // the group pass below skips a group with no rows in it, so before this
+    // nothing could hide one whatever the reader chose.
+    function filterableRows(view) {
+      var rows = Array.prototype.slice.call(
+        view.querySelectorAll('.test-summary, .test-summary-group')
+      );
+      return rows.filter(function (row) {
+        return !row.classList.contains('test-summary-group')
+          || row.querySelector('.test-summary, .test-summary-group') === null;
       });
     }
 
-    function hideElementsWithSelector(sel) {
-      setDisplayToElementsWithSelector(sel, 'none');
+    // A group's visibility is otherwise derived from its rows, below.
+    function rowMatches(row, status, query) {
+      if (status !== 'all' && !row.classList.contains(status)) {
+        return false;
+      }
+      if (!query) {
+        return true;
+      }
+      var name = row.querySelector('.row-name');
+      return !!name && name.textContent.toLowerCase().indexOf(query) >= 0;
     }
 
-    function showElementsWithSelector(sel) {
-      setDisplayToElementsWithSelector(sel, 'block');
+    // How many times the run executed what a row stands for: the `data-runs`
+    // the template writes when a test was parameterized or repeated, and 1
+    // otherwise — which is why the attribute is absent on almost every row.
+    function executionsOf(row) {
+      return parseInt(row.getAttribute('data-runs'), 10) || 1;
+    }
+
+    function applyTestFilters(view) {
+      if (!view) {
+        return;
+      }
+      var status = statusOf(view),
+          query = queryOf(view),
+          rows = filterableRows(view),
+          executions = 0;
+      for (var i = 0; i < rows.length; i++) {
+        var shown = rowMatches(rows[i], status, query);
+        rows[i].style.display = shown ? 'block' : 'none';
+        // A test's tail screenshot is emitted *between* rows rather than
+        // inside one (A2), so it is a sibling the row's own `display` does not
+        // reach. Left behind, a filtered-out test leaves its screenshot in the
+        // tree with no row to belong to — a 200px picture of a test the reader
+        // asked not to see.
+        var tail = rows[i].previousElementSibling;
+        if (tail && tail.classList.contains('screenshot-tail')) {
+          tail.style.display = shown ? 'block' : 'none';
+        }
+        if (shown) {
+          executions += executionsOf(rows[i]);
+        }
+      }
+      hideSummaryGroupsIfNeeded(view);
+      setCount(view, executions === 1 ? '1 execution' : executions + ' executions');
+    }
+
+    // The toolbar figure this view answers with. One writer, so the rendered
+    // value and every recomputation of it are the same sentence.
+    function setCount(view, text) {
+      var count = view.querySelector('.view-toolbar-count');
+      if (count) {
+        count.textContent = text;
+      }
     }
 
     // The chosen filter, as an ARIA fact rather than a class: these are
@@ -2488,81 +2629,124 @@ struct HTMLTemplates
       setRovingTabStop(pills, el);
     }
 
-    function showAllScenarios(el) {
-      selectedElement(el);
-      showElementsWithSelector('.test-summary.succeeded');
-      showElementsWithSelector('.test-summary.skipped');
-      showElementsWithSelector('.test-summary.failed');
-      showElementsWithSelector('.test-summary.mixed');
-      hideSummaryGroupsIfNeeded();
+    function chooseStatus(pill) {
+      var view = pill.closest('.run-view');
+      if (!view) {
+        return;
+      }
+      selectedElement(pill);
+      view.setAttribute('data-filter-status', pill.getAttribute('data-filter') || 'all');
+      applyTestFilters(view);
     }
 
-    function showSuccessfulScenariosOnly(el) {
-      selectedElement(el);
-      showElementsWithSelector('.test-summary.succeeded');
-      hideElementsWithSelector('.test-summary.skipped');
-      hideElementsWithSelector('.test-summary.failed');
-      hideElementsWithSelector('.test-summary.mixed');
-      hideSummaryGroupsIfNeeded();
-    }
-
-    function showSkippedScenariosOnly(el) {
-      selectedElement(el);
-      hideElementsWithSelector('.test-summary.succeeded');
-      showElementsWithSelector('.test-summary.skipped');
-      hideElementsWithSelector('.test-summary.failed');
-      hideElementsWithSelector('.test-summary.mixed');
-      hideSummaryGroupsIfNeeded();
-    }
-
-    function showFailedScenariosOnly(el) {
-      selectedElement(el);
-      hideElementsWithSelector('.test-summary.succeeded');
-      hideElementsWithSelector('.test-summary.skipped');
-      showElementsWithSelector('.test-summary.failed');
-      hideElementsWithSelector('.test-summary.mixed');
-      hideSummaryGroupsIfNeeded();
-    }
-  
-    function showMixedScenariosOnly(el) {
-      selectedElement(el);
-      hideElementsWithSelector('.test-summary.succeeded');
-      hideElementsWithSelector('.test-summary.skipped');
-      hideElementsWithSelector('.test-summary.failed');
-      showElementsWithSelector('.test-summary.mixed');
-      hideSummaryGroupsIfNeeded();
-    }
-
-    function hideSummaryGroupsIfNeeded() {
-      var testSummaryGroups = Array.prototype.slice.call(
-        inActiveTests('.test-summary-group')
+    // A suite is shown when anything under it is, and the walk is bottom-up so
+    // a parent reads children that have already been decided.
+    //
+    // The pass this replaces bailed out on any group holding a sub-group
+    // (`testSummaryGroupChildren.length > 0`), so the legacy backend's two
+    // wrapper levels — \"Selected tests\" and \"<target>.xctest\", which hold
+    // only other groups — were never hidden by anything. A filter that
+    // selected two rows left them under three empty headings. Deciding
+    // deepest-first is what makes one rule cover both cases: `querySelectorAll`
+    // yields document order, and an ancestor always precedes its descendants
+    // in it, so iterating backwards visits every child before its parent.
+    //
+    // A group with no rows and no sub-groups is skipped, not because it cannot
+    // be decided but because it already has been: `applyTestFilters` treats a
+    // childless suite as a row, since that is what `Run.allTests` counts it as.
+    function hideSummaryGroupsIfNeeded(view) {
+      var groups = Array.prototype.slice.call(
+        view.querySelectorAll('.test-summary-group')
       );
-      for (var i = 0; i < testSummaryGroups.length; i++) {
-          var testSummaryGroup = testSummaryGroups[i];
-          var children = Array.prototype.slice.call(testSummaryGroup.children);
-          var testSummaryChildren = children.filter(function(a) { return a.classList.contains('test-summary'); });
-          var testSummaryGroupChildren = children.filter(function(a) { return a.classList.contains('test-summary-group'); });
-          if (testSummaryChildren == 0 || testSummaryGroupChildren.length > 0) {
-            continue;
-          }
-
-          if (testSummaryChildren.filter(function(a) { return a.style.display == 'block' }).length == 0) {
-            testSummaryGroup.style.display = 'none';
-          } else {
-            testSummaryGroup.style.display = 'block';
-          }
+      for (var i = groups.length - 1; i >= 0; i--) {
+        var group = groups[i];
+        var children = Array.prototype.slice.call(group.children).filter(function (child) {
+          return child.classList.contains('test-summary')
+            || child.classList.contains('test-summary-group');
+        });
+        if (children.length === 0) {
+          continue;
+        }
+        var anyShown = children.some(function (child) {
+          return child.style.display !== 'none';
+        });
+        group.style.display = anyShown ? 'block' : 'none';
       }
     }
 
+    var filterPills = document.querySelectorAll('.filter-pills [role=\"radio\"]');
+    for (var fp = 0; fp < filterPills.length; fp++) {
+      filterPills[fp].addEventListener('click', function (e) {
+        chooseStatus(e.currentTarget);
+      }, false);
+    }
+
     // Arrow keys inside a radiogroup both move focus and choose, which is the
-    // behaviour a native radio group has. The pill's own `onclick` is the one
-    // definition of what choosing does, so the handler dispatches to it rather
-    // than restating the mapping from pill to filter.
+    // behaviour a native radio group has.
     var filterGroups = document.querySelectorAll('.filter-pills');
     for (var f = 0; f < filterGroups.length; f++) {
-      rovingGroup(filterGroups[f], '[role=\"radio\"]', function (pill) {
-        pill.onclick();
-      });
+      rovingGroup(filterGroups[f], '[role=\"radio\"]', chooseStatus);
+    }
+
+    // The name filter. Composes with the pills rather than replacing them:
+    // both are read by `applyTestFilters`, so \"Failed\" and \"one\" together
+    // mean the failing tests whose names contain \"one\", which is what a
+    // reader who set both is asking for.
+    var testFilters = document.querySelectorAll('.tests-filter');
+    for (var tf = 0; tf < testFilters.length; tf++) {
+      testFilters[tf].addEventListener('input', function (e) {
+        var view = e.currentTarget.closest('.run-view');
+        if (!view) {
+          return;
+        }
+        view.setAttribute('data-filter-text', e.currentTarget.value.trim().toLowerCase());
+        applyTestFilters(view);
+      }, false);
+    }
+
+    // ---- The log filter ------------------------------------------------
+    //
+    // The log is one text document, so the only filter its content supports is
+    // over its lines — which is the control Xcode's own Log view puts in this
+    // same corner. It is possible at all because A3b renders the log in the
+    // page: behind the `iframe` it replaces, the log was a foreign origin and
+    // nothing here could have read a line of it.
+    //
+    // The lines are split once, on first use, and kept on the element. The
+    // `<pre>` stays a single text node either way — a line per element would
+    // be one node per line of a log that can run to six figures.
+    var logFilters = document.querySelectorAll('.log-filter');
+    for (var lf = 0; lf < logFilters.length; lf++) {
+      logFilters[lf].addEventListener('input', function (e) {
+        var view = e.currentTarget.closest('.run-view'),
+            body = view && view.querySelector('.log-body');
+        if (!body) {
+          return;
+        }
+        if (!body.logLines) {
+          var text = body.textContent;
+          // A trailing newline ends the last line rather than starting an
+          // empty one, which is what the rendered count already assumes.
+          if (text.charAt(text.length - 1) === '\\n') {
+            text = text.slice(0, -1);
+          }
+          body.logLines = text === '' ? [] : text.split('\\n');
+        }
+        var query = e.currentTarget.value.trim().toLowerCase(),
+            lines = body.logLines,
+            kept = query
+              ? lines.filter(function (line) {
+                  return line.toLowerCase().indexOf(query) >= 0;
+                })
+              : lines;
+        body.textContent = kept.join('\\n');
+        setCount(
+          view,
+          query
+            ? kept.length + ' of ' + lines.length + (lines.length === 1 ? ' line' : ' lines')
+            : lines.length + (lines.length === 1 ? ' line' : ' lines')
+        );
+      }, false);
     }
 
     // ---- Boot ----------------------------------------------------------
@@ -2611,13 +2795,19 @@ struct HTMLTemplates
 
       activateRunContaining(row);
 
-      // The filter writes `display: none` onto the element itself, and its
-      // group as well. Clearing both un-hides this one row without resetting
-      // the filter the reader chose.
+      // The filter writes `display: none` onto the element itself and onto
+      // every suite above it that the row was the last visible thing in.
+      // Clearing the whole chain un-hides this one row without resetting the
+      // filter the reader chose — the nearest suite alone is not enough, since
+      // A3b's group pass hides a wrapper whose every child went, which the
+      // pass it replaces never did.
       row.style.display = 'block';
-      var group = row.closest('.test-summary-group');
-      if (group) {
-        group.style.display = 'block';
+      var ancestor = row.parentElement;
+      while (ancestor && !ancestor.classList.contains('tests')) {
+        if (ancestor.classList.contains('test-summary-group')) {
+          ancestor.style.display = 'block';
+        }
+        ancestor = ancestor.parentElement;
       }
 
       disclosure.style.display = 'block';
@@ -2806,21 +2996,28 @@ struct HTMLTemplates
   /// the arrow keys keep going to the row navigation, which scrolls the same
   /// region by moving the selection.
   ///
-  /// The trailing group in the toolbar is empty on purpose. A3b's text filter
-  /// and its dropdowns (#460) land in it, and having the slot already laid out
-  /// — right-aligned, in the flex row, with the pills sized against it — is
-  /// what makes that an addition rather than a second toolbar redesign.
+  /// The toolbar is A3b's (#439, #460). A3a laid out the row and reserved the
+  /// trailing group; what lands in it is Xcode's own control — a Filter field,
+  /// right-aligned, in the same place Xcode's test report puts one.
+  ///
+  /// The pills are rendered from the run's `Tally` rather than written out
+  /// here, so the row states the outcomes the run actually produced instead of
+  /// a fixed five that could never include a sixth. See `Run.filterPillsHTML`.
+  ///
+  /// The executions count sits between the two: `21 tests` is the pill row's
+  /// business and `23 executions` is a different number about the same run —
+  /// Xcode states both, side by side, and it is `aria-live` because the filter
+  /// changes it and a change nobody is told about is not a reading.
   static let runTests = """
   <div class=\"run-view\" id=\"tests_[[DEVICE_IDENTIFIER]]\">
       <div class=\"view-toolbar\">
         <div class=\"filter-pills\" role=\"radiogroup\" aria-label=\"Filter tests by status\">
-          <button type=\"button\" role=\"radio\" class=\"pill\" aria-checked=\"true\" tabindex=\"0\" onclick=\"showAllScenarios(this);\">All ([[N_OF_TESTS]])</button>
-          <button type=\"button\" role=\"radio\" class=\"pill\" aria-checked=\"false\" tabindex=\"-1\" onclick=\"showSuccessfulScenariosOnly(this);\">Passed ([[N_OF_PASSED_TESTS]])</button>
-          <button type=\"button\" role=\"radio\" class=\"pill\" aria-checked=\"false\" tabindex=\"-1\" onclick=\"showSkippedScenariosOnly(this);\">Skipped ([[N_OF_SKIPPED_TESTS]])</button>
-          <button type=\"button\" role=\"radio\" class=\"pill\" aria-checked=\"false\" tabindex=\"-1\" onclick=\"showFailedScenariosOnly(this);\">Failed ([[N_OF_FAILED_TESTS]])</button>
-          <button type=\"button\" role=\"radio\" class=\"pill\" aria-checked=\"false\" tabindex=\"-1\" onclick=\"showMixedScenariosOnly(this);\">Mixed ([[N_OF_MIXED_TESTS]])</button>
+          [[FILTER_PILLS]]
         </div>
-        <div class=\"view-toolbar-trailing\"></div>
+        <p class=\"view-toolbar-count\" aria-live=\"polite\">[[EXECUTIONS_LABEL]]</p>
+        <div class=\"view-toolbar-trailing\">
+          <input type=\"search\" class=\"view-filter tests-filter\" placeholder=\"Filter\" aria-label=\"Filter tests by name\" autocomplete=\"off\">
+        </div>
       </div>
       <ul class=\"table-header\">
         <li>Test</li>
@@ -2832,22 +3029,48 @@ struct HTMLTemplates
     </div>
   """
 
+  /// One status filter (#439, A3b).
+  ///
+  /// `data-filter` names the row class the pill selects — `all`, or a
+  /// `Status.cssClass` — instead of an `onclick` naming one of five functions.
+  /// That is what lets the script hold a single mapping from pill to rows, and
+  /// what makes adding a status a change to `Status` rather than to the page's
+  /// JavaScript.
+  static let filterPill = """
+  <button type=\"button\" role=\"radio\" class=\"pill\" data-filter=\"[[FILTER]]\" aria-checked=\"[[CHECKED]]\" tabindex=\"[[TABINDEX]]\">[[LABEL]] ([[COUNT]])</button>
+  """
+
   /// One destination's log view (#439, A3a).
   ///
-  /// Its own toolbar and its own frame, and — unlike the shell it replaces —
-  /// its own element ids. Before A3a every run rendered `id="logs"`,
-  /// `id="logs-header"` and `id="logs-iframe"`, so a report built from two
-  /// bundles emitted each of them twice; the page only behaved because the
-  /// duplicates were hidden inside an inactive run. The ids are per
-  /// destination now, which is also what lets the picker switch the log and
-  /// the tree together.
+  /// Its own toolbar and its own element ids. Before A3a every run rendered
+  /// `id="logs"`, `id="logs-header"` and `id="logs-iframe"`, so a report built
+  /// from two bundles emitted each of them twice; the page only behaved
+  /// because the duplicates were hidden inside an inactive run. The ids are
+  /// per destination now, which is also what lets the picker switch the log
+  /// and the tree together.
+  ///
+  /// **The log is in the document** (#439, A3b), where it used to be an
+  /// `<iframe src>` pointing at a `file://` sibling or a `data:` URI. Both are
+  /// foreign origins, and two things followed from that which the report
+  /// shipped: nothing in the page could filter, search or scroll the log — so
+  /// A3a's toolbar carried an inert "All Messages" label where a control
+  /// belongs — and the log could not see the token layer, so in dark mode the
+  /// Logs view was a white slab with black text. See `Run.logText`.
+  ///
+  /// `<pre>` rather than a line per element: a filter that rebuilds one text
+  /// node is a string join, where a hundred thousand `<div>`s is a hundred
+  /// thousand nodes. `tabindex="0"` for the same reason the tests list carries
+  /// one — axe's `scrollable-region-focusable`: a region a mouse can scroll
+  /// has to be reachable by a keyboard too.
   static let runLogs = """
   <div class=\"run-view\" id=\"logs_[[DEVICE_IDENTIFIER]]\">
       <div class=\"view-toolbar\">
-        <p class=\"view-toolbar-label\">All Messages</p>
-        <div class=\"view-toolbar-trailing\"></div>
+        <p class=\"view-toolbar-count\" aria-live=\"polite\">[[LOG_LINES_LABEL]]</p>
+        <div class=\"view-toolbar-trailing\">
+          <input type=\"search\" class=\"view-filter log-filter\" placeholder=\"Filter\" aria-label=\"Filter log lines\" autocomplete=\"off\">
+        </div>
       </div>
-      <iframe class=\"logs-iframe\" src=\"[[LOG_SOURCE]]\" title=\"Run log\" loading=\"lazy\"></iframe>
+      <pre class=\"log-body\" tabindex=\"0\">[[LOG_TEXT]]</pre>
     </div>
   """
 
@@ -2881,13 +3104,19 @@ struct HTMLTemplates
   /// gone: the status badge beside it already says "this row is a test", the
   /// mockup has no equivalent, and it cost 20px of a 375px row to repeat a
   /// fact. Nothing selects it.
+  /// `data-runs` is how many times the run executed this test (#439, A3b) —
+  /// the number behind the toolbar's executions count, written onto the row so
+  /// the count can be re-derived from whichever rows a filter left showing.
+  /// Omitted when it is 1, which is every row that is not parameterized or
+  /// repeated, so the attribute costs nothing on the overwhelming majority of
+  /// a tree.
   static let testCase = """
     [[SCREENSHOT_TAIL]]
-    <div class=\"[[ITEM_CLASS]] [[ICON_CLASS]]\">
+    <div class=\"[[ITEM_CLASS]] [[ICON_CLASS]]\"[[RUNS_ATTR]]>
         <p class=\"list-item\">
             <span class=\"icon drop-down-icon\" onclick=\"toggle(this, '[[UUID]]')\"></span>
             <span class=\"icon test-result-icon\"></span>
-            <span class=\"row-name\">[[TITLE]]</span>
+            <span class=\"row-name\">[[TITLE]]</span>[[EXECUTION_NOTE]]
             <span class=\"row-duration\">([[DURATION]])</span>
         </p>
         <div id=\"activities-[[UUID]]\" class=\"activities\">
@@ -2898,7 +3127,7 @@ struct HTMLTemplates
   """
 
   static let testCaseWithIterations = """
-    <div class=\"[[ITEM_CLASS]] [[ICON_CLASS]]\">
+    <div class=\"[[ITEM_CLASS]] [[ICON_CLASS]]\"[[RUNS_ATTR]]>
         <p class=\"list-item\">
             <span class=\"icon drop-down-icon dropped\" onclick=\"toggle(this, '[[UUID]]')\"></span>
             <span class=\"icon test-result-icon\"></span>

--- a/Sources/XCTestHTMLReportCore/Classes/Models/Run.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Models/Run.swift
@@ -13,6 +13,25 @@ struct Run {
     let runDestination: RunDestination
     let testSummaries: [TestSummary]
     let logContent: RenderingContent
+    /// The log as text, for the Logs view to render in the page (#439, A3b).
+    ///
+    /// The log used to be an `<iframe src>`, which put it in a *foreign
+    /// document*: a `file://` sibling in linking mode, an opaque `data:` URI
+    /// in inline mode. Two consequences, both of which the report shipped:
+    ///
+    /// - Nothing in the page could act on it. A3a's Logs toolbar therefore had
+    ///   an inert "All Messages" label where a control belongs, because no
+    ///   control the parent can hold is able to filter, scroll or search across
+    ///   an origin boundary.
+    /// - It could not see the token layer. In dark mode the Logs view rendered
+    ///   as a white slab with black text — the same class of defect as the
+    ///   base64 status PNGs #459 replaced with masks, and for the same reason.
+    ///
+    /// Both go away when the text is in the document. `logContent` is kept and
+    /// unchanged: the exported `.log` file is the artifact #480 fixed and
+    /// `DifferentialLogTests` compares, and it stays the signal
+    /// `logFailedToResolve` reads.
+    let logText: String
     /// The reference this run's log content was resolved from, kept so that a
     /// failure to resolve it can be reported against something identifiable —
     /// the same reason `Attachment` keeps `payloadId`.
@@ -59,6 +78,19 @@ struct Run {
         allTests.filter { $0.status == .mixed }.count
     }
 
+    /// The second of Xcode's two numbers (#439, A3b): 21 tests, 23 runs.
+    ///
+    /// Summed over the leaves, like every other figure the header and the
+    /// toolbar derive, so a suite's own node can never be counted on top of
+    /// the cases inside it. Equal to `numberOfTests` on a run that neither
+    /// repeated nor parameterized anything, which is most runs — the toolbar
+    /// states it either way, because "23 executions" and "21 executions" are
+    /// both answers to the question, and a figure that only appears when it
+    /// disagrees is a figure a reader cannot learn to look for.
+    var numberOfExecutions: Int {
+        allTests.reduce(0) { $0 + $1.executionCount }
+    }
+
     init?(
         run: ParsedRun,
         identifierPath: IdentifierPath,
@@ -76,23 +108,37 @@ struct Run {
         logReference = run.logReference
 
         if let logReference = run.logReference {
-            logContent = file.exportLogsContent(
-                reference: logReference,
-                renderingMode: renderingMode,
-                // Named from the run's identifier path, not from `reference`:
-                // the reference is backend-internal (a CAS id on legacy, a
-                // `--type` selector on modern), so a file named after it can
-                // never agree across backends. The path digest is the same
-                // scheme every element id already uses (#430), identical on
-                // both backends, and unique per run — a multi-action bundle
-                // gets one log file per action instead of a shared name that
-                // would leave last-writer-wins. No fixture exercises multiple
-                // actions, so that property is asserted here rather than in a
-                // test.
-                fileName: "\(identifierPath.identifier).log"
-            )
+            // The bytes first and once, because the rendered text and — in
+            // inline mode — the exported content are the same bytes. Only
+            // linking mode reads a second time, to write the file, which is
+            // why this is spelled out rather than left to `exportLogsContent`.
+            let data = file.exportLogsData(reference: logReference)
+            // Both readers build this text out of Swift `String`s before it is
+            // ever bytes, so it is valid UTF-8 by construction and the failable
+            // initializer is the repo's idiom rather than a risk taken here.
+            logText = data.flatMap { String(data: $0, encoding: .utf8) } ?? ""
+            switch renderingMode {
+            case .inline:
+                logContent = data.map(RenderingContent.data) ?? .none
+            case .linking:
+                logContent = file.exportLogs(
+                    reference: logReference,
+                    // Named from the run's identifier path, not from
+                    // `reference`: the reference is backend-internal (a CAS id
+                    // on legacy, a `--type` selector on modern), so a file
+                    // named after it can never agree across backends. The path
+                    // digest is the same scheme every element id already uses
+                    // (#430), identical on both backends, and unique per run —
+                    // a multi-action bundle gets one log file per action
+                    // instead of a shared name that would leave
+                    // last-writer-wins. No fixture exercises multiple actions,
+                    // so that property is asserted here rather than in a test.
+                    fileName: "\(identifierPath.identifier).log"
+                ).map(RenderingContent.url) ?? .none
+            }
         } else {
             Logger.warning("Can't find log reference for run \(run.destination.displayName)")
+            logText = ""
             logContent = .none
         }
 
@@ -173,17 +219,6 @@ struct Run {
         "log for run \(runDestination.name)"
     }
 
-    private var logSource: String? {
-        switch logContent {
-        case let .url(url):
-            return url.relativePath
-        case let .data(data):
-            return "data:text/plain;base64,\(data.base64EncodedString())"
-        case .none:
-            return nil
-        }
-    }
-
     // PRAGMA MARK: - HTML
 
     /// A run renders into two places, not one (#439, A3a).
@@ -205,33 +240,113 @@ struct Run {
     /// named properties instead of conforming. The substitution is the
     /// protocol's own — same placeholder syntax, same verbatim-value rule, so
     /// the escaping contract in `HTML`'s documentation still governs every
-    /// value below — applied to two templates from one dictionary, because one
-    /// source for the counts and the identifier is the point.
+    /// value below.
+    ///
+    /// **Ordered, and one list per template** (#439, A3b). `HTML.html` reduces
+    /// over a dictionary, so it fills placeholders in whatever order the hash
+    /// happens to yield and fills the ones an earlier replacement *inserted*
+    /// as readily as the ones the template author wrote — the substitution
+    /// hazard the A3a review found in the picker and `PlaceholderOrderTests`
+    /// pins. Two per-view templates make it closable here rather than merely
+    /// ordered: each list carries only what its own template needs, and the one
+    /// value in each that is test-author text goes in last, with nothing after
+    /// it to fill. So a test named `[[LOG_TEXT]]` renders as itself (the Tests
+    /// list has no such entry) and a log line reading `[[TEST_SUMMARIES]]`
+    /// renders as itself, where one shared dictionary in hash order could
+    /// substitute either into the other.
     var testsViewHTML: String {
-        render(HTMLTemplates.runTests)
+        // Identifier, counts and pills first — every one of them opaque by
+        // construction (a digest, an Int, a label from an enum) — then the
+        // tree, which is the only value here a test author can write.
+        render(HTMLTemplates.runTests, [
+            ("DEVICE_IDENTIFIER", runDestination.targetDevice.uniqueIdentifier),
+            ("N_OF_TESTS", String(numberOfTests)),
+            ("EXECUTIONS_LABEL", Self.executionsLabel(numberOfExecutions)),
+            ("FILTER_PILLS", filterPillsHTML),
+            ("TEST_SUMMARIES", testSummaries.map(\.html).joined()),
+        ])
     }
 
     var logsViewHTML: String {
-        render(HTMLTemplates.runLogs)
+        render(HTMLTemplates.runLogs, [
+            ("DEVICE_IDENTIFIER", runDestination.targetDevice.uniqueIdentifier),
+            ("LOG_LINES_LABEL", Self.linesLabel(logLineCount)),
+            ("LOG_TEXT", logText.stringByEscapingXMLChars),
+        ])
     }
 
-    private func render(_ template: String) -> String {
-        placeholderValues.reduce(template) { accumulator, entry in
-            accumulator.replacingOccurrences(of: "[[\(entry.key)]]", with: entry.value)
+    private func render(_ template: String, _ values: [(String, String)]) -> String {
+        values.reduce(template) { accumulator, entry in
+            accumulator.replacingOccurrences(of: "[[\(entry.0)]]", with: entry.1)
         }
     }
 
-    private var placeholderValues: [String: String] {
-        [
-            "DEVICE_IDENTIFIER": runDestination.targetDevice.uniqueIdentifier,
-            "LOG_SOURCE": (logSource ?? "").stringByEscapingXMLChars,
-            "N_OF_TESTS": String(numberOfTests),
-            "N_OF_PASSED_TESTS": String(numberOfPassedTests),
-            "N_OF_SKIPPED_TESTS": String(numberOfSkippedTests),
-            "N_OF_FAILED_TESTS": String(numberOfFailedTests),
-            "N_OF_MIXED_TESTS": String(numberOfMixedTests),
-            "TEST_SUMMARIES": testSummaries.map(\.html).joined(),
-        ]
+    /// Lines as the `<pre>` will show them: a trailing newline ends the last
+    /// line rather than starting an empty one, which is what the script's own
+    /// count has to agree with or the toolbar states a number the reader
+    /// cannot find.
+    var logLineCount: Int {
+        guard !logText.isEmpty else {
+            return 0
+        }
+        return logText.hasSuffix("\n")
+            ? logText.dropLast().components(separatedBy: "\n").count
+            : logText.components(separatedBy: "\n").count
+    }
+
+    static func executionsLabel(_ count: Int) -> String {
+        count == 1 ? "1 execution" : "\(count) executions"
+    }
+
+    static func linesLabel(_ count: Int) -> String {
+        count == 1 ? "1 line" : "\(count) lines"
+    }
+
+    /// The status filter row (#439, A3b).
+    ///
+    /// The same buckets the summary header's legend draws, in the same order,
+    /// under the same drop-the-empty-ones rule — because they are the same
+    /// `Tally`. That is the whole of the #460 decision made operable: A1
+    /// already gave expected failures a bucket of their own, and the filter row
+    /// was the one reading of the run that still had them in no bucket at all,
+    /// neither shown by "All" nor hidden by "Passed".
+    ///
+    /// A leading "All" and then one pill per outcome the run produced. Empty
+    /// buckets are dropped for the reason the legend drops them — a permanent
+    /// "Mixed (0)" in a report that never retried a test is noise — and
+    /// dropping them is also what keeps the row honest as the set of statuses
+    /// grows: `unknown` gets a pill exactly when a run contains one, which is
+    /// the same gap #460 names, closed for the other status that had it.
+    private var filterPillsHTML: String {
+        let all = Self.filterPill(
+            filter: "all", label: "All", count: numberOfTests, checked: true
+        )
+        // Joined on a newline at the template's own indentation, so a rendered
+        // report — and the committed golden a reviewer reads the diff of —
+        // shows one pill per line rather than the whole row as one.
+        return ([all] + tally.buckets.map {
+            Self.filterPill(
+                filter: $0.status.cssClass, label: $0.label, count: $0.count, checked: false
+            )
+        }).joined(separator: "\n          ")
+    }
+
+    /// One pill. `data-filter` carries the row class it selects, so the script
+    /// has one mapping from pill to rows instead of five functions naming the
+    /// classes over again — and adding a status adds a case to `Status`, not a
+    /// function to the page.
+    ///
+    /// Every value is opaque by construction: a CSS class from an enum, a
+    /// literal label, an `Int`.
+    private static func filterPill(
+        filter: String, label: String, count: Int, checked: Bool
+    ) -> String {
+        HTMLTemplates.filterPill
+            .replacingOccurrences(of: "[[FILTER]]", with: filter)
+            .replacingOccurrences(of: "[[CHECKED]]", with: checked ? "true" : "false")
+            .replacingOccurrences(of: "[[TABINDEX]]", with: checked ? "0" : "-1")
+            .replacingOccurrences(of: "[[LABEL]]", with: label)
+            .replacingOccurrences(of: "[[COUNT]]", with: String(count))
     }
 }
 

--- a/Sources/XCTestHTMLReportCore/Classes/Models/Status.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Models/Status.swift
@@ -1,0 +1,71 @@
+//
+//  Status.swift
+//  XCTestHTMLReport
+//
+//  Split out of `Test.swift` by A3b (#439, #460), which made this enum the
+//  single mapping between an outcome and the report's own vocabulary for it:
+//  `cssClass` names the row class the stylesheet paints, the `data-filter` a
+//  pill carries, and — through `RunSummary.Tally` — the bucket the summary
+//  legend and the filter row are both rendered from. Adding a case now adds a
+//  glyph, a legend row, a pill and a filter, with no list anywhere else to
+//  keep in step.
+//
+
+import Foundation
+
+/// `CaseIterable` so `StatusCSSClassTests` can assert its table covers every
+/// case: a status added without a `cssClass` draws no glyph at all, which is
+/// how `.expectedFailure` went unnoticed until #439.
+enum Status: String, CaseIterable {
+    case unknown = ""
+    case failure = "Failure"
+    case success = "Success"
+    case skipped = "Skipped"
+    case mixed = "Mixed"
+    case expectedFailure = "Expected Failure"
+
+    init(_ parsed: ParsedStatus) {
+        switch parsed {
+        case .passed:
+            self = .success
+        case .failed:
+            self = .failure
+        case .skipped:
+            self = .skipped
+        case .expectedFailure:
+            // Folded into `.unknown` until #439: with no case of its own an
+            // expected failure rendered an empty status class, which the
+            // stylesheet draws as a blank cell. Both readers already map
+            // xcresult's `Expected Failure` here, so carrying it through
+            // diverges neither backend.
+            self = .expectedFailure
+        case .unknown:
+            self = .unknown
+        }
+    }
+
+    /// The class the stylesheet draws a status glyph from, and — since A3b
+    /// (#439, #460) — the value a filter pill carries in `data-filter`, so one
+    /// enum is the whole mapping between a status and its rows. Adding a case
+    /// therefore adds a pill and a filter, with no list to update elsewhere.
+    ///
+    /// `.unknown` returns a name rather than the empty string it used to: "no
+    /// icon at all" and "an icon meaning we do not know" are different
+    /// statements, and only the second is true.
+    var cssClass: String {
+        switch self {
+        case .failure:
+            return "failed"
+        case .success:
+            return "succeeded"
+        case .skipped:
+            return "skipped"
+        case .mixed:
+            return "mixed"
+        case .expectedFailure:
+            return "expected-failure"
+        case .unknown:
+            return "unknown"
+        }
+    }
+}

--- a/Sources/XCTestHTMLReportCore/Classes/Models/Test.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Models/Test.swift
@@ -8,63 +8,6 @@
 
 import Foundation
 
-/// `CaseIterable` so `StatusCSSClassTests` can assert its table covers every
-/// case: a status added without a `cssClass` draws no glyph at all, which is
-/// how `.expectedFailure` went unnoticed until #439.
-enum Status: String, CaseIterable {
-    case unknown = ""
-    case failure = "Failure"
-    case success = "Success"
-    case skipped = "Skipped"
-    case mixed = "Mixed"
-    case expectedFailure = "Expected Failure"
-
-    init(_ parsed: ParsedStatus) {
-        switch parsed {
-        case .passed:
-            self = .success
-        case .failed:
-            self = .failure
-        case .skipped:
-            self = .skipped
-        case .expectedFailure:
-            // Folded into `.unknown` until #439: with no case of its own an
-            // expected failure rendered an empty status class, which the
-            // stylesheet draws as a blank cell. Both readers already map
-            // xcresult's `Expected Failure` to `ParsedStatus.expectedFailure`
-            // (legacy and modern alike), so carrying it through to the
-            // renderer costs nothing and diverges neither backend.
-            self = .expectedFailure
-        case .unknown:
-            self = .unknown
-        }
-    }
-
-    /// The class the stylesheet draws a status glyph from.
-    ///
-    /// `.unknown` returns a name rather than the empty string it used to:
-    /// "no icon at all" and "an icon meaning we do not know" are different
-    /// statements, and only the second one is true. Note this is *not* the
-    /// same set the header counts use — `Run` buckets on the enum, and
-    /// expected failures deliberately land in no bucket.
-    var cssClass: String {
-        switch self {
-        case .failure:
-            return "failed"
-        case .success:
-            return "succeeded"
-        case .skipped:
-            return "skipped"
-        case .mixed:
-            return "mixed"
-        case .expectedFailure:
-            return "expected-failure"
-        case .unknown:
-            return "unknown"
-        }
-    }
-}
-
 /// What kind of node a row represents, and the CSS class the report's own
 /// stylesheet and JavaScript select on.
 ///
@@ -111,6 +54,13 @@ public struct TestGroup: Test {
     }
 
     var subTests: [Test] = []
+
+    /// A suite executes whatever its children did. An empty group is a leaf as
+    /// far as `Run.allTests` is concerned, and a leaf that ran once, so it
+    /// falls back to the protocol's default rather than summing to zero.
+    var executionCount: Int {
+        subTests.isEmpty ? 1 : subTests.reduce(0) { $0 + $1.executionCount }
+    }
 
     var descendantSubTests: [Test] {
         subTests.flatMap { subTest -> [Test] in
@@ -268,6 +218,18 @@ struct TestCase: Test {
 
     let iterations: [Iteration]
 
+    /// How many times the run executed this test (#439, A3b). Never below
+    /// `iterations.count`, since an iteration is an execution with a row.
+    let executionCount: Int
+
+    /// The executions the tree draws no row for. Non-zero on one shape any
+    /// fixture produces: an unrepeated parameterized `@Test(arguments:)`,
+    /// whose argument executions are one row on both backends. A repeated test
+    /// is excluded — its iterations are rows already.
+    var undrawnExecutions: Int {
+        iterations.count == 1 ? max(executionCount - 1, 0) : 0
+    }
+
     init(
         testCase: ParsedTestCase,
         identifierPath: IdentifierPath,
@@ -286,6 +248,8 @@ struct TestCase: Test {
         uuid = path.identifier
 
         Logger.substep("Initializing TestCase \(identifier)")
+
+        executionCount = max(testCase.executionCount, testCase.iterations.count)
 
         // The reader already merged repetitions into ordered iterations, so
         // each iteration's rendered position — and with it the
@@ -307,6 +271,32 @@ struct TestCase: Test {
 
 /// HTML conforming
 extension TestCase {
+    /// ` data-runs="3"`, or nothing. The whole attribute rather than its
+    /// value, so a row that ran once carries none — see
+    /// `HTMLTemplates.testCase`. Opaque by construction: an `Int`.
+    private var runsAttribute: String {
+        executionCount > 1 ? " data-runs=\"\(executionCount)\"" : ""
+    }
+
+    /// "3 arguments" beside the name — the option-A mockup's own tag for a
+    /// parameterized row, and what makes the toolbar's executions count
+    /// legible: without it a reader is told the run holds 23 executions of 21
+    /// tests with no way to see which rows account for the difference. Only
+    /// the *count* is stated, never the values, which only modern names.
+    ///
+    /// Rendered markup, and the element goes with it: an empty `<span>` on
+    /// every unparameterized row would be a tag per test to say nothing.
+    /// Nothing here needs escaping — a count and a fixed word.
+    private var executionNote: String {
+        let undrawn = undrawnExecutions
+        guard undrawn > 0 else {
+            return ""
+        }
+        let sets = undrawn + 1
+        return "\n            <span class=\"row-note row-arguments\">\(sets) argument"
+            + (sets == 1 ? "" : "s") + "</span>"
+    }
+
     var htmlPlaceholderValues: [String: String] {
         if iterations.count == 1 {
             let iteration = iterations[0]
@@ -316,6 +306,8 @@ extension TestCase {
                 "DURATION": duration.formattedSeconds,
                 "ICON_CLASS": status.cssClass,
                 "ITEM_CLASS": nodeKind.cssClass,
+                "RUNS_ATTR": runsAttribute,
+                "EXECUTION_NOTE": executionNote,
                 "SCREENSHOT_TAIL": iteration.testScreenshotFlow?.screenshotsTail
                     .accumulateHTMLAsString ?? "",
                 "SCREENSHOT_FLOW": iteration.testScreenshotFlow?.screenshots
@@ -329,6 +321,7 @@ extension TestCase {
                 "DURATION": duration.formattedSeconds,
                 "ICON_CLASS": status.cssClass,
                 "ITEM_CLASS": nodeKind.cssClass,
+                "RUNS_ATTR": runsAttribute,
                 "ITERATIONS": iterations.reduce("") { $0 + $1.html },
                 // Sorted because `Dictionary` iteration order is seeded per
                 // process: unsorted, "1 failed, 1 succeeded" renders as

--- a/Sources/XCTestHTMLReportCore/Classes/Protocols/TestConforming.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Protocols/TestConforming.swift
@@ -14,4 +14,19 @@ protocol Test: HTML, ContainingAttachment {
     var nodeKind: NodeKind { get }
     var status: Status { get }
     var duration: TimeInterval { get }
+    /// How many times the run executed what this node stands for (#439, A3b).
+    ///
+    /// One row is not one execution: a repeated test carries an iteration per
+    /// repetition, and a parameterized one carries a single row for several
+    /// argument sets. `Run.numberOfExecutions` sums this over the leaves to
+    /// state the second of Xcode's two numbers — 21 tests, 23 runs.
+    var executionCount: Int { get }
+}
+
+extension Test {
+    /// One, for every node that is exactly what it looks like. Only `TestCase`
+    /// can hold more, and only `TestGroup` has children to sum.
+    var executionCount: Int {
+        1
+    }
 }

--- a/Sources/XCTestHTMLReportCore/Classes/ResultReading/Legacy/LegacyResultReader.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/ResultReading/Legacy/LegacyResultReader.swift
@@ -87,6 +87,13 @@ struct LegacyResultReader: ResultReader {
                 identifier: identifier,
                 // Legacy has no counterpart to Swift Testing's Arguments nodes.
                 arguments: [],
+                // Counted here, before the merge below folds them: this is the
+                // one point at which legacy still knows a parameterized case
+                // ran three times. `mergingArgumentExecutions` exists to make
+                // the two backends agree on the *rows*, and it did that by
+                // discarding the number — which is why the report could state
+                // 21 tests and never 23 runs. See `ParsedTestCase.executionCount`.
+                executionCount: max(entries.count, 1),
                 iterations: Self.strippingLoneIterationNumber(
                     Self.mergingArgumentExecutions(iterations)
                 )

--- a/Sources/XCTestHTMLReportCore/Classes/ResultReading/Modern/ModernResultReader.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/ResultReading/Modern/ModernResultReader.swift
@@ -156,6 +156,7 @@ struct ModernResultReader: ResultReader {
     private func parseTestCase(_ node: TestNode) -> ParsedTestCase {
         let repetitions = (node.children ?? []).filter { $0.nodeType == "Repetition" }
         let identifier = node.nodeIdentifier ?? ""
+        let argumentSets = Self.arguments(of: node)
 
         let iterations: [ParsedIteration]
         if repetitions.isEmpty {
@@ -203,7 +204,14 @@ struct ModernResultReader: ResultReader {
                 ? (node.name ?? "")
                 : (identifier.components(separatedBy: "/").last ?? node.name ?? ""),
             identifier: identifier,
-            arguments: Self.arguments(of: node),
+            arguments: argumentSets,
+            // Repetitions are executions the format lists individually; an
+            // unrepeated parameterized case has one per argument set, in
+            // `Arguments` children the renderer collapses into a single row.
+            // Either way this is how many times the test ran — the number
+            // legacy recovers from its sibling entries. See
+            // `ParsedTestCase.executionCount`.
+            executionCount: max(repetitions.count, argumentSets.count, 1),
             iterations: iterations
         )
     }

--- a/Sources/XCTestHTMLReportCore/Classes/ResultReading/ParsedResult.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/ResultReading/ParsedResult.swift
@@ -178,14 +178,18 @@ public struct ParsedTestCase {
     ///
     /// So this converges the readers rather than reading something new: the
     /// fact was in both bundles and one of them was throwing it away.
-    /// `DifferentialTests.testExecutionCountsMatchAcrossBackends` is what holds
+    /// `DifferentialTests.testExecutionCountsAgreeAcrossBackends` is what holds
     /// them equal, and `1` is the floor — a test that ran once.
     ///
     /// A test that is *both* parameterized and repeated is not exercised by
-    /// any fixture, and the two readers derive it differently there (legacy
-    /// counts the product, modern the larger of the two); nothing in the
-    /// report depends on that shape today, and closing it needs a fixture
-    /// first.
+    /// any fixture, and what either reader derives for it is not knowable from
+    /// here: legacy's answer is however many sibling entries that format
+    /// happens to emit for the combination, and modern's turns on where the
+    /// `Repetition` nodes sit — `R` if they nest under `Arguments`, `max(R, A)`
+    /// if the two are siblings. Nothing in the report depends on that shape
+    /// today, and `testExecutionCountsAgreeAcrossBackends` is the gate that
+    /// would fail and name the identifier if a bundle ever carried one; closing
+    /// it needs that fixture first.
     public let executionCount: Int
     public let iterations: [ParsedIteration]
 }

--- a/Sources/XCTestHTMLReportCore/Classes/ResultReading/ParsedResult.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/ResultReading/ParsedResult.swift
@@ -159,6 +159,34 @@ public struct ParsedTestCase {
     /// the slot afterwards means reshaping the port and every reader with it.
     /// Not yet exercised by any fixture — see Task 8 of the migration plan.
     public let arguments: [String]
+    /// How many times the run actually executed this test (#439, A3b).
+    ///
+    /// Xcode's own toolbar states 21 tests and 23 *runs* on `TestResults`, and
+    /// the two differ for exactly one reason here: `parameterizedAddition`
+    /// executed once per argument set. `iterations` cannot carry that number —
+    /// both readers deliberately collapse argument executions into one row, so
+    /// a parameterized case has one iteration on either backend — and
+    /// `arguments` cannot either, because only the modern format names the
+    /// values.
+    ///
+    /// What *both* formats carry is the count, and this is where it lands:
+    ///
+    /// - legacy: the number of sibling metadata entries sharing the identifier,
+    ///   taken before `mergingArgumentExecutions` folds them;
+    /// - modern: the number of `Repetition` children, or of `Arguments`
+    ///   children when there are no repetitions.
+    ///
+    /// So this converges the readers rather than reading something new: the
+    /// fact was in both bundles and one of them was throwing it away.
+    /// `DifferentialTests.testExecutionCountsMatchAcrossBackends` is what holds
+    /// them equal, and `1` is the floor — a test that ran once.
+    ///
+    /// A test that is *both* parameterized and repeated is not exercised by
+    /// any fixture, and the two readers derive it differently there (legacy
+    /// counts the product, modern the larger of the two); nothing in the
+    /// report depends on that shape today, and closing it needs a fixture
+    /// first.
+    public let executionCount: Int
     public let iterations: [ParsedIteration]
 }
 

--- a/Sources/XCTestHTMLReportCore/Classes/ResultReading/ResultReader.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/ResultReading/ResultReader.swift
@@ -45,18 +45,10 @@ extension PayloadProviding {
         }
     }
 
-    func exportLogsContent(
-        reference: String,
-        renderingMode: Summary.RenderingMode,
-        fileName: String
-    ) -> RenderingContent {
-        switch renderingMode {
-        case .inline:
-            return exportLogsData(reference: reference)
-                .map(RenderingContent.data) ?? .none
-        case .linking:
-            return exportLogs(reference: reference, fileName: fileName)
-                .map(RenderingContent.url) ?? .none
-        }
-    }
+    // The log has no `exportLogsContent` counterpart to the above (#439, A3b).
+    // Both modes now need the log's *text* as well as its rendering content —
+    // the Logs view renders the log in the page rather than pointing an iframe
+    // at it — and one call returning only the content would leave inline mode
+    // exporting the same bytes twice. `Run.init` reads the data once and
+    // derives both.
 }

--- a/Tests/XCTestHTMLReportTests/CoreTests.swift
+++ b/Tests/XCTestHTMLReportTests/CoreTests.swift
@@ -34,85 +34,18 @@ final class CoreTests: XCTestCase {
                     .select("div.view-toolbar .filter-pills > button[role=radio]")
             )
             let texts = try elements.eachText()
-            XCTAssertEqual(texts.count, 5)
-            XCTAssertEqual(texts[0].intGroupMatch("All \\((\\d+)\\)"), 4)
-            XCTAssertEqual(texts[1].intGroupMatch("Passed \\((\\d+)\\)"), 1)
-            XCTAssertEqual(texts[2].intGroupMatch("Skipped \\((\\d+)\\)"), 0)
-            XCTAssertEqual(texts[3].intGroupMatch("Failed \\((\\d+)\\)"), 1)
-            XCTAssertEqual(texts[4].intGroupMatch("Mixed \\((\\d+)\\)"), 1)
+            // A3b renders the pills from the run's own tally, so the row holds
+            // one pill per outcome the run produced rather than a fixed five
+            // (#439, A3b). Two consequences here, both asserted as the whole
+            // list because a count alone would not catch either: `RetryResults`
+            // skips nothing, so the "Skipped (0)" this used to assert is not
+            // offered; and `RetryTests` records an expected failure, which had
+            // no pill at all before #460.
+            XCTAssertEqual(
+                texts,
+                ["All (4)", "Passed (1)", "Failed (1)", "Mixed (1)", "Expected failures (1)"]
+            )
         })
-    }
-
-    func testResultStatusCount() throws {
-        let testResultsUrl = try XCTUnwrap(testResultsUrl)
-        let summary = Summary(
-            resultPaths: [testResultsUrl.path],
-            renderingMode: .linking,
-            downsizeImagesEnabled: false,
-            downsizeScaleFactor: 0.5
-        )
-
-        let document = try SwiftSoup.parse(summary.html)
-
-        try XCTContext.runActivity(named: "Test header contain the right number of results") { _ in
-            let elements = try XCTUnwrap(
-                document
-                    .select("div.view-toolbar .filter-pills > button[role=radio]")
-            )
-            let texts = try elements.eachText()
-            XCTAssertEqual(texts.count, 5)
-
-            let all = try XCTUnwrap(texts[0].intGroupMatch("All \\((\\d+)\\)"))
-            let passed = try XCTUnwrap(texts[1].intGroupMatch("Passed \\((\\d+)\\)"))
-            let skipped = try XCTUnwrap(texts[2].intGroupMatch("Skipped \\((\\d+)\\)"))
-            let failed = try XCTUnwrap(texts[3].intGroupMatch("Failed \\((\\d+)\\)"))
-            let mixed = try XCTUnwrap(texts[4].intGroupMatch("Mixed \\((\\d+)\\)"))
-
-            // Fixtures are regenerated on every run, so assert only what the
-            // sample sources actually determine, not the pass/fail split.
-            //
-            // The original reason for that caution -- the suites launched the
-            // app in setUp with continueAfterFailure = false, so a slow
-            // simulator turned a would-be pass into a failure -- no longer
-            // applies: #423 removed those launches. The caution stands anyway,
-            // because a run still depends on the simulator behaving, and an
-            // exact split would measure that rather than this project.
-            //
-            // 21 = 16 XCTest methods + 5 Swift Testing `@Test` functions in
-            // SwiftTestingSuite (SampleAppUnitTests target). Beyond the
-            // original 13 XCTest methods: FirstSuite.testAttachScreenshot was
-            // added by #393 to give the image rendering path a fixture, and
-            // testExpectedFailure + testWithPngAttachment by #439 for the
-            // redesign's status-icon and attachment-type work. The 4th `@Test`
-            // is parameterizedAddition, added by the xcresulttool migration
-            // (Task 8) to exercise `Arguments` nodes — its three argument sets
-            // merge into one row, exactly like repetitions — and the 5th is
-            // knownIssue (#439), Swift Testing's expected-failure counterpart.
-            XCTAssertEqual(all, 21, "One row per test method; fixed by the sample sources")
-            XCTAssertEqual(
-                skipped,
-                1,
-                "SampleAppUnitTests.testSkipped is an unconditional XCTSkipIf"
-            )
-            XCTAssertEqual(mixed, 0, "TestResults excludes RetryTests, so nothing can be mixed")
-            XCTAssertEqual(
-                passed + failed,
-                all - skipped - 2,
-                "Every remaining test lands in exactly one bucket, except the " +
-                    "two `Expected Failure` cases (testExpectedFailure and " +
-                    "knownIssue). These are the per-run *filter pills*, which " +
-                    "#439's A1 did not touch: they still offer five buckets " +
-                    "and an expected failure matches none of them. The summary " +
-                    "header added by A1 does count them — see " +
-                    "`testSummaryHeaderAccountsForExpectedFailures` below — so " +
-                    "the two readings disagree until A3 rebuilds the filters"
-            )
-            XCTAssertGreaterThanOrEqual(
-                failed, 6,
-                "Six sample tests fail deliberately (including SwiftTestingSuite.intentionalFailure); " +
-                    "a lower count means failures are being lost"
-            )
-        }
     }
 
     /// The summary header's counts, on the real fixture rather than the

--- a/Tests/XCTestHTMLReportTests/DifferentialExecutionCountTests.swift
+++ b/Tests/XCTestHTMLReportTests/DifferentialExecutionCountTests.swift
@@ -1,0 +1,84 @@
+//
+//  DifferentialExecutionCountTests.swift
+//
+//  The cross-backend assertion for A3b's executions count (#439), in an
+//  extension for the reason `DifferentialSummaryHeaderTests` gives: that file
+//  is at its length limit and this shares its cached summaries.
+//
+//  This is the gate the port change was made against. `ParsedTestCase`
+//  gained `executionCount` because Xcode states two numbers — 21 tests and 23
+//  runs — and neither `iterations` nor `arguments` could carry the second:
+//  both readers deliberately collapse a parameterized case's argument
+//  executions into one iteration, and only the modern format names the
+//  argument values at all. The count itself *is* in both bundles — legacy has
+//  one sibling metadata entry per execution, modern one `Arguments` child —
+//  and one of them was throwing it away. So the readers converge here rather
+//  than one of them reading something new, and this is what holds them
+//  converged.
+//
+//  `testMaskedRendersAreIdenticalAcrossBackends` would also catch a divergence,
+//  since `data-runs` and the toolbar's figure are both rendered text. It would
+//  report it as one more differing line in a diff of two documents; this
+//  reports it as the identifier whose two counts disagree.
+//
+
+import XCTest
+@testable import XCTestHTMLReportCore
+
+extension DifferentialTests {
+    func testExecutionCountsAgreeAcrossBackends() throws {
+        try requireBothBackends()
+
+        // Non-vacuity, checked across all fixtures at the end: if every test in
+        // every bundle ran exactly once, the equalities below hold on any two
+        // readers — including one that dropped the field entirely — and this
+        // test would pass while proving nothing.
+        var fixturesWhereExecutionsExceedTests = 0
+
+        for fixture in Self.fixtures {
+            let legacy = try summary(fixture, .legacy)
+            let modern = try summary(fixture, .modern)
+
+            // Before zipping, which truncates to the shorter side.
+            XCTAssertEqual(
+                legacy.runs.count, modern.runs.count,
+                "\(fixture): backends disagree on the number of runs"
+            )
+
+            for (index, pair) in zip(legacy.runs, modern.runs).enumerated() {
+                let (legacyRun, modernRun) = pair
+
+                /// Per test, not just per run: two backends can reach the same
+                /// total from different rows, and a total-only assertion would
+                /// report the disagreement without naming what disagrees.
+                func counts(_ run: Run) -> [String: Int] {
+                    Dictionary(
+                        run.allTests.map { ($0.identifier, $0.executionCount) },
+                        uniquingKeysWith: { first, _ in first }
+                    )
+                }
+                XCTAssertEqual(
+                    counts(legacyRun), counts(modernRun),
+                    "\(fixture) run \(index): identifier→executions differs between backends"
+                )
+                XCTAssertEqual(
+                    legacyRun.numberOfExecutions, modernRun.numberOfExecutions,
+                    "\(fixture) run \(index): the toolbar's executions figure differs"
+                )
+                if legacyRun.numberOfExecutions > legacyRun.numberOfTests {
+                    fixturesWhereExecutionsExceedTests += 1
+                }
+            }
+        }
+
+        XCTAssertGreaterThan(
+            fixturesWhereExecutionsExceedTests, 0,
+            "no fixture ran a test more than once, so nothing above "
+                + "distinguishes a converged reader from one that returns 1 "
+                + "for everything. TestResults holds a parameterized @Test and "
+                + "RetryResults is generated with -test-iterations 2; if "
+                + "neither still does, this suite has stopped covering the "
+                + "field it exists for"
+        )
+    }
+}

--- a/Tests/XCTestHTMLReportTests/FilterCountTests.swift
+++ b/Tests/XCTestHTMLReportTests/FilterCountTests.swift
@@ -1,0 +1,185 @@
+//
+//  FilterCountTests.swift
+//
+//  The toolbar's two numbers on the *generated* fixtures (#439, A3b; #460).
+//
+//  `FilterToolbarTests` pins the same claims against the synthetic tree, whose
+//  inputs are constants; these pin them against bundles a simulator produced,
+//  where the counts come from the sample sources and — for `RetryResults` — from
+//  how many repetitions the run happened to need.
+//
+//  An extension on `CoreTests` rather than a suite of its own, in the shape
+//  `DifferentialSummaryHeaderTests` already uses: `testResultStatusCount` moved
+//  here whole because A3b's additions put `CoreTests.swift` over its length
+//  limit, and it shares that file's fixture accessors.
+//
+
+import SwiftSoup
+import XCTest
+@testable import XCTestHTMLReportCore
+
+extension CoreTests {
+    /// Every pill's count, keyed by its label.
+    ///
+    /// Read by label rather than by position: A3b renders the row from the
+    /// run's tally, so it holds one pill per outcome the run produced — no
+    /// "Mixed (0)" on a bundle that excludes the retry suite, and an "Expected
+    /// failures" pill that exists only because this fixture has two (#460). A
+    /// bucket with no pill reads as 0, which is what it means.
+    private func pillCounts(in document: Document) throws -> [String: Int] {
+        let pills = try document
+            .select("div.view-toolbar .filter-pills > button[role=radio]")
+            .eachText()
+        return pills.reduce(into: [:]) { counts, text in
+            guard let label = text.groupMatch("^(.+) \\(\\d+\\)$"),
+                  let value = text.intGroupMatch("\\((\\d+)\\)$")
+            else {
+                return
+            }
+            counts[label] = value
+        }
+    }
+
+    func testResultStatusCount() throws {
+        let testResultsUrl = try XCTUnwrap(testResultsUrl)
+        let summary = Summary(
+            resultPaths: [testResultsUrl.path],
+            renderingMode: .linking,
+            downsizeImagesEnabled: false,
+            downsizeScaleFactor: 0.5
+        )
+
+        let document = try SwiftSoup.parse(summary.html)
+
+        try XCTContext.runActivity(named: "Test header contain the right number of results") { _ in
+            let counts = try pillCounts(in: document)
+            let (all, passed) = (counts["All"] ?? 0, counts["Passed"] ?? 0)
+            let (skipped, failed) = (counts["Skipped"] ?? 0, counts["Failed"] ?? 0)
+            let (mixed, expected) = (counts["Mixed"] ?? 0, counts["Expected failures"] ?? 0)
+
+            // Fixtures are regenerated on every run, so assert only what the
+            // sample sources actually determine, not the pass/fail split.
+            //
+            // The original reason for that caution -- the suites launched the
+            // app in setUp with continueAfterFailure = false, so a slow
+            // simulator turned a would-be pass into a failure -- no longer
+            // applies: #423 removed those launches. The caution stands anyway,
+            // because a run still depends on the simulator behaving, and an
+            // exact split would measure that rather than this project.
+            //
+            // 21 = 16 XCTest methods + 5 Swift Testing `@Test` functions in
+            // SwiftTestingSuite (SampleAppUnitTests target). Beyond the
+            // original 13 XCTest methods: FirstSuite.testAttachScreenshot was
+            // added by #393 to give the image rendering path a fixture, and
+            // testExpectedFailure + testWithPngAttachment by #439 for the
+            // redesign's status-icon and attachment-type work. The 4th `@Test`
+            // is parameterizedAddition, added by the xcresulttool migration
+            // (Task 8) to exercise `Arguments` nodes — its three argument sets
+            // merge into one row, exactly like repetitions — and the 5th is
+            // knownIssue (#439), Swift Testing's expected-failure counterpart.
+            XCTAssertEqual(all, 21, "One row per test method; fixed by the sample sources")
+            XCTAssertEqual(
+                skipped,
+                1,
+                "SampleAppUnitTests.testSkipped is an unconditional XCTSkipIf"
+            )
+            XCTAssertEqual(mixed, 0, "TestResults excludes RetryTests, so nothing can be mixed")
+            XCTAssertEqual(
+                expected, 2,
+                "testExpectedFailure and knownIssue, the sample sources' two " +
+                    "deliberate expected failures — one from each test " +
+                    "framework. #460: before A3b they were in no pill at all, " +
+                    "neither shown by \"All\" nor hidden by \"Passed\""
+            )
+            XCTAssertEqual(
+                passed + failed + skipped + mixed + expected,
+                all,
+                "Every test lands in exactly one bucket. The pills and the " +
+                    "summary header's legend are now two readings of one " +
+                    "tally — see `testSummaryHeaderAccountsForExpectedFailures` " +
+                    "below, which asserts the same partition on the legend. " +
+                    "Until A3b they disagreed: the header counted six buckets " +
+                    "and the toolbar offered five, none of which an expected " +
+                    "failure matched"
+            )
+            XCTAssertGreaterThanOrEqual(
+                failed, 6,
+                "Six sample tests fail deliberately (including SwiftTestingSuite.intentionalFailure); " +
+                    "a lower count means failures are being lost"
+            )
+        }
+    }
+
+    /// Xcode's second number, on the fixture Xcode itself was measured on:
+    /// `TestResults.xcresult` reads "All Tests (21)" and "All Runs (23)" in
+    /// Xcode 26's viewer, and the two differ for exactly one reason —
+    /// `parameterizedAddition(value:)` ran once per argument set.
+    ///
+    /// Pinned exactly rather than as an inequality, because both halves are
+    /// fixed by the sample sources: 21 test methods, one of them parameterized
+    /// over three values. It is also the assertion that would catch the legacy
+    /// backend quietly losing the count again — it is the reader that has to
+    /// recover it from sibling metadata entries, and `DifferentialTests`
+    /// proves the two agree but not what they agree *on*.
+    func testTheToolbarStatesXcodesRunCount() throws {
+        let testResultsUrl = try XCTUnwrap(testResultsUrl)
+        let summary = Summary(
+            resultPaths: [testResultsUrl.path],
+            renderingMode: .linking,
+            downsizeImagesEnabled: false,
+            downsizeScaleFactor: 0.5
+        )
+        let document = try SwiftSoup.parse(summary.html)
+
+        XCTAssertEqual(
+            try document.select("#view-tests .view-toolbar-count").text(),
+            "23 executions",
+            "21 tests, 23 executions — the three argument sets of "
+                + "parameterizedAddition are two executions the tree draws no row for"
+        )
+        XCTAssertEqual(
+            try document.select("#view-tests .test-summary[data-runs]").attr("data-runs"),
+            "3",
+            "and the row that accounts for them says so"
+        )
+        XCTAssertEqual(
+            try document.select("#view-tests .row-arguments").text(),
+            "3 arguments"
+        )
+    }
+
+    /// The other half of the distinction, from the other direction: a run that
+    /// repeated its tests holds more executions than rows.
+    ///
+    /// An inequality rather than an exact figure, because
+    /// `-retry-tests-on-failure` stops repeating once a test passes — how many
+    /// iterations a generation records depends on the simulator.
+    func testARepeatedRunHoldsMoreExecutionsThanTests() throws {
+        // Looked up here rather than through `CoreTests.getRetryResultsUrl`,
+        // which lives in that file's `private extension`.
+        guard let retryResultsUrl = Bundle.testBundle.url(
+            forResource: "RetryResults", withExtension: "xcresult"
+        ) else {
+            throw XCTSkip("RetryResults.xcresult not found; Xcode < 13.0")
+        }
+        let summary = Summary(
+            resultPaths: [retryResultsUrl.path],
+            renderingMode: .linking,
+            downsizeImagesEnabled: false,
+            downsizeScaleFactor: 0.5
+        )
+        let document = try SwiftSoup.parse(summary.html)
+        let run = try XCTUnwrap(summary.runs.first)
+
+        XCTAssertGreaterThan(
+            run.numberOfExecutions, run.numberOfTests,
+            "RetryResults is generated with -test-iterations 2, so it must "
+                + "hold more executions than rows"
+        )
+        XCTAssertEqual(
+            try document.select("#view-tests .view-toolbar-count").text(),
+            Run.executionsLabel(run.numberOfExecutions),
+            "the rendered figure and the model must be the same number"
+        )
+    }
+}

--- a/Tests/XCTestHTMLReportTests/FilterToolbarTests.swift
+++ b/Tests/XCTestHTMLReportTests/FilterToolbarTests.swift
@@ -1,0 +1,317 @@
+//
+//  FilterToolbarTests.swift
+//
+//  The per-view toolbars A3b fills (#439, A3b; #460), asserted on the rendered
+//  page over the synthetic fixture — whose inputs are constants, so the counts
+//  below are determined by the fixture rather than by whatever the simulator
+//  did this morning.
+//
+//  Three claims, one per feature:
+//
+//  - the status pills are the summary header's buckets made operable, which is
+//    the whole of the #460 decision: expected failures already had a bucket in
+//    A1's tally, and the filter row was the last reading of a run that still
+//    had them in no bucket at all;
+//  - the toolbar states executions as well as tests, from data both backends
+//    carry;
+//  - each view carries a real filter field where A3a reserved the slot — and
+//    the Logs view carries its log, rather than an iframe pointed at another
+//    origin that nothing in the page could filter.
+//
+
+import SwiftSoup
+import XCTest
+@testable import XCTestHTMLReportCore
+
+final class FilterToolbarTests: XCTestCase {
+    private func summary(_ run: ParsedRun = SyntheticResult.parsedRun) -> Summary {
+        Summary(
+            parsedRuns: [run],
+            payloads: SyntheticResult.payloads,
+            renderingMode: .linking,
+            downsizeImagesEnabled: false,
+            downsizeScaleFactor: 0.5,
+            bundleNames: ["Synthetic"]
+        )
+    }
+
+    private func document(_ run: ParsedRun = SyntheticResult.parsedRun) throws -> Document {
+        try SwiftSoup.parse(summary(run).generatedHtmlReport())
+    }
+
+    private func pills(_ page: Document) throws -> [Element] {
+        try page.select("div.view-toolbar .filter-pills > button[role=radio]").array()
+    }
+
+    // MARK: - #460: the expected-failure bucket
+
+    /// The pills and the legend are two readings of one `Tally`, so they name
+    /// the same buckets in the same order and neither can grow a bucket the
+    /// other lacks.
+    ///
+    /// This is the assertion #460 asked for. Before it, the row offered a
+    /// fixed five — All, Passed, Skipped, Failed, Mixed — and an expected
+    /// failure matched none of them: "Passed" left it on screen and "All"
+    /// could not put it back, because "All" only ever set `display` on the
+    /// four classes those five functions knew about.
+    func testTheFilterRowOffersTheSameBucketsAsTheHeaderLegend() throws {
+        let page = try document()
+        let legend = try page.select("ul.summary-legend li").array()
+            .map { try $0.select(".legend-count").text() }
+        let legendLabels = try page.select("ul.summary-legend li").array()
+            .map { try $0.ownText().trimmingCharacters(in: .whitespaces) }
+
+        let rendered = try pills(page).map { try $0.text() }
+        XCTAssertEqual(
+            rendered.first, "All (6)",
+            "the row leads with the whole run, which is the only pill the "
+                + "legend has no counterpart for"
+        )
+        XCTAssertEqual(
+            Array(rendered.dropFirst()),
+            zip(legendLabels, legend).map { "\($0) (\($1))" },
+            "every other pill is a legend bucket: same label, same count, same "
+                + "order, because both are rendered from the run's Tally"
+        )
+        XCTAssertTrue(
+            rendered.contains("Expected failures (1)"),
+            "#460: the status the model has carried since #443 must have a "
+                + "filter of its own"
+        )
+    }
+
+    /// A pill selects rows by the class the renderer writes, so the mapping is
+    /// `Status.cssClass` in both directions and there is no second list of
+    /// class names in the page's JavaScript to fall out of step with it.
+    func testEachPillNamesTheRowClassItSelects() throws {
+        let page = try document()
+        let filters = try pills(page).map { try $0.attr("data-filter") }
+        XCTAssertEqual(
+            filters,
+            ["all", "succeeded", "failed", "skipped", "mixed", "expected-failure"],
+            "the pills carry row classes, and `all` for the whole run"
+        )
+
+        for filter in filters.dropFirst() {
+            XCTAssertFalse(
+                try page.select("#view-tests .\(filter)").isEmpty(),
+                "the pill for '\(filter)' selects nothing in this fixture, so "
+                    + "it would filter the tree to an empty pane"
+            )
+        }
+    }
+
+    /// The counts must partition the run: the pills either add up to "All" or
+    /// one of them is quietly counting a test twice, or not at all — which is
+    /// exactly the state #460 describes, where the header counted six buckets
+    /// and the toolbar filtered four.
+    func testThePillCountsAddUpToTheWholeRun() throws {
+        let counted = try pills(document()).dropFirst().reduce(0) { total, pill in
+            try total + (Int(pill.text().groupMatch("\\((\\d+)\\)$") ?? "") ?? 0)
+        }
+        XCTAssertEqual(counted, 6, "every test lands in exactly one pill")
+    }
+
+    /// An empty bucket is dropped, by the rule the legend already follows: a
+    /// permanent "Mixed (0)" in a report that never retried a test is noise,
+    /// and — the part that matters for #460 — a status gets a pill *because*
+    /// the run produced it, so a status nobody anticipated cannot end up
+    /// unfilterable again.
+    func testAnEmptyBucketGetsNoPill() throws {
+        let passing = ParsedRun(
+            destination: SyntheticResult.parsedRun.destination,
+            logReference: SyntheticResult.logReference,
+            testables: [ParsedTestable(
+                targetName: "SyntheticTests",
+                groups: [ParsedGroup(
+                    name: "SyntheticSuite",
+                    identifier: "SyntheticSuite",
+                    duration: 1,
+                    children: [.testCase(SyntheticResult.testCase(
+                        name: "testPasses()",
+                        iterations: [SyntheticResult.iteration(
+                            number: nil, status: .passed, activities: []
+                        )]
+                    ))]
+                )]
+            )]
+        )
+        XCTAssertEqual(
+            try pills(document(passing)).map { try $0.text() },
+            ["All (1)", "Passed (1)"],
+            "a run that only passed offers the two pills it can act on"
+        )
+    }
+
+    // MARK: - Tests and runs
+
+    /// Xcode's two numbers, on a fixture where they differ: six tests, nine
+    /// executions — four cases ran once, the retried one twice and the
+    /// parameterized one three times.
+    func testTheToolbarStatesExecutionsAsWellAsTests() throws {
+        let page = try document()
+        XCTAssertEqual(
+            try page.select("#view-tests .view-toolbar-count").text(),
+            "9 executions",
+            "one row is not one execution: repetitions and argument sets are "
+                + "both executions the tree does not draw a row for"
+        )
+        XCTAssertEqual(
+            summary().runs.first?.numberOfExecutions, 9,
+            "the rendered figure and the model must be the same number"
+        )
+        XCTAssertEqual(
+            summary().runs.first?.numberOfTests, 6,
+            "and it must not have moved the test count with it"
+        )
+    }
+
+    /// The executions a row accounts for, written onto the row so the page can
+    /// re-derive the toolbar's figure from whichever rows a filter left
+    /// showing. Absent when it is 1, which is most rows.
+    func testOnlyRowsWithSeveralExecutionsCarryTheCount() throws {
+        let page = try document()
+        let carrying = try page.select("#view-tests .test-summary[data-runs]").array()
+        XCTAssertEqual(
+            try carrying.map { try (
+                $0.select(".row-name").first()?.text() ?? "",
+                $0.attr("data-runs")
+            ) }
+            .sorted { $0.0 < $1.0 }
+            .map { "\($0.0)=\($0.1)" },
+            ["testParameterized()=3", "testRetries()=2"],
+            "the parameterized case ran three times and the retried one twice; "
+                + "every other row ran once and carries no attribute"
+        )
+    }
+
+    /// The mockup's own treatment of a parameterized row, and the thing that
+    /// makes the toolbar's second number legible: without it a reader is told
+    /// the run holds nine executions of six tests with no way to see which
+    /// rows account for the difference.
+    ///
+    /// A retried test deliberately gets no tag — its iterations are rows
+    /// already, and "2 arguments" beside two iteration rows would be a second,
+    /// wrong reading of the same fact.
+    func testAParameterizedRowSaysHowManyArgumentSetsItRan() throws {
+        let page = try document()
+        let notes = try page.select("#view-tests .row-arguments").array()
+        XCTAssertEqual(
+            try notes.map { try $0.text() },
+            ["3 arguments"],
+            "exactly the parameterized row carries the tag"
+        )
+        XCTAssertEqual(
+            try page.select("#view-tests .row-note").array().map { try $0.text() },
+            ["3 arguments", "1 failed, 1 succeeded"],
+            "it wears the same chip as a retried row's outcome breakdown, and "
+                + "a class of its own so the two are distinguishable"
+        )
+        let row = try XCTUnwrap(notes.first?.parent()?.select(".row-name").first())
+        XCTAssertEqual(try row.text(), "testParameterized()")
+    }
+
+    // MARK: - The filter fields
+
+    /// One control shape in both views, in the trailing slot A3a laid out for
+    /// it, which is also where Xcode's test report puts its Filter field.
+    func testBothViewsCarryANamedFilterField() throws {
+        let page = try document()
+        for (view, label) in [
+            ("#view-tests", "Filter tests by name"),
+            ("#view-logs", "Filter log lines"),
+        ] {
+            let field = try XCTUnwrap(
+                page.select("\(view) .view-toolbar-trailing input.view-filter").first(),
+                "\(view) must carry a filter field in the reserved slot"
+            )
+            XCTAssertEqual(try field.attr("type"), "search")
+            XCTAssertEqual(
+                try field.attr("aria-label"), label,
+                "a placeholder is not an accessible name"
+            )
+        }
+    }
+
+    /// The log is in the document (#439, A3b).
+    ///
+    /// Behind the `<iframe src>` this replaces, the log was a `file://`
+    /// sibling or a `data:` URI — a foreign origin either way — so nothing in
+    /// the page could filter it, and it could not see the token layer, which
+    /// is why the Logs view rendered as a white slab in dark mode. The inert
+    /// "All Messages" label A3a left in this slot was the symptom.
+    func testTheLogIsRenderedInThePageRatherThanBehindAnIframe() throws {
+        let page = try document()
+        XCTAssertTrue(
+            try page.select("#view-logs iframe").isEmpty(),
+            "a log on another origin cannot be filtered, scrolled or themed by "
+                + "anything in this page"
+        )
+        XCTAssertTrue(
+            try page.select(".view-toolbar-label").isEmpty(),
+            "the inert 'All Messages' label is gone, not restyled"
+        )
+
+        let body = try XCTUnwrap(page.select("#view-logs pre.log-body").first())
+        XCTAssertEqual(
+            try body.text(trimAndNormaliseWhitespace: false),
+            "Synthetic run log line one\nSynthetic run log line two\n",
+            "the log's own text, from the same bytes the .log export carries, "
+                + "with its line breaks intact"
+        )
+        XCTAssertEqual(
+            try body.attr("tabindex"), "0",
+            "a region a mouse can scroll must be reachable by a keyboard "
+                + "(axe: scrollable-region-focusable)"
+        )
+        XCTAssertEqual(
+            try page.select("#view-logs .view-toolbar-count").text(), "2 lines",
+            "the toolbar states what the field acts on"
+        )
+    }
+
+    /// The exported `.log` file is unchanged, which is what keeps #480's fix
+    /// and `DifferentialLogTests` meaning what they meant: A3b changes where
+    /// the log is *rendered*, not what is written.
+    func testTheLogExportIsUnchanged() throws {
+        let run = try XCTUnwrap(summary().runs.first)
+        guard case let .url(url) = run.logContent else {
+            return XCTFail("linking mode must still export the log to a file")
+        }
+        XCTAssertTrue(url.lastPathComponent.hasSuffix(".log"))
+        XCTAssertEqual(
+            run.logText,
+            String(data: StubPayloadProvider.logText, encoding: .utf8),
+            "and the text the page renders is those same bytes"
+        )
+    }
+
+    /// A log with no trailing newline and one with a trailing newline hold the
+    /// same number of lines, because the trailing one *ends* the last line.
+    /// The script re-derives this count when the field is used, so a
+    /// disagreement here would make the toolbar state a number the reader
+    /// cannot find.
+    func testTheLineCountAgreesWithWhatThePreShows() {
+        func run(log: String) -> Run? {
+            let parsed = ParsedRun(
+                destination: SyntheticResult.parsedRun.destination,
+                logReference: "log",
+                testables: SyntheticResult.parsedRun.testables
+            )
+            return Summary(
+                parsedRuns: [parsed],
+                payloads: StubPayloadProvider(exports: ["log": Data(log.utf8)]),
+                renderingMode: .inline,
+                downsizeImagesEnabled: false,
+                downsizeScaleFactor: 0.5,
+                bundleNames: ["Synthetic"]
+            ).runs.first
+        }
+        XCTAssertEqual(run(log: "")?.logLineCount, 0)
+        XCTAssertEqual(run(log: "one")?.logLineCount, 1)
+        XCTAssertEqual(run(log: "one\n")?.logLineCount, 1)
+        XCTAssertEqual(run(log: "one\ntwo")?.logLineCount, 2)
+        XCTAssertEqual(run(log: "one\ntwo\n")?.logLineCount, 2)
+        XCTAssertEqual(run(log: "one\n\nthree\n")?.logLineCount, 3)
+    }
+}

--- a/Tests/XCTestHTMLReportTests/HTMLEscapingTests.swift
+++ b/Tests/XCTestHTMLReportTests/HTMLEscapingTests.swift
@@ -269,6 +269,7 @@ final class HTMLEscapingTests: XCTestCase {
                 name: "testHostile\(hostile)()",
                 identifier: "Suite\(hostile)/testHostile\(hostile)()",
                 arguments: [],
+                executionCount: 1,
                 iterations: [SyntheticResult.iteration(
                     number: nil,
                     status: .failed,

--- a/Tests/XCTestHTMLReportTests/PlaceholderOrderTests.swift
+++ b/Tests/XCTestHTMLReportTests/PlaceholderOrderTests.swift
@@ -102,6 +102,76 @@ final class PlaceholderOrderTests: XCTestCase {
         )
     }
 
+    /// The per-view templates are *closed*, not merely ordered (#439, A3b).
+    ///
+    /// `Run` fills two templates from two lists rather than one dictionary, and
+    /// each list holds only what its own template needs — so the one value in
+    /// each that a test author controls goes in last, with nothing after it to
+    /// fill. That is stronger than ordering: a test named after the log's
+    /// placeholder is not merely filled late, it is unfillable, because the
+    /// Tests list has no such entry at all.
+    ///
+    /// Both directions, because the hazard is symmetric and a dictionary in
+    /// hash order could have substituted either value into the other.
+    func testATestNamedAfterTheLogsPlaceholderIsNotFilledByIt() {
+        let html = report(
+            testName: "test[[LOG_TEXT]]()",
+            log: "a line belonging to the log alone"
+        )
+
+        try? XCTAssertContains(html, "test[[LOG_TEXT]]()")
+        XCTAssertEqual(
+            occurrences(of: "a line belonging to the log alone", in: html), 1,
+            "the log belongs to the Logs view and nowhere else — a test that "
+                + "spells its placeholder must not pull it into the tree"
+        )
+    }
+
+    func testALogLineNamedAfterTheTreesPlaceholderIsNotFilledByIt() {
+        let html = report(
+            testName: "testOrdinary()",
+            log: "a log line reading [[TEST_SUMMARIES]]"
+        )
+
+        try? XCTAssertContains(html, "a log line reading [[TEST_SUMMARIES]]")
+        XCTAssertEqual(
+            occurrences(of: "testOrdinary()", in: html), 1,
+            "and the tree must not be pulled into the log by a line that "
+                + "spells its placeholder"
+        )
+    }
+
+    /// A run holding one named test and one crafted log.
+    private func report(testName: String, log: String) -> String {
+        let logReference = "crafted-log"
+        let run = ParsedRun(
+            destination: SyntheticResult.parsedRun.destination,
+            logReference: logReference,
+            testables: [ParsedTestable(
+                targetName: "SyntheticTests",
+                groups: [ParsedGroup(
+                    name: "SyntheticSuite",
+                    identifier: "SyntheticSuite",
+                    duration: 1,
+                    children: [.testCase(SyntheticResult.testCase(
+                        name: testName,
+                        iterations: [SyntheticResult.iteration(
+                            number: nil, status: .passed, activities: []
+                        )]
+                    ))]
+                )]
+            )]
+        )
+        return Summary(
+            parsedRuns: [run],
+            payloads: StubPayloadProvider(exports: [logReference: Data(log.utf8)]),
+            renderingMode: .linking,
+            downsizeImagesEnabled: false,
+            downsizeScaleFactor: 0.5,
+            bundleNames: ["Synthetic"]
+        ).generatedHtmlReport()
+    }
+
     private func occurrences(of needle: String, in haystack: String) -> Int {
         haystack.components(separatedBy: needle).count - 1
     }

--- a/Tests/XCTestHTMLReportTests/RunSummaryTests.swift
+++ b/Tests/XCTestHTMLReportTests/RunSummaryTests.swift
@@ -29,15 +29,16 @@ final class RunSummaryTests: XCTestCase {
     /// The six statuses partition the tests, so the ring is a whole circle
     /// rather than a circle with a gap in it.
     ///
-    /// The fixture puts exactly one test in each of five buckets, which is
-    /// also what makes the legend below assertable: any bucket that stopped
-    /// being counted would drop a row rather than change a number.
+    /// The fixture puts a test in each of five buckets — two in `passed`
+    /// since A3b added a parameterized case — which is also what makes the
+    /// legend below assertable: any bucket that stopped being counted would
+    /// drop a row rather than change a number.
     func testLegendCountsEveryStatusTheFixtureProduces() throws {
         let rows = try document().select("ul.summary-legend li").array()
         XCTAssertEqual(
             try rows.map { try $0.text() },
             [
-                "Passed 1",
+                "Passed 2",
                 "Failed 1",
                 "Skipped 1",
                 "Mixed 1",
@@ -47,7 +48,7 @@ final class RunSummaryTests: XCTestCase {
         )
 
         let total = try document().select(".donut-center strong").text()
-        XCTAssertEqual(total, "5", "the ring's centre states the run's test count")
+        XCTAssertEqual(total, "6", "the ring's centre states the run's test count")
     }
 
     /// The bucket `Status` folds nowhere else: before #439 an expected failure
@@ -68,8 +69,13 @@ final class RunSummaryTests: XCTestCase {
 
     /// The header's duration is the sum of the *leaf* tests, never of the
     /// groups. The fixture makes the two answers different on purpose: its
-    /// group declares 6s while its five test cases add up to 9s (four at 1.5s
-    /// plus a retried one with two 1.5s iterations).
+    /// group declares 6s while its six test cases add up to 10.5s (five at
+    /// 1.5s plus a retried one with two 1.5s iterations).
+    ///
+    /// The parameterized case contributes 1.5s and not 4.5s, deliberately: it
+    /// is one iteration however many argument sets produced it, and both
+    /// readers collapse it that way. Its three executions are a count, not a
+    /// duration.
     ///
     /// This is the assertion that keeps the cross-backend differential green
     /// without an allow-list entry. `durationInSeconds` is null on every suite
@@ -78,7 +84,7 @@ final class RunSummaryTests: XCTestCase {
     /// and 0s on the other.
     func testDurationSumsLeafTestsAndNotGroups() throws {
         let meta = try document().select("#run-summary-heading .summary-meta").text()
-        XCTAssertEqual(meta, "Duration (9.00s) · 1 device")
+        XCTAssertEqual(meta, "Duration (10.50s) · 1 device")
 
         let group = SyntheticResult.parsedRun.testables[0].groups[0]
         XCTAssertEqual(group.duration, 6, "the fixture's group must disagree with its leaves")
@@ -97,11 +103,11 @@ final class RunSummaryTests: XCTestCase {
     /// moment that happens.
     func testTheHeadersDurationIsWrittenInAMaskedShape() throws {
         let rendered = summary().generatedHtmlReport()
-        try XCTAssertContains(rendered, "<span class=\"summary-duration\">(9.00s)</span>")
+        try XCTAssertContains(rendered, "<span class=\"summary-duration\">(10.50s)</span>")
 
         let masked = KnownLossMasker.mask(rendered, rules: ["durations"])
         XCTAssertFalse(
-            masked.contains("(9.00s)"),
+            masked.contains("(10.50s)"),
             "the durations rule must normalise the header's total, as it does "
                 + "every duration in the tree"
         )
@@ -238,7 +244,7 @@ final class RunSummaryTests: XCTestCase {
         )
         XCTAssertEqual(
             try XCTUnwrap(options.first).select(".device-row-tally").text(),
-            "1 passed, 1 failed, 1 skipped, 1 mixed, 1 expected failure",
+            "2 passed, 1 failed, 1 skipped, 1 mixed, 1 expected failure",
             "the bar is aria-hidden, so this caption is the only accessible "
                 + "reading of the proportions it draws"
         )

--- a/Tests/XCTestHTMLReportTests/SanityTests.swift
+++ b/Tests/XCTestHTMLReportTests/SanityTests.swift
@@ -25,12 +25,23 @@ final class SanityTests: XCTestCase {
                     .select("div.view-toolbar .filter-pills > button[role=radio]")
             )
             let texts = try elements.eachText()
-            XCTAssertEqual(texts.count, 5)
-            XCTAssertEqual(texts[0].intGroupMatch("All \\((\\d+)\\)"), 1)
-            XCTAssertEqual(texts[1].intGroupMatch("Passed \\((\\d+)\\)"), 1)
-            XCTAssertEqual(texts[2].intGroupMatch("Skipped \\((\\d+)\\)"), 0)
-            XCTAssertEqual(texts[3].intGroupMatch("Failed \\((\\d+)\\)"), 0)
-            XCTAssertEqual(texts[4].intGroupMatch("Mixed \\((\\d+)\\)"), 0)
+            // One passing test, so one outcome and one pill beside "All"
+            // (#439, A3b): the row is rendered from the run's tally now, and a
+            // bucket the run never filled offers no filter — the rule the
+            // summary legend already followed. Three pills reading "(0)" were
+            // three controls that could only ever empty the pane.
+            XCTAssertEqual(texts, ["All (1)", "Passed (1)"])
+        }
+
+        // A single passing test executed once, which is the case the two
+        // numbers agree on — and the one that proves the executions figure is
+        // not simply the test count with a different word on it, since
+        // `CoreTests` holds the disagreeing case.
+        try XCTContext.runActivity(named: "States the executions it ran") { _ in
+            XCTAssertEqual(
+                try document.select("#view-tests .view-toolbar-count").text(),
+                "1 execution"
+            )
         }
     }
 }

--- a/Tests/XCTestHTMLReportTests/Snapshots/index-inline.html
+++ b/Tests/XCTestHTMLReportTests/Snapshots/index-inline.html
@@ -3098,14 +3098,20 @@ Synthetic run log line two
     for (var i = 0; i < rows.length; i++) {
       var shown = rowMatches(rows[i], status, query);
       rows[i].style.display = shown ? 'block' : 'none';
-      // A test's tail screenshot is emitted *between* rows rather than
-      // inside one (A2), so it is a sibling the row's own `display` does not
-      // reach. Left behind, a filtered-out test leaves its screenshot in the
-      // tree with no row to belong to — a 200px picture of a test the reader
-      // asked not to see.
+      // A test's tail screenshots are emitted *between* rows rather than
+      // inside one (A2), so they are siblings the row's own `display` does
+      // not reach. Left behind, a filtered-out test leaves its screenshots in
+      // the tree with no row to belong to — 200px pictures of a test the
+      // reader asked not to see.
+      //
+      // A loop, not one sibling: `TestScreenshotFlow` emits the *last three*
+      // screenshots of a test (`suffix(tailCount)`), so a test with several
+      // is preceded by several. The synthetic fixture has such a row, which
+      // is why the gate on this counts every tail rather than the first.
       var tail = rows[i].previousElementSibling;
-      if (tail && tail.classList.contains('screenshot-tail')) {
+      while (tail && tail.classList.contains('screenshot-tail')) {
         tail.style.display = shown ? 'block' : 'none';
+        tail = tail.previousElementSibling;
       }
       if (shown) {
         executions += executionsOf(rows[i]);

--- a/Tests/XCTestHTMLReportTests/Snapshots/index-inline.html
+++ b/Tests/XCTestHTMLReportTests/Snapshots/index-inline.html
@@ -626,9 +626,8 @@
   }
 
   /* The per-view toolbar. Left group is the view's own controls; the
-     trailing group is deliberately empty and deliberately present — it is
-     where A3b's text filter and its dropdowns land (#460), and reserving it
-     here is what keeps that from being a re-layout. */
+     trailing group holds the Filter field, which is where A3a reserved the
+     slot for it and where Xcode's own test report puts one. */
   .view-toolbar {
     display: flex;
     flex-wrap: wrap;
@@ -648,23 +647,63 @@
     gap: var(--space-xs);
   }
 
-  /* A label, not a control. The Logs view has one scope and no way to change
-     it, and the shipped markup said otherwise: `<li class="selected">All
-     Messages</li>` in a `toggle-toolbar`, wearing a selected pill's fill and
-     hover with nothing bound to it. Dressing an inert string as the chosen
-     one of several options is the kind of thing a keyboard user finds out
-     the hard way. Real log filters are #460's, and land in the trailing slot
-     beside this. */
-  .view-toolbar-label {
+  /* A count, and a live one (#439, A3b).
+
+     This is the slot A3a's inert "All Messages" label occupied. That label
+     was a placeholder for a control the Logs view could not have — nothing
+     in the page can filter a document on another origin — and the honest
+     replacement is not a better-dressed label but a real filter beside a
+     figure that answers to it: `23 executions` on Tests, `312 lines` on
+     Logs, both recomputed whenever a filter changes what is showing.
+
+     Styled as text rather than as a pill on purpose: the pills beside it are
+     controls, and something that looks like the chosen one of several
+     options while being unclickable is exactly what the label it replaces
+     got wrong. */
+  .view-toolbar-count {
     padding: 2px var(--space-sm);
     color: var(--color-text-muted);
     font-size: var(--font-size-xs);
+    font-variant-numeric: tabular-nums;
+  }
+
+  /* The Filter field. One control shape for both views, because they are the
+     same question asked of different content — which rows, which lines.
+
+     `type="search"` for the browser's own clear affordance and for the
+     Escape-clears behaviour a reader already has in every other search
+     field; nothing here re-implements either. The width is capped rather
+     than fixed so the field gives way first at 375px, where the pills are
+     what a reader cannot do without. */
+  .view-filter {
+    width: 100%;
+    max-width: 180px;
+    min-width: 0;
+    padding: 2px var(--space-sm);
+    border: 1px solid var(--color-border-control);
+    border-radius: var(--radius-sm);
+    background-color: var(--color-surface);
+    color: var(--color-text-primary);
+    font: inherit;
+    font-size: var(--font-size-xs);
+  }
+
+  .view-filter::placeholder {
+    color: var(--color-text-muted);
+    /* Chrome renders a placeholder at the UA's own opacity, which would put
+       an already-muted token below the 4.5:1 the token was sized for. */
+    opacity: 1;
+  }
+
+  .view-filter:focus-visible {
+    outline: 2px solid var(--color-accent);
+    outline-offset: 1px;
   }
 
   /* The status filters. Buttons in a radiogroup, because they are mutually
      exclusive and only one can be in effect — `aria-checked` says which,
-     where the old `<li class="selected">` said nothing at all. A3b upgrades
-     what they filter; the five functions behind them are unchanged. */
+     where the old `<li class="selected">` said nothing at all. A3b renders
+     them from the run's own tally: see `Run.filterPillsHTML`. */
   .filter-pills {
     display: flex;
     flex-wrap: wrap;
@@ -724,10 +763,34 @@
     margin-left: auto;
   }
 
-  .logs-iframe {
-    border: 0;
+  /* The run log (#439, A3b), in the document rather than behind an iframe.
+
+     `white-space: pre-wrap` rather than `pre`: the log carries indented
+     section headers whose leading tabs are the structure, so the whitespace
+     has to survive — but a line that runs past the window has to wrap rather
+     than push the page sideways, which is what `pre` would do inside a
+     `body` that is `overflow: hidden`. `overflow-wrap: anywhere` covers the
+     one shape wrapping cannot otherwise break: the absolute paths the log
+     prints, which have no spaces in them. */
+  .log-body {
     flex: 1;
     min-height: 0;
+    margin: 0;
+    padding: var(--space-sm);
+    overflow: auto;
+    background-color: var(--color-surface);
+    color: var(--color-text-primary);
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: var(--font-size-xs);
+    line-height: 1.5;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+    tab-size: 2;
+  }
+
+  .log-body:focus-visible {
+    outline: 2px solid var(--color-accent);
+    outline-offset: -2px;
   }
 
   /* Icons (#439).
@@ -1909,8 +1972,8 @@
                 <span class="icon device-result failure"></span>
                 <span class="device-row-name">Synthetic Device <span class="device-row-os">1.0</span></span>
               </span>
-              <svg class="segbar" viewBox="0 0 100 8" preserveAspectRatio="none" aria-hidden="true" focusable="false"><rect class="status-tint-succeeded" x="0.0000" y="0" width="20.0000" height="8"></rect><rect class="status-tint-failed" x="20.0000" y="0" width="20.0000" height="8"></rect><rect class="status-tint-skipped" x="40.0000" y="0" width="20.0000" height="8"></rect><rect class="status-tint-mixed" x="60.0000" y="0" width="20.0000" height="8"></rect><rect class="status-tint-expected-failure" x="80.0000" y="0" width="20.0000" height="8"></rect></svg>
-              <span class="device-row-tally">1 passed, 1 failed, 1 skipped, 1 mixed, 1 expected failure</span>
+              <svg class="segbar" viewBox="0 0 100 8" preserveAspectRatio="none" aria-hidden="true" focusable="false"><rect class="status-tint-succeeded" x="0.0000" y="0" width="33.3333" height="8"></rect><rect class="status-tint-failed" x="33.3333" y="0" width="16.6667" height="8"></rect><rect class="status-tint-skipped" x="50.0000" y="0" width="16.6667" height="8"></rect><rect class="status-tint-mixed" x="66.6667" y="0" width="16.6667" height="8"></rect><rect class="status-tint-expected-failure" x="83.3333" y="0" width="16.6667" height="8"></rect></svg>
+              <span class="device-row-tally">2 passed, 1 failed, 1 skipped, 1 mixed, 1 expected failure</span>
               <span class="device-option-meta">Synthetic Model</span>
             </button>
           </div>
@@ -1921,18 +1984,18 @@
         <h2 id="run-summary-heading">
           <span class="icon failure"></span>
           Tests
-          <span class="summary-meta">Duration <span class="summary-duration">(9.00s)</span> &middot; 1 device</span>
+          <span class="summary-meta">Duration <span class="summary-duration">(10.50s)</span> &middot; 1 device</span>
         </h2>
         <div class="summary-grid">
           <div class="donut">
             <svg class="donut-ring" viewBox="0 0 120 120" aria-hidden="true" focusable="false">
               <circle class="donut-track" cx="60" cy="60" r="48"></circle>
-              <circle class="donut-seg status-tint-succeeded" cx="60" cy="60" r="48" pathLength="100" stroke-dasharray="20.0000 80.0000" stroke-dashoffset="0.0000" transform="rotate(-90 60 60)"></circle><circle class="donut-seg status-tint-failed" cx="60" cy="60" r="48" pathLength="100" stroke-dasharray="20.0000 80.0000" stroke-dashoffset="-20.0000" transform="rotate(-90 60 60)"></circle><circle class="donut-seg status-tint-skipped" cx="60" cy="60" r="48" pathLength="100" stroke-dasharray="20.0000 80.0000" stroke-dashoffset="-40.0000" transform="rotate(-90 60 60)"></circle><circle class="donut-seg status-tint-mixed" cx="60" cy="60" r="48" pathLength="100" stroke-dasharray="20.0000 80.0000" stroke-dashoffset="-60.0000" transform="rotate(-90 60 60)"></circle><circle class="donut-seg status-tint-expected-failure" cx="60" cy="60" r="48" pathLength="100" stroke-dasharray="20.0000 80.0000" stroke-dashoffset="-80.0000" transform="rotate(-90 60 60)"></circle>
+              <circle class="donut-seg status-tint-succeeded" cx="60" cy="60" r="48" pathLength="100" stroke-dasharray="33.3333 66.6667" stroke-dashoffset="0.0000" transform="rotate(-90 60 60)"></circle><circle class="donut-seg status-tint-failed" cx="60" cy="60" r="48" pathLength="100" stroke-dasharray="16.6667 83.3333" stroke-dashoffset="-33.3333" transform="rotate(-90 60 60)"></circle><circle class="donut-seg status-tint-skipped" cx="60" cy="60" r="48" pathLength="100" stroke-dasharray="16.6667 83.3333" stroke-dashoffset="-50.0000" transform="rotate(-90 60 60)"></circle><circle class="donut-seg status-tint-mixed" cx="60" cy="60" r="48" pathLength="100" stroke-dasharray="16.6667 83.3333" stroke-dashoffset="-66.6667" transform="rotate(-90 60 60)"></circle><circle class="donut-seg status-tint-expected-failure" cx="60" cy="60" r="48" pathLength="100" stroke-dasharray="16.6667 83.3333" stroke-dashoffset="-83.3333" transform="rotate(-90 60 60)"></circle>
             </svg>
-            <span class="donut-center"><strong>5</strong><small>Tests</small></span>
+            <span class="donut-center"><strong>6</strong><small>Tests</small></span>
           </div>
           <ul class="summary-legend">
-            <li><span class="legend-swatch status-tint-succeeded"></span>Passed <span class="legend-count">1</span></li><li><span class="legend-swatch status-tint-failed"></span>Failed <span class="legend-count">1</span></li><li><span class="legend-swatch status-tint-skipped"></span>Skipped <span class="legend-count">1</span></li><li><span class="legend-swatch status-tint-mixed"></span>Mixed <span class="legend-count">1</span></li><li><span class="legend-swatch status-tint-expected-failure"></span>Expected failures <span class="legend-count">1</span></li>
+            <li><span class="legend-swatch status-tint-succeeded"></span>Passed <span class="legend-count">2</span></li><li><span class="legend-swatch status-tint-failed"></span>Failed <span class="legend-count">1</span></li><li><span class="legend-swatch status-tint-skipped"></span>Skipped <span class="legend-count">1</span></li><li><span class="legend-swatch status-tint-mixed"></span>Mixed <span class="legend-count">1</span></li><li><span class="legend-swatch status-tint-expected-failure"></span>Expected failures <span class="legend-count">1</span></li>
           </ul>
         </div>
       </div>
@@ -1961,13 +2024,17 @@
         <div class="run-view" id="tests_42230e298d9d9e832714ebad20e680c6">
     <div class="view-toolbar">
       <div class="filter-pills" role="radiogroup" aria-label="Filter tests by status">
-        <button type="button" role="radio" class="pill" aria-checked="true" tabindex="0" onclick="showAllScenarios(this);">All (5)</button>
-        <button type="button" role="radio" class="pill" aria-checked="false" tabindex="-1" onclick="showSuccessfulScenariosOnly(this);">Passed (1)</button>
-        <button type="button" role="radio" class="pill" aria-checked="false" tabindex="-1" onclick="showSkippedScenariosOnly(this);">Skipped (1)</button>
-        <button type="button" role="radio" class="pill" aria-checked="false" tabindex="-1" onclick="showFailedScenariosOnly(this);">Failed (1)</button>
-        <button type="button" role="radio" class="pill" aria-checked="false" tabindex="-1" onclick="showMixedScenariosOnly(this);">Mixed (1)</button>
+        <button type="button" role="radio" class="pill" data-filter="all" aria-checked="true" tabindex="0">All (6)</button>
+          <button type="button" role="radio" class="pill" data-filter="succeeded" aria-checked="false" tabindex="-1">Passed (2)</button>
+          <button type="button" role="radio" class="pill" data-filter="failed" aria-checked="false" tabindex="-1">Failed (1)</button>
+          <button type="button" role="radio" class="pill" data-filter="skipped" aria-checked="false" tabindex="-1">Skipped (1)</button>
+          <button type="button" role="radio" class="pill" data-filter="mixed" aria-checked="false" tabindex="-1">Mixed (1)</button>
+          <button type="button" role="radio" class="pill" data-filter="expected-failure" aria-checked="false" tabindex="-1">Expected failures (1)</button>
       </div>
-      <div class="view-toolbar-trailing"></div>
+      <p class="view-toolbar-count" aria-live="polite">9 executions</p>
+      <div class="view-toolbar-trailing">
+        <input type="search" class="view-filter tests-filter" placeholder="Filter" aria-label="Filter tests by name" autocomplete="off">
+      </div>
     </div>
     <ul class="table-header">
       <li>Test</li>
@@ -2104,6 +2171,80 @@
 </div>
       </div>
   </div>  <img class="screenshot-tail" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
+  <div class="test-summary succeeded" data-runs="3">
+      <p class="list-item">
+          <span class="icon drop-down-icon" onclick="toggle(this, '0b826fba7727d72ce840258316314d96')"></span>
+          <span class="icon test-result-icon"></span>
+          <span class="row-name">testParameterized()</span>
+            <span class="row-note row-arguments">3 arguments</span>
+          <span class="row-duration">(1.50s)</span>
+      </p>
+      <div id="activities-0b826fba7727d72ce840258316314d96" class="activities">
+          <img class="screenshot-flow" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
+          <div class="activity  no-drop-down">
+  <p class="list-item">
+    <span style="margin-left: 38px" class="padding"></span>
+    <span class="icon drop-down-icon" onclick="toggle(this, 'cfb3666c0d21f7c6c49701e17aa04b6a')"></span>
+    <span class="row-name">Start Test</span>
+    <span class="icon paperclip-icon" style="display: none"></span>
+  </p>
+  <div id="attachments-cfb3666c0d21f7c6c49701e17aa04b6a" class="attachments">
+      
+  </div>
+  <div id="activities-cfb3666c0d21f7c6c49701e17aa04b6a" class="sub-activities">
+      
+  </div>
+</div><div class="activity  ">
+  <p class="list-item">
+    <span style="margin-left: 20px" class="padding"></span>
+    <span class="icon drop-down-icon" onclick="toggle(this, '7f68515b542c73fa411846f548f3bc9f')"></span>
+    <span class="row-name">Attachments</span>
+    <span class="icon paperclip-icon" style="display: inline-block"></span>
+  </p>
+  <div id="attachments-7f68515b542c73fa411846f548f3bc9f" class="attachments">
+      <p class="attachment list-item">
+  <span class="icon screenshot-icon" style="margin-left: 36px"></span>
+  <span class="row-name">Screenshot</span>
+  <button type="button" class="preview-button" aria-label="Preview attachment" data-kind="screenshot" data="screenshot.png" onclick="openAttachment(this)"><span class="icon preview-icon" aria-hidden="true"></span></button>
+  <img class="screenshot" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
+</p><p class="attachment list-item">
+  <span class="icon text-icon" style="margin-left: 36px"></span>
+  <span class="row-name">Log</span>
+  <button type="button" class="preview-button" aria-label="Preview attachment" data-kind="text" data="data:text/plain;base64,c3ludGhldGljIGF0dGFjaG1lbnQgYm9keQo=" onclick="openAttachment(this)"><span class="icon preview-icon" aria-hidden="true"></span></button>
+</p>
+  </div>
+  <div id="activities-7f68515b542c73fa411846f548f3bc9f" class="sub-activities">
+      
+  </div>
+</div><div class="activity  ">
+  <p class="list-item">
+    <span style="margin-left: 20px" class="padding"></span>
+    <span class="icon drop-down-icon" onclick="toggle(this, '3fe83024c6f1adf7c5d6d4825883b168')"></span>
+    <span class="row-name">Nested</span>
+    <span class="icon paperclip-icon" style="display: none"></span>
+  </p>
+  <div id="attachments-3fe83024c6f1adf7c5d6d4825883b168" class="attachments">
+      
+  </div>
+  <div id="activities-3fe83024c6f1adf7c5d6d4825883b168" class="sub-activities">
+      <div class="activity  no-drop-down">
+  <p class="list-item">
+    <span style="margin-left: 48px" class="padding"></span>
+    <span class="icon drop-down-icon" onclick="toggle(this, '1ef9e05a2a4d97f6be64befb9b950dfc')"></span>
+    <span class="row-name">Inner step</span>
+    <span class="icon paperclip-icon" style="display: none"></span>
+  </p>
+  <div id="attachments-1ef9e05a2a4d97f6be64befb9b950dfc" class="attachments">
+      
+  </div>
+  <div id="activities-1ef9e05a2a4d97f6be64befb9b950dfc" class="sub-activities">
+      
+  </div>
+</div>
+  </div>
+</div>
+      </div>
+  </div>  <img class="screenshot-tail" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
   <div class="test-summary succeeded">
       <p class="list-item">
           <span class="icon drop-down-icon" onclick="toggle(this, '16170791d4b96668f53ace117678c387')"></span>
@@ -2176,7 +2317,7 @@
   </div>
 </div>
       </div>
-  </div>  <div class="test-summary mixed">
+  </div>  <div class="test-summary mixed" data-runs="2">
       <p class="list-item">
           <span class="icon drop-down-icon dropped" onclick="toggle(this, '751413da1b48c31cffea0e4c31cc99bc')"></span>
           <span class="icon test-result-icon"></span>
@@ -2324,10 +2465,14 @@
       <section class="view" id="view-logs" role="tabpanel" aria-labelledby="tab-logs">
         <div class="run-view" id="logs_42230e298d9d9e832714ebad20e680c6">
     <div class="view-toolbar">
-      <p class="view-toolbar-label">All Messages</p>
-      <div class="view-toolbar-trailing"></div>
+      <p class="view-toolbar-count" aria-live="polite">2 lines</p>
+      <div class="view-toolbar-trailing">
+        <input type="search" class="view-filter log-filter" placeholder="Filter" aria-label="Filter log lines" autocomplete="off">
+      </div>
     </div>
-    <iframe class="logs-iframe" src="data:text/plain;base64,U3ludGhldGljIHJ1biBsb2cgbGluZSBvbmUKU3ludGhldGljIHJ1biBsb2cgbGluZSB0d28K" title="Run log" loading="lazy"></iframe>
+    <pre class="log-body" tabindex="0">Synthetic run log line one
+Synthetic run log line two
+</pre>
   </div>
       </section>
     </main>
@@ -2371,11 +2516,6 @@
   function activeTree() {
     var view = activeTestsView();
     return view ? view.querySelector('.tests') : null;
-  }
-
-  function inActiveTests(selector) {
-    var view = activeTestsView();
-    return view ? view.querySelectorAll(selector) : [];
   }
 
   // ---- Roving focus --------------------------------------------------
@@ -2849,26 +2989,109 @@
     }
   }
 
-  // ---- Status filters ------------------------------------------------
+  // ---- Filters (#439, A3b; #460) -------------------------------------
   //
-  // The five functions A3b upgrades, unchanged in what they do. What
-  // changed is only what they are scoped to: `.run.active` named the shell's
-  // per-run pane, which the per-view split replaced with one slice per view.
-  // Everything downstream of the scope — which classes are shown, which are
-  // hidden, and the group-collapsing pass — is the same code it was.
+  // What A3a left here was five functions, one per pill, each naming the
+  // four row classes it shows or hides. That shape is why #460 existed: an
+  // expected failure carries none of those four classes, so no function
+  // mentioned it, so "Passed" left it on screen and "All" — which sets
+  // `display: block` on the four it knows — left it at whatever it already
+  // was. The group pass below then read it as hidden, and a suite whose every
+  // test was an expected failure disappeared from a report the moment the
+  // reader touched any filter, including "All".
+  //
+  // One function replaces the five. A row is shown when it matches *both* of
+  // the view's filters, and the status one is a class comparison against
+  // `data-filter` rather than a list of classes written out here — so a
+  // status added to `Status` gets a pill and gets filtered, with nothing in
+  // this file to update. `unknown` is filtered today for exactly that
+  // reason, having had the same gap as `expectedFailure` and no issue.
+  //
+  // State lives on the view, not in a variable: a report holds one tests
+  // slice per destination and each keeps its own filters, so switching
+  // destination and switching back does not silently reset what the reader
+  // chose.
 
-  function setDisplayToElementsWithSelector(sel, display) {
-    [].forEach.call(inActiveTests(sel), function (el) {
-      el.style.display = display;
+  function statusOf(view) {
+    return view.getAttribute('data-filter-status') || 'all';
+  }
+
+  function queryOf(view) {
+    return view.getAttribute('data-filter-text') || '';
+  }
+
+  // What the filter treats as a row, which is what the *report* treats as a
+  // test: every `.test-summary`, plus a suite heading with nothing inside
+  // it. `Run.allTests` flattens the tree to its leaves and a childless group
+  // is one of them — the shape a crashed target leaves behind, which
+  // `TruncationFaultTests` is built out of — so it is counted in the pills
+  // and has to be filtered by them. It also had the same defect #460 names:
+  // the group pass below skips a group with no rows in it, so before this
+  // nothing could hide one whatever the reader chose.
+  function filterableRows(view) {
+    var rows = Array.prototype.slice.call(
+      view.querySelectorAll('.test-summary, .test-summary-group')
+    );
+    return rows.filter(function (row) {
+      return !row.classList.contains('test-summary-group')
+        || row.querySelector('.test-summary, .test-summary-group') === null;
     });
   }
 
-  function hideElementsWithSelector(sel) {
-    setDisplayToElementsWithSelector(sel, 'none');
+  // A group's visibility is otherwise derived from its rows, below.
+  function rowMatches(row, status, query) {
+    if (status !== 'all' && !row.classList.contains(status)) {
+      return false;
+    }
+    if (!query) {
+      return true;
+    }
+    var name = row.querySelector('.row-name');
+    return !!name && name.textContent.toLowerCase().indexOf(query) >= 0;
   }
 
-  function showElementsWithSelector(sel) {
-    setDisplayToElementsWithSelector(sel, 'block');
+  // How many times the run executed what a row stands for: the `data-runs`
+  // the template writes when a test was parameterized or repeated, and 1
+  // otherwise — which is why the attribute is absent on almost every row.
+  function executionsOf(row) {
+    return parseInt(row.getAttribute('data-runs'), 10) || 1;
+  }
+
+  function applyTestFilters(view) {
+    if (!view) {
+      return;
+    }
+    var status = statusOf(view),
+        query = queryOf(view),
+        rows = filterableRows(view),
+        executions = 0;
+    for (var i = 0; i < rows.length; i++) {
+      var shown = rowMatches(rows[i], status, query);
+      rows[i].style.display = shown ? 'block' : 'none';
+      // A test's tail screenshot is emitted *between* rows rather than
+      // inside one (A2), so it is a sibling the row's own `display` does not
+      // reach. Left behind, a filtered-out test leaves its screenshot in the
+      // tree with no row to belong to — a 200px picture of a test the reader
+      // asked not to see.
+      var tail = rows[i].previousElementSibling;
+      if (tail && tail.classList.contains('screenshot-tail')) {
+        tail.style.display = shown ? 'block' : 'none';
+      }
+      if (shown) {
+        executions += executionsOf(rows[i]);
+      }
+    }
+    hideSummaryGroupsIfNeeded(view);
+    setCount(view, executions === 1 ? '1 execution' : executions + ' executions');
+  }
+
+  // The toolbar figure this view answers with. One writer, so the rendered
+  // value and every recomputation of it are the same sentence.
+  function setCount(view, text) {
+    var count = view.querySelector('.view-toolbar-count');
+    if (count) {
+      count.textContent = text;
+    }
   }
 
   // The chosen filter, as an ARIA fact rather than a class: these are
@@ -2883,81 +3106,124 @@
     setRovingTabStop(pills, el);
   }
 
-  function showAllScenarios(el) {
-    selectedElement(el);
-    showElementsWithSelector('.test-summary.succeeded');
-    showElementsWithSelector('.test-summary.skipped');
-    showElementsWithSelector('.test-summary.failed');
-    showElementsWithSelector('.test-summary.mixed');
-    hideSummaryGroupsIfNeeded();
+  function chooseStatus(pill) {
+    var view = pill.closest('.run-view');
+    if (!view) {
+      return;
+    }
+    selectedElement(pill);
+    view.setAttribute('data-filter-status', pill.getAttribute('data-filter') || 'all');
+    applyTestFilters(view);
   }
 
-  function showSuccessfulScenariosOnly(el) {
-    selectedElement(el);
-    showElementsWithSelector('.test-summary.succeeded');
-    hideElementsWithSelector('.test-summary.skipped');
-    hideElementsWithSelector('.test-summary.failed');
-    hideElementsWithSelector('.test-summary.mixed');
-    hideSummaryGroupsIfNeeded();
-  }
-
-  function showSkippedScenariosOnly(el) {
-    selectedElement(el);
-    hideElementsWithSelector('.test-summary.succeeded');
-    showElementsWithSelector('.test-summary.skipped');
-    hideElementsWithSelector('.test-summary.failed');
-    hideElementsWithSelector('.test-summary.mixed');
-    hideSummaryGroupsIfNeeded();
-  }
-
-  function showFailedScenariosOnly(el) {
-    selectedElement(el);
-    hideElementsWithSelector('.test-summary.succeeded');
-    hideElementsWithSelector('.test-summary.skipped');
-    showElementsWithSelector('.test-summary.failed');
-    hideElementsWithSelector('.test-summary.mixed');
-    hideSummaryGroupsIfNeeded();
-  }
-
-  function showMixedScenariosOnly(el) {
-    selectedElement(el);
-    hideElementsWithSelector('.test-summary.succeeded');
-    hideElementsWithSelector('.test-summary.skipped');
-    hideElementsWithSelector('.test-summary.failed');
-    showElementsWithSelector('.test-summary.mixed');
-    hideSummaryGroupsIfNeeded();
-  }
-
-  function hideSummaryGroupsIfNeeded() {
-    var testSummaryGroups = Array.prototype.slice.call(
-      inActiveTests('.test-summary-group')
+  // A suite is shown when anything under it is, and the walk is bottom-up so
+  // a parent reads children that have already been decided.
+  //
+  // The pass this replaces bailed out on any group holding a sub-group
+  // (`testSummaryGroupChildren.length > 0`), so the legacy backend's two
+  // wrapper levels — "Selected tests" and "<target>.xctest", which hold
+  // only other groups — were never hidden by anything. A filter that
+  // selected two rows left them under three empty headings. Deciding
+  // deepest-first is what makes one rule cover both cases: `querySelectorAll`
+  // yields document order, and an ancestor always precedes its descendants
+  // in it, so iterating backwards visits every child before its parent.
+  //
+  // A group with no rows and no sub-groups is skipped, not because it cannot
+  // be decided but because it already has been: `applyTestFilters` treats a
+  // childless suite as a row, since that is what `Run.allTests` counts it as.
+  function hideSummaryGroupsIfNeeded(view) {
+    var groups = Array.prototype.slice.call(
+      view.querySelectorAll('.test-summary-group')
     );
-    for (var i = 0; i < testSummaryGroups.length; i++) {
-        var testSummaryGroup = testSummaryGroups[i];
-        var children = Array.prototype.slice.call(testSummaryGroup.children);
-        var testSummaryChildren = children.filter(function(a) { return a.classList.contains('test-summary'); });
-        var testSummaryGroupChildren = children.filter(function(a) { return a.classList.contains('test-summary-group'); });
-        if (testSummaryChildren == 0 || testSummaryGroupChildren.length > 0) {
-          continue;
-        }
-
-        if (testSummaryChildren.filter(function(a) { return a.style.display == 'block' }).length == 0) {
-          testSummaryGroup.style.display = 'none';
-        } else {
-          testSummaryGroup.style.display = 'block';
-        }
+    for (var i = groups.length - 1; i >= 0; i--) {
+      var group = groups[i];
+      var children = Array.prototype.slice.call(group.children).filter(function (child) {
+        return child.classList.contains('test-summary')
+          || child.classList.contains('test-summary-group');
+      });
+      if (children.length === 0) {
+        continue;
+      }
+      var anyShown = children.some(function (child) {
+        return child.style.display !== 'none';
+      });
+      group.style.display = anyShown ? 'block' : 'none';
     }
   }
 
+  var filterPills = document.querySelectorAll('.filter-pills [role="radio"]');
+  for (var fp = 0; fp < filterPills.length; fp++) {
+    filterPills[fp].addEventListener('click', function (e) {
+      chooseStatus(e.currentTarget);
+    }, false);
+  }
+
   // Arrow keys inside a radiogroup both move focus and choose, which is the
-  // behaviour a native radio group has. The pill's own `onclick` is the one
-  // definition of what choosing does, so the handler dispatches to it rather
-  // than restating the mapping from pill to filter.
+  // behaviour a native radio group has.
   var filterGroups = document.querySelectorAll('.filter-pills');
   for (var f = 0; f < filterGroups.length; f++) {
-    rovingGroup(filterGroups[f], '[role="radio"]', function (pill) {
-      pill.onclick();
-    });
+    rovingGroup(filterGroups[f], '[role="radio"]', chooseStatus);
+  }
+
+  // The name filter. Composes with the pills rather than replacing them:
+  // both are read by `applyTestFilters`, so "Failed" and "one" together
+  // mean the failing tests whose names contain "one", which is what a
+  // reader who set both is asking for.
+  var testFilters = document.querySelectorAll('.tests-filter');
+  for (var tf = 0; tf < testFilters.length; tf++) {
+    testFilters[tf].addEventListener('input', function (e) {
+      var view = e.currentTarget.closest('.run-view');
+      if (!view) {
+        return;
+      }
+      view.setAttribute('data-filter-text', e.currentTarget.value.trim().toLowerCase());
+      applyTestFilters(view);
+    }, false);
+  }
+
+  // ---- The log filter ------------------------------------------------
+  //
+  // The log is one text document, so the only filter its content supports is
+  // over its lines — which is the control Xcode's own Log view puts in this
+  // same corner. It is possible at all because A3b renders the log in the
+  // page: behind the `iframe` it replaces, the log was a foreign origin and
+  // nothing here could have read a line of it.
+  //
+  // The lines are split once, on first use, and kept on the element. The
+  // `<pre>` stays a single text node either way — a line per element would
+  // be one node per line of a log that can run to six figures.
+  var logFilters = document.querySelectorAll('.log-filter');
+  for (var lf = 0; lf < logFilters.length; lf++) {
+    logFilters[lf].addEventListener('input', function (e) {
+      var view = e.currentTarget.closest('.run-view'),
+          body = view && view.querySelector('.log-body');
+      if (!body) {
+        return;
+      }
+      if (!body.logLines) {
+        var text = body.textContent;
+        // A trailing newline ends the last line rather than starting an
+        // empty one, which is what the rendered count already assumes.
+        if (text.charAt(text.length - 1) === '\n') {
+          text = text.slice(0, -1);
+        }
+        body.logLines = text === '' ? [] : text.split('\n');
+      }
+      var query = e.currentTarget.value.trim().toLowerCase(),
+          lines = body.logLines,
+          kept = query
+            ? lines.filter(function (line) {
+                return line.toLowerCase().indexOf(query) >= 0;
+              })
+            : lines;
+      body.textContent = kept.join('\n');
+      setCount(
+        view,
+        query
+          ? kept.length + ' of ' + lines.length + (lines.length === 1 ? ' line' : ' lines')
+          : lines.length + (lines.length === 1 ? ' line' : ' lines')
+      );
+    }, false);
   }
 
   // ---- Boot ----------------------------------------------------------
@@ -3006,13 +3272,19 @@
 
     activateRunContaining(row);
 
-    // The filter writes `display: none` onto the element itself, and its
-    // group as well. Clearing both un-hides this one row without resetting
-    // the filter the reader chose.
+    // The filter writes `display: none` onto the element itself and onto
+    // every suite above it that the row was the last visible thing in.
+    // Clearing the whole chain un-hides this one row without resetting the
+    // filter the reader chose — the nearest suite alone is not enough, since
+    // A3b's group pass hides a wrapper whose every child went, which the
+    // pass it replaces never did.
     row.style.display = 'block';
-    var group = row.closest('.test-summary-group');
-    if (group) {
-      group.style.display = 'block';
+    var ancestor = row.parentElement;
+    while (ancestor && !ancestor.classList.contains('tests')) {
+      if (ancestor.classList.contains('test-summary-group')) {
+        ancestor.style.display = 'block';
+      }
+      ancestor = ancestor.parentElement;
     }
 
     disclosure.style.display = 'block';

--- a/Tests/XCTestHTMLReportTests/Snapshots/index-inline.html
+++ b/Tests/XCTestHTMLReportTests/Snapshots/index-inline.html
@@ -146,6 +146,13 @@
        Safari versions that predate it, then named fallbacks, and a
        generic family last so the chain can always terminate. */
     --font-family-base: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Helvetica, Arial, sans-serif;
+    /* The run log is the one thing in the report that is a *document* rather
+       than a layout, and its structure is columns of `-------- title
+       --------` rules and indentation — which only a monospace face keeps
+       aligned. `ui-monospace` first, so it is the platform's own coding
+       face where there is one, with the named fallbacks for browsers that
+       do not know the generic yet (#439, A3b). */
+    --font-family-mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
     --font-size-xs: 11px;
     --font-size-sm: 12px;
     --font-size-md: 13px;
@@ -780,7 +787,7 @@
     overflow: auto;
     background-color: var(--color-surface);
     color: var(--color-text-primary);
-    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-family: var(--font-family-mono);
     font-size: var(--font-size-xs);
     line-height: 1.5;
     white-space: pre-wrap;

--- a/Tests/XCTestHTMLReportTests/Snapshots/index-inline.html
+++ b/Tests/XCTestHTMLReportTests/Snapshots/index-inline.html
@@ -3039,6 +3039,16 @@ Synthetic run log line two
   }
 
   // A group's visibility is otherwise derived from its rows, below.
+  //
+  // The name is matched against the row *and every suite above it*, because
+  // a filter over a tree that only ever reads its leaves is one a reader
+  // finds out about the hard way: typing the name of a suite they can see
+  // would empty the pane. Matching an ancestor keeps that suite and the
+  // tests inside it, which is what the same query does in Xcode's outline.
+  //
+  // The status is a leaf question either way — a suite's own status is
+  // folded from its children, so filtering on it would put rows of every
+  // outcome under a heading claiming one.
   function rowMatches(row, status, query) {
     if (status !== 'all' && !row.classList.contains(status)) {
       return false;
@@ -3046,8 +3056,21 @@ Synthetic run log line two
     if (!query) {
       return true;
     }
-    var name = row.querySelector('.row-name');
-    return !!name && name.textContent.toLowerCase().indexOf(query) >= 0;
+    var node = row;
+    while (node && !node.classList.contains('tests')) {
+      if (node.classList.contains('test-summary')
+        || node.classList.contains('test-summary-group')) {
+        // The first `.row-name` inside a row is its own: a suite's heading
+        // precedes its children, and a retried test's precedes its
+        // iterations.
+        var name = node.querySelector('.row-name');
+        if (name && name.textContent.toLowerCase().indexOf(query) >= 0) {
+          return true;
+        }
+      }
+      node = node.parentElement;
+    }
+    return false;
   }
 
   // How many times the run executed what a row stands for: the `data-runs`

--- a/Tests/XCTestHTMLReportTests/Snapshots/index-inline.html
+++ b/Tests/XCTestHTMLReportTests/Snapshots/index-inline.html
@@ -3093,8 +3093,7 @@ Synthetic run log line two
     }
     var status = statusOf(view),
         query = queryOf(view),
-        rows = filterableRows(view),
-        executions = 0;
+        rows = filterableRows(view);
     for (var i = 0; i < rows.length; i++) {
       var shown = rowMatches(rows[i], status, query);
       rows[i].style.display = shown ? 'block' : 'none';
@@ -3113,11 +3112,27 @@ Synthetic run log line two
         tail.style.display = shown ? 'block' : 'none';
         tail = tail.previousElementSibling;
       }
-      if (shown) {
+    }
+    hideSummaryGroupsIfNeeded(view);
+    countExecutionsOnScreen(view);
+  }
+
+  // Counted off the rows rather than accumulated while deciding them, so
+  // that anything which changes what is on screen can restate the figure by
+  // calling this — the digest jump reveals a row the filter hid, and a count
+  // that only the filter could write would keep announcing the filter's
+  // number at a pane that no longer holds it.
+  function countExecutionsOnScreen(view) {
+    if (!view) {
+      return;
+    }
+    var rows = filterableRows(view),
+        executions = 0;
+    for (var i = 0; i < rows.length; i++) {
+      if (rows[i].style.display !== 'none') {
         executions += executionsOf(rows[i]);
       }
     }
-    hideSummaryGroupsIfNeeded(view);
     setCount(view, executions === 1 ? '1 execution' : executions + ' executions');
   }
 
@@ -3322,6 +3337,12 @@ Synthetic run log line two
       }
       ancestor = ancestor.parentElement;
     }
+
+    // A row appearing is a change to what the pane holds, so the toolbar
+    // restates its figure through the same writer the filter uses. The count
+    // is `aria-live`: silence here is a reader being told nothing while a
+    // test they did not filter for arrives on screen.
+    countExecutionsOnScreen(row.closest('.run-view'));
 
     disclosure.style.display = 'block';
     var chevron = row.querySelector('.drop-down-icon');

--- a/Tests/XCTestHTMLReportTests/Snapshots/index.html
+++ b/Tests/XCTestHTMLReportTests/Snapshots/index.html
@@ -3098,14 +3098,20 @@ Synthetic run log line two
     for (var i = 0; i < rows.length; i++) {
       var shown = rowMatches(rows[i], status, query);
       rows[i].style.display = shown ? 'block' : 'none';
-      // A test's tail screenshot is emitted *between* rows rather than
-      // inside one (A2), so it is a sibling the row's own `display` does not
-      // reach. Left behind, a filtered-out test leaves its screenshot in the
-      // tree with no row to belong to — a 200px picture of a test the reader
-      // asked not to see.
+      // A test's tail screenshots are emitted *between* rows rather than
+      // inside one (A2), so they are siblings the row's own `display` does
+      // not reach. Left behind, a filtered-out test leaves its screenshots in
+      // the tree with no row to belong to — 200px pictures of a test the
+      // reader asked not to see.
+      //
+      // A loop, not one sibling: `TestScreenshotFlow` emits the *last three*
+      // screenshots of a test (`suffix(tailCount)`), so a test with several
+      // is preceded by several. The synthetic fixture has such a row, which
+      // is why the gate on this counts every tail rather than the first.
       var tail = rows[i].previousElementSibling;
-      if (tail && tail.classList.contains('screenshot-tail')) {
+      while (tail && tail.classList.contains('screenshot-tail')) {
         tail.style.display = shown ? 'block' : 'none';
+        tail = tail.previousElementSibling;
       }
       if (shown) {
         executions += executionsOf(rows[i]);

--- a/Tests/XCTestHTMLReportTests/Snapshots/index.html
+++ b/Tests/XCTestHTMLReportTests/Snapshots/index.html
@@ -626,9 +626,8 @@
   }
 
   /* The per-view toolbar. Left group is the view's own controls; the
-     trailing group is deliberately empty and deliberately present — it is
-     where A3b's text filter and its dropdowns land (#460), and reserving it
-     here is what keeps that from being a re-layout. */
+     trailing group holds the Filter field, which is where A3a reserved the
+     slot for it and where Xcode's own test report puts one. */
   .view-toolbar {
     display: flex;
     flex-wrap: wrap;
@@ -648,23 +647,63 @@
     gap: var(--space-xs);
   }
 
-  /* A label, not a control. The Logs view has one scope and no way to change
-     it, and the shipped markup said otherwise: `<li class="selected">All
-     Messages</li>` in a `toggle-toolbar`, wearing a selected pill's fill and
-     hover with nothing bound to it. Dressing an inert string as the chosen
-     one of several options is the kind of thing a keyboard user finds out
-     the hard way. Real log filters are #460's, and land in the trailing slot
-     beside this. */
-  .view-toolbar-label {
+  /* A count, and a live one (#439, A3b).
+
+     This is the slot A3a's inert "All Messages" label occupied. That label
+     was a placeholder for a control the Logs view could not have — nothing
+     in the page can filter a document on another origin — and the honest
+     replacement is not a better-dressed label but a real filter beside a
+     figure that answers to it: `23 executions` on Tests, `312 lines` on
+     Logs, both recomputed whenever a filter changes what is showing.
+
+     Styled as text rather than as a pill on purpose: the pills beside it are
+     controls, and something that looks like the chosen one of several
+     options while being unclickable is exactly what the label it replaces
+     got wrong. */
+  .view-toolbar-count {
     padding: 2px var(--space-sm);
     color: var(--color-text-muted);
     font-size: var(--font-size-xs);
+    font-variant-numeric: tabular-nums;
+  }
+
+  /* The Filter field. One control shape for both views, because they are the
+     same question asked of different content — which rows, which lines.
+
+     `type="search"` for the browser's own clear affordance and for the
+     Escape-clears behaviour a reader already has in every other search
+     field; nothing here re-implements either. The width is capped rather
+     than fixed so the field gives way first at 375px, where the pills are
+     what a reader cannot do without. */
+  .view-filter {
+    width: 100%;
+    max-width: 180px;
+    min-width: 0;
+    padding: 2px var(--space-sm);
+    border: 1px solid var(--color-border-control);
+    border-radius: var(--radius-sm);
+    background-color: var(--color-surface);
+    color: var(--color-text-primary);
+    font: inherit;
+    font-size: var(--font-size-xs);
+  }
+
+  .view-filter::placeholder {
+    color: var(--color-text-muted);
+    /* Chrome renders a placeholder at the UA's own opacity, which would put
+       an already-muted token below the 4.5:1 the token was sized for. */
+    opacity: 1;
+  }
+
+  .view-filter:focus-visible {
+    outline: 2px solid var(--color-accent);
+    outline-offset: 1px;
   }
 
   /* The status filters. Buttons in a radiogroup, because they are mutually
      exclusive and only one can be in effect — `aria-checked` says which,
-     where the old `<li class="selected">` said nothing at all. A3b upgrades
-     what they filter; the five functions behind them are unchanged. */
+     where the old `<li class="selected">` said nothing at all. A3b renders
+     them from the run's own tally: see `Run.filterPillsHTML`. */
   .filter-pills {
     display: flex;
     flex-wrap: wrap;
@@ -724,10 +763,34 @@
     margin-left: auto;
   }
 
-  .logs-iframe {
-    border: 0;
+  /* The run log (#439, A3b), in the document rather than behind an iframe.
+
+     `white-space: pre-wrap` rather than `pre`: the log carries indented
+     section headers whose leading tabs are the structure, so the whitespace
+     has to survive — but a line that runs past the window has to wrap rather
+     than push the page sideways, which is what `pre` would do inside a
+     `body` that is `overflow: hidden`. `overflow-wrap: anywhere` covers the
+     one shape wrapping cannot otherwise break: the absolute paths the log
+     prints, which have no spaces in them. */
+  .log-body {
     flex: 1;
     min-height: 0;
+    margin: 0;
+    padding: var(--space-sm);
+    overflow: auto;
+    background-color: var(--color-surface);
+    color: var(--color-text-primary);
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: var(--font-size-xs);
+    line-height: 1.5;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+    tab-size: 2;
+  }
+
+  .log-body:focus-visible {
+    outline: 2px solid var(--color-accent);
+    outline-offset: -2px;
   }
 
   /* Icons (#439).
@@ -1909,8 +1972,8 @@
                 <span class="icon device-result failure"></span>
                 <span class="device-row-name">Synthetic Device <span class="device-row-os">1.0</span></span>
               </span>
-              <svg class="segbar" viewBox="0 0 100 8" preserveAspectRatio="none" aria-hidden="true" focusable="false"><rect class="status-tint-succeeded" x="0.0000" y="0" width="20.0000" height="8"></rect><rect class="status-tint-failed" x="20.0000" y="0" width="20.0000" height="8"></rect><rect class="status-tint-skipped" x="40.0000" y="0" width="20.0000" height="8"></rect><rect class="status-tint-mixed" x="60.0000" y="0" width="20.0000" height="8"></rect><rect class="status-tint-expected-failure" x="80.0000" y="0" width="20.0000" height="8"></rect></svg>
-              <span class="device-row-tally">1 passed, 1 failed, 1 skipped, 1 mixed, 1 expected failure</span>
+              <svg class="segbar" viewBox="0 0 100 8" preserveAspectRatio="none" aria-hidden="true" focusable="false"><rect class="status-tint-succeeded" x="0.0000" y="0" width="33.3333" height="8"></rect><rect class="status-tint-failed" x="33.3333" y="0" width="16.6667" height="8"></rect><rect class="status-tint-skipped" x="50.0000" y="0" width="16.6667" height="8"></rect><rect class="status-tint-mixed" x="66.6667" y="0" width="16.6667" height="8"></rect><rect class="status-tint-expected-failure" x="83.3333" y="0" width="16.6667" height="8"></rect></svg>
+              <span class="device-row-tally">2 passed, 1 failed, 1 skipped, 1 mixed, 1 expected failure</span>
               <span class="device-option-meta">Synthetic Model</span>
             </button>
           </div>
@@ -1921,18 +1984,18 @@
         <h2 id="run-summary-heading">
           <span class="icon failure"></span>
           Tests
-          <span class="summary-meta">Duration <span class="summary-duration">(9.00s)</span> &middot; 1 device</span>
+          <span class="summary-meta">Duration <span class="summary-duration">(10.50s)</span> &middot; 1 device</span>
         </h2>
         <div class="summary-grid">
           <div class="donut">
             <svg class="donut-ring" viewBox="0 0 120 120" aria-hidden="true" focusable="false">
               <circle class="donut-track" cx="60" cy="60" r="48"></circle>
-              <circle class="donut-seg status-tint-succeeded" cx="60" cy="60" r="48" pathLength="100" stroke-dasharray="20.0000 80.0000" stroke-dashoffset="0.0000" transform="rotate(-90 60 60)"></circle><circle class="donut-seg status-tint-failed" cx="60" cy="60" r="48" pathLength="100" stroke-dasharray="20.0000 80.0000" stroke-dashoffset="-20.0000" transform="rotate(-90 60 60)"></circle><circle class="donut-seg status-tint-skipped" cx="60" cy="60" r="48" pathLength="100" stroke-dasharray="20.0000 80.0000" stroke-dashoffset="-40.0000" transform="rotate(-90 60 60)"></circle><circle class="donut-seg status-tint-mixed" cx="60" cy="60" r="48" pathLength="100" stroke-dasharray="20.0000 80.0000" stroke-dashoffset="-60.0000" transform="rotate(-90 60 60)"></circle><circle class="donut-seg status-tint-expected-failure" cx="60" cy="60" r="48" pathLength="100" stroke-dasharray="20.0000 80.0000" stroke-dashoffset="-80.0000" transform="rotate(-90 60 60)"></circle>
+              <circle class="donut-seg status-tint-succeeded" cx="60" cy="60" r="48" pathLength="100" stroke-dasharray="33.3333 66.6667" stroke-dashoffset="0.0000" transform="rotate(-90 60 60)"></circle><circle class="donut-seg status-tint-failed" cx="60" cy="60" r="48" pathLength="100" stroke-dasharray="16.6667 83.3333" stroke-dashoffset="-33.3333" transform="rotate(-90 60 60)"></circle><circle class="donut-seg status-tint-skipped" cx="60" cy="60" r="48" pathLength="100" stroke-dasharray="16.6667 83.3333" stroke-dashoffset="-50.0000" transform="rotate(-90 60 60)"></circle><circle class="donut-seg status-tint-mixed" cx="60" cy="60" r="48" pathLength="100" stroke-dasharray="16.6667 83.3333" stroke-dashoffset="-66.6667" transform="rotate(-90 60 60)"></circle><circle class="donut-seg status-tint-expected-failure" cx="60" cy="60" r="48" pathLength="100" stroke-dasharray="16.6667 83.3333" stroke-dashoffset="-83.3333" transform="rotate(-90 60 60)"></circle>
             </svg>
-            <span class="donut-center"><strong>5</strong><small>Tests</small></span>
+            <span class="donut-center"><strong>6</strong><small>Tests</small></span>
           </div>
           <ul class="summary-legend">
-            <li><span class="legend-swatch status-tint-succeeded"></span>Passed <span class="legend-count">1</span></li><li><span class="legend-swatch status-tint-failed"></span>Failed <span class="legend-count">1</span></li><li><span class="legend-swatch status-tint-skipped"></span>Skipped <span class="legend-count">1</span></li><li><span class="legend-swatch status-tint-mixed"></span>Mixed <span class="legend-count">1</span></li><li><span class="legend-swatch status-tint-expected-failure"></span>Expected failures <span class="legend-count">1</span></li>
+            <li><span class="legend-swatch status-tint-succeeded"></span>Passed <span class="legend-count">2</span></li><li><span class="legend-swatch status-tint-failed"></span>Failed <span class="legend-count">1</span></li><li><span class="legend-swatch status-tint-skipped"></span>Skipped <span class="legend-count">1</span></li><li><span class="legend-swatch status-tint-mixed"></span>Mixed <span class="legend-count">1</span></li><li><span class="legend-swatch status-tint-expected-failure"></span>Expected failures <span class="legend-count">1</span></li>
           </ul>
         </div>
       </div>
@@ -1961,13 +2024,17 @@
         <div class="run-view" id="tests_42230e298d9d9e832714ebad20e680c6">
     <div class="view-toolbar">
       <div class="filter-pills" role="radiogroup" aria-label="Filter tests by status">
-        <button type="button" role="radio" class="pill" aria-checked="true" tabindex="0" onclick="showAllScenarios(this);">All (5)</button>
-        <button type="button" role="radio" class="pill" aria-checked="false" tabindex="-1" onclick="showSuccessfulScenariosOnly(this);">Passed (1)</button>
-        <button type="button" role="radio" class="pill" aria-checked="false" tabindex="-1" onclick="showSkippedScenariosOnly(this);">Skipped (1)</button>
-        <button type="button" role="radio" class="pill" aria-checked="false" tabindex="-1" onclick="showFailedScenariosOnly(this);">Failed (1)</button>
-        <button type="button" role="radio" class="pill" aria-checked="false" tabindex="-1" onclick="showMixedScenariosOnly(this);">Mixed (1)</button>
+        <button type="button" role="radio" class="pill" data-filter="all" aria-checked="true" tabindex="0">All (6)</button>
+          <button type="button" role="radio" class="pill" data-filter="succeeded" aria-checked="false" tabindex="-1">Passed (2)</button>
+          <button type="button" role="radio" class="pill" data-filter="failed" aria-checked="false" tabindex="-1">Failed (1)</button>
+          <button type="button" role="radio" class="pill" data-filter="skipped" aria-checked="false" tabindex="-1">Skipped (1)</button>
+          <button type="button" role="radio" class="pill" data-filter="mixed" aria-checked="false" tabindex="-1">Mixed (1)</button>
+          <button type="button" role="radio" class="pill" data-filter="expected-failure" aria-checked="false" tabindex="-1">Expected failures (1)</button>
       </div>
-      <div class="view-toolbar-trailing"></div>
+      <p class="view-toolbar-count" aria-live="polite">9 executions</p>
+      <div class="view-toolbar-trailing">
+        <input type="search" class="view-filter tests-filter" placeholder="Filter" aria-label="Filter tests by name" autocomplete="off">
+      </div>
     </div>
     <ul class="table-header">
       <li>Test</li>
@@ -2104,6 +2171,80 @@
 </div>
       </div>
   </div>  <img class="screenshot-tail" src="screenshot.png" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
+  <div class="test-summary succeeded" data-runs="3">
+      <p class="list-item">
+          <span class="icon drop-down-icon" onclick="toggle(this, '0b826fba7727d72ce840258316314d96')"></span>
+          <span class="icon test-result-icon"></span>
+          <span class="row-name">testParameterized()</span>
+            <span class="row-note row-arguments">3 arguments</span>
+          <span class="row-duration">(1.50s)</span>
+      </p>
+      <div id="activities-0b826fba7727d72ce840258316314d96" class="activities">
+          <img class="screenshot-flow" src="screenshot.png" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
+          <div class="activity  no-drop-down">
+  <p class="list-item">
+    <span style="margin-left: 38px" class="padding"></span>
+    <span class="icon drop-down-icon" onclick="toggle(this, 'cfb3666c0d21f7c6c49701e17aa04b6a')"></span>
+    <span class="row-name">Start Test</span>
+    <span class="icon paperclip-icon" style="display: none"></span>
+  </p>
+  <div id="attachments-cfb3666c0d21f7c6c49701e17aa04b6a" class="attachments">
+      
+  </div>
+  <div id="activities-cfb3666c0d21f7c6c49701e17aa04b6a" class="sub-activities">
+      
+  </div>
+</div><div class="activity  ">
+  <p class="list-item">
+    <span style="margin-left: 20px" class="padding"></span>
+    <span class="icon drop-down-icon" onclick="toggle(this, '7f68515b542c73fa411846f548f3bc9f')"></span>
+    <span class="row-name">Attachments</span>
+    <span class="icon paperclip-icon" style="display: inline-block"></span>
+  </p>
+  <div id="attachments-7f68515b542c73fa411846f548f3bc9f" class="attachments">
+      <p class="attachment list-item">
+  <span class="icon screenshot-icon" style="margin-left: 36px"></span>
+  <span class="row-name">Screenshot</span>
+  <button type="button" class="preview-button" aria-label="Preview attachment" data-kind="screenshot" data="screenshot.png" onclick="openAttachment(this)"><span class="icon preview-icon" aria-hidden="true"></span></button>
+  <img class="screenshot" src="screenshot.png" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
+</p><p class="attachment list-item">
+  <span class="icon text-icon" style="margin-left: 36px"></span>
+  <span class="row-name">Log</span>
+  <button type="button" class="preview-button" aria-label="Preview attachment" data-kind="text" data="FileName with DoubleQuote&quot;SingleQuote&apos;LessThan&lt;GreaterThan&gt;Ampersand&amp;.txt" onclick="openAttachment(this)"><span class="icon preview-icon" aria-hidden="true"></span></button>
+</p>
+  </div>
+  <div id="activities-7f68515b542c73fa411846f548f3bc9f" class="sub-activities">
+      
+  </div>
+</div><div class="activity  ">
+  <p class="list-item">
+    <span style="margin-left: 20px" class="padding"></span>
+    <span class="icon drop-down-icon" onclick="toggle(this, '3fe83024c6f1adf7c5d6d4825883b168')"></span>
+    <span class="row-name">Nested</span>
+    <span class="icon paperclip-icon" style="display: none"></span>
+  </p>
+  <div id="attachments-3fe83024c6f1adf7c5d6d4825883b168" class="attachments">
+      
+  </div>
+  <div id="activities-3fe83024c6f1adf7c5d6d4825883b168" class="sub-activities">
+      <div class="activity  no-drop-down">
+  <p class="list-item">
+    <span style="margin-left: 48px" class="padding"></span>
+    <span class="icon drop-down-icon" onclick="toggle(this, '1ef9e05a2a4d97f6be64befb9b950dfc')"></span>
+    <span class="row-name">Inner step</span>
+    <span class="icon paperclip-icon" style="display: none"></span>
+  </p>
+  <div id="attachments-1ef9e05a2a4d97f6be64befb9b950dfc" class="attachments">
+      
+  </div>
+  <div id="activities-1ef9e05a2a4d97f6be64befb9b950dfc" class="sub-activities">
+      
+  </div>
+</div>
+  </div>
+</div>
+      </div>
+  </div>  <img class="screenshot-tail" src="screenshot.png" id="screenshot-screenshot.png" alt="Screenshot" loading="lazy"/>
   <div class="test-summary succeeded">
       <p class="list-item">
           <span class="icon drop-down-icon" onclick="toggle(this, '16170791d4b96668f53ace117678c387')"></span>
@@ -2176,7 +2317,7 @@
   </div>
 </div>
       </div>
-  </div>  <div class="test-summary mixed">
+  </div>  <div class="test-summary mixed" data-runs="2">
       <p class="list-item">
           <span class="icon drop-down-icon dropped" onclick="toggle(this, '751413da1b48c31cffea0e4c31cc99bc')"></span>
           <span class="icon test-result-icon"></span>
@@ -2324,10 +2465,14 @@
       <section class="view" id="view-logs" role="tabpanel" aria-labelledby="tab-logs">
         <div class="run-view" id="logs_42230e298d9d9e832714ebad20e680c6">
     <div class="view-toolbar">
-      <p class="view-toolbar-label">All Messages</p>
-      <div class="view-toolbar-trailing"></div>
+      <p class="view-toolbar-count" aria-live="polite">2 lines</p>
+      <div class="view-toolbar-trailing">
+        <input type="search" class="view-filter log-filter" placeholder="Filter" aria-label="Filter log lines" autocomplete="off">
+      </div>
     </div>
-    <iframe class="logs-iframe" src="20264b52b84cb3e65c5ff06be4bb344d.log" title="Run log" loading="lazy"></iframe>
+    <pre class="log-body" tabindex="0">Synthetic run log line one
+Synthetic run log line two
+</pre>
   </div>
       </section>
     </main>
@@ -2371,11 +2516,6 @@
   function activeTree() {
     var view = activeTestsView();
     return view ? view.querySelector('.tests') : null;
-  }
-
-  function inActiveTests(selector) {
-    var view = activeTestsView();
-    return view ? view.querySelectorAll(selector) : [];
   }
 
   // ---- Roving focus --------------------------------------------------
@@ -2849,26 +2989,109 @@
     }
   }
 
-  // ---- Status filters ------------------------------------------------
+  // ---- Filters (#439, A3b; #460) -------------------------------------
   //
-  // The five functions A3b upgrades, unchanged in what they do. What
-  // changed is only what they are scoped to: `.run.active` named the shell's
-  // per-run pane, which the per-view split replaced with one slice per view.
-  // Everything downstream of the scope — which classes are shown, which are
-  // hidden, and the group-collapsing pass — is the same code it was.
+  // What A3a left here was five functions, one per pill, each naming the
+  // four row classes it shows or hides. That shape is why #460 existed: an
+  // expected failure carries none of those four classes, so no function
+  // mentioned it, so "Passed" left it on screen and "All" — which sets
+  // `display: block` on the four it knows — left it at whatever it already
+  // was. The group pass below then read it as hidden, and a suite whose every
+  // test was an expected failure disappeared from a report the moment the
+  // reader touched any filter, including "All".
+  //
+  // One function replaces the five. A row is shown when it matches *both* of
+  // the view's filters, and the status one is a class comparison against
+  // `data-filter` rather than a list of classes written out here — so a
+  // status added to `Status` gets a pill and gets filtered, with nothing in
+  // this file to update. `unknown` is filtered today for exactly that
+  // reason, having had the same gap as `expectedFailure` and no issue.
+  //
+  // State lives on the view, not in a variable: a report holds one tests
+  // slice per destination and each keeps its own filters, so switching
+  // destination and switching back does not silently reset what the reader
+  // chose.
 
-  function setDisplayToElementsWithSelector(sel, display) {
-    [].forEach.call(inActiveTests(sel), function (el) {
-      el.style.display = display;
+  function statusOf(view) {
+    return view.getAttribute('data-filter-status') || 'all';
+  }
+
+  function queryOf(view) {
+    return view.getAttribute('data-filter-text') || '';
+  }
+
+  // What the filter treats as a row, which is what the *report* treats as a
+  // test: every `.test-summary`, plus a suite heading with nothing inside
+  // it. `Run.allTests` flattens the tree to its leaves and a childless group
+  // is one of them — the shape a crashed target leaves behind, which
+  // `TruncationFaultTests` is built out of — so it is counted in the pills
+  // and has to be filtered by them. It also had the same defect #460 names:
+  // the group pass below skips a group with no rows in it, so before this
+  // nothing could hide one whatever the reader chose.
+  function filterableRows(view) {
+    var rows = Array.prototype.slice.call(
+      view.querySelectorAll('.test-summary, .test-summary-group')
+    );
+    return rows.filter(function (row) {
+      return !row.classList.contains('test-summary-group')
+        || row.querySelector('.test-summary, .test-summary-group') === null;
     });
   }
 
-  function hideElementsWithSelector(sel) {
-    setDisplayToElementsWithSelector(sel, 'none');
+  // A group's visibility is otherwise derived from its rows, below.
+  function rowMatches(row, status, query) {
+    if (status !== 'all' && !row.classList.contains(status)) {
+      return false;
+    }
+    if (!query) {
+      return true;
+    }
+    var name = row.querySelector('.row-name');
+    return !!name && name.textContent.toLowerCase().indexOf(query) >= 0;
   }
 
-  function showElementsWithSelector(sel) {
-    setDisplayToElementsWithSelector(sel, 'block');
+  // How many times the run executed what a row stands for: the `data-runs`
+  // the template writes when a test was parameterized or repeated, and 1
+  // otherwise — which is why the attribute is absent on almost every row.
+  function executionsOf(row) {
+    return parseInt(row.getAttribute('data-runs'), 10) || 1;
+  }
+
+  function applyTestFilters(view) {
+    if (!view) {
+      return;
+    }
+    var status = statusOf(view),
+        query = queryOf(view),
+        rows = filterableRows(view),
+        executions = 0;
+    for (var i = 0; i < rows.length; i++) {
+      var shown = rowMatches(rows[i], status, query);
+      rows[i].style.display = shown ? 'block' : 'none';
+      // A test's tail screenshot is emitted *between* rows rather than
+      // inside one (A2), so it is a sibling the row's own `display` does not
+      // reach. Left behind, a filtered-out test leaves its screenshot in the
+      // tree with no row to belong to — a 200px picture of a test the reader
+      // asked not to see.
+      var tail = rows[i].previousElementSibling;
+      if (tail && tail.classList.contains('screenshot-tail')) {
+        tail.style.display = shown ? 'block' : 'none';
+      }
+      if (shown) {
+        executions += executionsOf(rows[i]);
+      }
+    }
+    hideSummaryGroupsIfNeeded(view);
+    setCount(view, executions === 1 ? '1 execution' : executions + ' executions');
+  }
+
+  // The toolbar figure this view answers with. One writer, so the rendered
+  // value and every recomputation of it are the same sentence.
+  function setCount(view, text) {
+    var count = view.querySelector('.view-toolbar-count');
+    if (count) {
+      count.textContent = text;
+    }
   }
 
   // The chosen filter, as an ARIA fact rather than a class: these are
@@ -2883,81 +3106,124 @@
     setRovingTabStop(pills, el);
   }
 
-  function showAllScenarios(el) {
-    selectedElement(el);
-    showElementsWithSelector('.test-summary.succeeded');
-    showElementsWithSelector('.test-summary.skipped');
-    showElementsWithSelector('.test-summary.failed');
-    showElementsWithSelector('.test-summary.mixed');
-    hideSummaryGroupsIfNeeded();
+  function chooseStatus(pill) {
+    var view = pill.closest('.run-view');
+    if (!view) {
+      return;
+    }
+    selectedElement(pill);
+    view.setAttribute('data-filter-status', pill.getAttribute('data-filter') || 'all');
+    applyTestFilters(view);
   }
 
-  function showSuccessfulScenariosOnly(el) {
-    selectedElement(el);
-    showElementsWithSelector('.test-summary.succeeded');
-    hideElementsWithSelector('.test-summary.skipped');
-    hideElementsWithSelector('.test-summary.failed');
-    hideElementsWithSelector('.test-summary.mixed');
-    hideSummaryGroupsIfNeeded();
-  }
-
-  function showSkippedScenariosOnly(el) {
-    selectedElement(el);
-    hideElementsWithSelector('.test-summary.succeeded');
-    showElementsWithSelector('.test-summary.skipped');
-    hideElementsWithSelector('.test-summary.failed');
-    hideElementsWithSelector('.test-summary.mixed');
-    hideSummaryGroupsIfNeeded();
-  }
-
-  function showFailedScenariosOnly(el) {
-    selectedElement(el);
-    hideElementsWithSelector('.test-summary.succeeded');
-    hideElementsWithSelector('.test-summary.skipped');
-    showElementsWithSelector('.test-summary.failed');
-    hideElementsWithSelector('.test-summary.mixed');
-    hideSummaryGroupsIfNeeded();
-  }
-
-  function showMixedScenariosOnly(el) {
-    selectedElement(el);
-    hideElementsWithSelector('.test-summary.succeeded');
-    hideElementsWithSelector('.test-summary.skipped');
-    hideElementsWithSelector('.test-summary.failed');
-    showElementsWithSelector('.test-summary.mixed');
-    hideSummaryGroupsIfNeeded();
-  }
-
-  function hideSummaryGroupsIfNeeded() {
-    var testSummaryGroups = Array.prototype.slice.call(
-      inActiveTests('.test-summary-group')
+  // A suite is shown when anything under it is, and the walk is bottom-up so
+  // a parent reads children that have already been decided.
+  //
+  // The pass this replaces bailed out on any group holding a sub-group
+  // (`testSummaryGroupChildren.length > 0`), so the legacy backend's two
+  // wrapper levels — "Selected tests" and "<target>.xctest", which hold
+  // only other groups — were never hidden by anything. A filter that
+  // selected two rows left them under three empty headings. Deciding
+  // deepest-first is what makes one rule cover both cases: `querySelectorAll`
+  // yields document order, and an ancestor always precedes its descendants
+  // in it, so iterating backwards visits every child before its parent.
+  //
+  // A group with no rows and no sub-groups is skipped, not because it cannot
+  // be decided but because it already has been: `applyTestFilters` treats a
+  // childless suite as a row, since that is what `Run.allTests` counts it as.
+  function hideSummaryGroupsIfNeeded(view) {
+    var groups = Array.prototype.slice.call(
+      view.querySelectorAll('.test-summary-group')
     );
-    for (var i = 0; i < testSummaryGroups.length; i++) {
-        var testSummaryGroup = testSummaryGroups[i];
-        var children = Array.prototype.slice.call(testSummaryGroup.children);
-        var testSummaryChildren = children.filter(function(a) { return a.classList.contains('test-summary'); });
-        var testSummaryGroupChildren = children.filter(function(a) { return a.classList.contains('test-summary-group'); });
-        if (testSummaryChildren == 0 || testSummaryGroupChildren.length > 0) {
-          continue;
-        }
-
-        if (testSummaryChildren.filter(function(a) { return a.style.display == 'block' }).length == 0) {
-          testSummaryGroup.style.display = 'none';
-        } else {
-          testSummaryGroup.style.display = 'block';
-        }
+    for (var i = groups.length - 1; i >= 0; i--) {
+      var group = groups[i];
+      var children = Array.prototype.slice.call(group.children).filter(function (child) {
+        return child.classList.contains('test-summary')
+          || child.classList.contains('test-summary-group');
+      });
+      if (children.length === 0) {
+        continue;
+      }
+      var anyShown = children.some(function (child) {
+        return child.style.display !== 'none';
+      });
+      group.style.display = anyShown ? 'block' : 'none';
     }
   }
 
+  var filterPills = document.querySelectorAll('.filter-pills [role="radio"]');
+  for (var fp = 0; fp < filterPills.length; fp++) {
+    filterPills[fp].addEventListener('click', function (e) {
+      chooseStatus(e.currentTarget);
+    }, false);
+  }
+
   // Arrow keys inside a radiogroup both move focus and choose, which is the
-  // behaviour a native radio group has. The pill's own `onclick` is the one
-  // definition of what choosing does, so the handler dispatches to it rather
-  // than restating the mapping from pill to filter.
+  // behaviour a native radio group has.
   var filterGroups = document.querySelectorAll('.filter-pills');
   for (var f = 0; f < filterGroups.length; f++) {
-    rovingGroup(filterGroups[f], '[role="radio"]', function (pill) {
-      pill.onclick();
-    });
+    rovingGroup(filterGroups[f], '[role="radio"]', chooseStatus);
+  }
+
+  // The name filter. Composes with the pills rather than replacing them:
+  // both are read by `applyTestFilters`, so "Failed" and "one" together
+  // mean the failing tests whose names contain "one", which is what a
+  // reader who set both is asking for.
+  var testFilters = document.querySelectorAll('.tests-filter');
+  for (var tf = 0; tf < testFilters.length; tf++) {
+    testFilters[tf].addEventListener('input', function (e) {
+      var view = e.currentTarget.closest('.run-view');
+      if (!view) {
+        return;
+      }
+      view.setAttribute('data-filter-text', e.currentTarget.value.trim().toLowerCase());
+      applyTestFilters(view);
+    }, false);
+  }
+
+  // ---- The log filter ------------------------------------------------
+  //
+  // The log is one text document, so the only filter its content supports is
+  // over its lines — which is the control Xcode's own Log view puts in this
+  // same corner. It is possible at all because A3b renders the log in the
+  // page: behind the `iframe` it replaces, the log was a foreign origin and
+  // nothing here could have read a line of it.
+  //
+  // The lines are split once, on first use, and kept on the element. The
+  // `<pre>` stays a single text node either way — a line per element would
+  // be one node per line of a log that can run to six figures.
+  var logFilters = document.querySelectorAll('.log-filter');
+  for (var lf = 0; lf < logFilters.length; lf++) {
+    logFilters[lf].addEventListener('input', function (e) {
+      var view = e.currentTarget.closest('.run-view'),
+          body = view && view.querySelector('.log-body');
+      if (!body) {
+        return;
+      }
+      if (!body.logLines) {
+        var text = body.textContent;
+        // A trailing newline ends the last line rather than starting an
+        // empty one, which is what the rendered count already assumes.
+        if (text.charAt(text.length - 1) === '\n') {
+          text = text.slice(0, -1);
+        }
+        body.logLines = text === '' ? [] : text.split('\n');
+      }
+      var query = e.currentTarget.value.trim().toLowerCase(),
+          lines = body.logLines,
+          kept = query
+            ? lines.filter(function (line) {
+                return line.toLowerCase().indexOf(query) >= 0;
+              })
+            : lines;
+      body.textContent = kept.join('\n');
+      setCount(
+        view,
+        query
+          ? kept.length + ' of ' + lines.length + (lines.length === 1 ? ' line' : ' lines')
+          : lines.length + (lines.length === 1 ? ' line' : ' lines')
+      );
+    }, false);
   }
 
   // ---- Boot ----------------------------------------------------------
@@ -3006,13 +3272,19 @@
 
     activateRunContaining(row);
 
-    // The filter writes `display: none` onto the element itself, and its
-    // group as well. Clearing both un-hides this one row without resetting
-    // the filter the reader chose.
+    // The filter writes `display: none` onto the element itself and onto
+    // every suite above it that the row was the last visible thing in.
+    // Clearing the whole chain un-hides this one row without resetting the
+    // filter the reader chose — the nearest suite alone is not enough, since
+    // A3b's group pass hides a wrapper whose every child went, which the
+    // pass it replaces never did.
     row.style.display = 'block';
-    var group = row.closest('.test-summary-group');
-    if (group) {
-      group.style.display = 'block';
+    var ancestor = row.parentElement;
+    while (ancestor && !ancestor.classList.contains('tests')) {
+      if (ancestor.classList.contains('test-summary-group')) {
+        ancestor.style.display = 'block';
+      }
+      ancestor = ancestor.parentElement;
     }
 
     disclosure.style.display = 'block';

--- a/Tests/XCTestHTMLReportTests/Snapshots/index.html
+++ b/Tests/XCTestHTMLReportTests/Snapshots/index.html
@@ -146,6 +146,13 @@
        Safari versions that predate it, then named fallbacks, and a
        generic family last so the chain can always terminate. */
     --font-family-base: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Helvetica, Arial, sans-serif;
+    /* The run log is the one thing in the report that is a *document* rather
+       than a layout, and its structure is columns of `-------- title
+       --------` rules and indentation — which only a monospace face keeps
+       aligned. `ui-monospace` first, so it is the platform's own coding
+       face where there is one, with the named fallbacks for browsers that
+       do not know the generic yet (#439, A3b). */
+    --font-family-mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
     --font-size-xs: 11px;
     --font-size-sm: 12px;
     --font-size-md: 13px;
@@ -780,7 +787,7 @@
     overflow: auto;
     background-color: var(--color-surface);
     color: var(--color-text-primary);
-    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-family: var(--font-family-mono);
     font-size: var(--font-size-xs);
     line-height: 1.5;
     white-space: pre-wrap;

--- a/Tests/XCTestHTMLReportTests/Snapshots/index.html
+++ b/Tests/XCTestHTMLReportTests/Snapshots/index.html
@@ -3039,6 +3039,16 @@ Synthetic run log line two
   }
 
   // A group's visibility is otherwise derived from its rows, below.
+  //
+  // The name is matched against the row *and every suite above it*, because
+  // a filter over a tree that only ever reads its leaves is one a reader
+  // finds out about the hard way: typing the name of a suite they can see
+  // would empty the pane. Matching an ancestor keeps that suite and the
+  // tests inside it, which is what the same query does in Xcode's outline.
+  //
+  // The status is a leaf question either way — a suite's own status is
+  // folded from its children, so filtering on it would put rows of every
+  // outcome under a heading claiming one.
   function rowMatches(row, status, query) {
     if (status !== 'all' && !row.classList.contains(status)) {
       return false;
@@ -3046,8 +3056,21 @@ Synthetic run log line two
     if (!query) {
       return true;
     }
-    var name = row.querySelector('.row-name');
-    return !!name && name.textContent.toLowerCase().indexOf(query) >= 0;
+    var node = row;
+    while (node && !node.classList.contains('tests')) {
+      if (node.classList.contains('test-summary')
+        || node.classList.contains('test-summary-group')) {
+        // The first `.row-name` inside a row is its own: a suite's heading
+        // precedes its children, and a retried test's precedes its
+        // iterations.
+        var name = node.querySelector('.row-name');
+        if (name && name.textContent.toLowerCase().indexOf(query) >= 0) {
+          return true;
+        }
+      }
+      node = node.parentElement;
+    }
+    return false;
   }
 
   // How many times the run executed what a row stands for: the `data-runs`

--- a/Tests/XCTestHTMLReportTests/Snapshots/index.html
+++ b/Tests/XCTestHTMLReportTests/Snapshots/index.html
@@ -3093,8 +3093,7 @@ Synthetic run log line two
     }
     var status = statusOf(view),
         query = queryOf(view),
-        rows = filterableRows(view),
-        executions = 0;
+        rows = filterableRows(view);
     for (var i = 0; i < rows.length; i++) {
       var shown = rowMatches(rows[i], status, query);
       rows[i].style.display = shown ? 'block' : 'none';
@@ -3113,11 +3112,27 @@ Synthetic run log line two
         tail.style.display = shown ? 'block' : 'none';
         tail = tail.previousElementSibling;
       }
-      if (shown) {
+    }
+    hideSummaryGroupsIfNeeded(view);
+    countExecutionsOnScreen(view);
+  }
+
+  // Counted off the rows rather than accumulated while deciding them, so
+  // that anything which changes what is on screen can restate the figure by
+  // calling this — the digest jump reveals a row the filter hid, and a count
+  // that only the filter could write would keep announcing the filter's
+  // number at a pane that no longer holds it.
+  function countExecutionsOnScreen(view) {
+    if (!view) {
+      return;
+    }
+    var rows = filterableRows(view),
+        executions = 0;
+    for (var i = 0; i < rows.length; i++) {
+      if (rows[i].style.display !== 'none') {
         executions += executionsOf(rows[i]);
       }
     }
-    hideSummaryGroupsIfNeeded(view);
     setCount(view, executions === 1 ? '1 execution' : executions + ' executions');
   }
 
@@ -3322,6 +3337,12 @@ Synthetic run log line two
       }
       ancestor = ancestor.parentElement;
     }
+
+    // A row appearing is a change to what the pane holds, so the toolbar
+    // restates its figure through the same writer the filter uses. The count
+    // is `aria-live`: silence here is a reader being told nothing while a
+    // test they did not filter for arrives on screen.
+    countExecutionsOnScreen(row.closest('.run-view'));
 
     disclosure.style.display = 'block';
     var chevron = row.querySelector('.drop-down-icon');

--- a/Tests/XCTestHTMLReportTests/StatusAggregationTests.swift
+++ b/Tests/XCTestHTMLReportTests/StatusAggregationTests.swift
@@ -24,6 +24,7 @@ final class StatusAggregationTests: XCTestCase {
                         name: "test\(index)()",
                         identifier: "Suite/test\(index)()",
                         arguments: [],
+                        executionCount: 1,
                         iterations: [ParsedIteration(
                             iterationNumber: nil,
                             status: status,

--- a/Tests/XCTestHTMLReportTests/SummarySeamTests.swift
+++ b/Tests/XCTestHTMLReportTests/SummarySeamTests.swift
@@ -22,31 +22,37 @@ final class SummarySeamTests: XCTestCase {
         XCTAssertTrue(html.hasPrefix("<!doctype html>"), "must render the index template")
         XCTAssertTrue(html.contains("SyntheticSuite"), "must render the fixture's group")
         XCTAssertTrue(html.contains(":root"), "must carry the token layer")
-        // `class`, not `id`: A3a (#439) gave every run its own log view, so
-        // the frame's `id="logs-iframe"` — which every run used to emit,
-        // duplicating it once per bundle — became a per-destination id and the
-        // class is what identifies the frame across them.
+        // A3b (#439) renders the log in the page, so the check that its
+        // reference resolved is that the `<pre>` holds something rather than
+        // that an iframe has a non-empty `src`. Same assertion, against the
+        // element the log actually lands in now.
         XCTAssertFalse(
-            html.contains("class=\"logs-iframe\" src=\"\""),
-            "the run's log reference must resolve to something, not degrade to an empty iframe"
+            html.contains("<pre class=\"log-body\" tabindex=\"0\"></pre>"),
+            "the run's log reference must resolve to something, not degrade to an empty pane"
         )
     }
 
     /// Distinct from `testRendersAFullPageWithoutAnXcresult`: that test proves
-    /// a log *reference* made it into the page under `.linking`, where the
-    /// iframe source is only a relative file name. This proves the log
-    /// *bytes* the fixture provides genuinely reach the rendered HTML, which
-    /// requires `.inline`, the one mode where `RenderingContent.data` embeds
-    /// them directly as the iframe's `data:` URI rather than pointing at a
-    /// file nothing in this synthetic pipeline ever writes.
-    func testInlineRenderingEmbedsTheActualLogBytes() {
-        let html = summary(renderingMode: .inline).generatedHtmlReport()
-        let expectedDataURI = "data:text/plain;base64,"
-            + StubPayloadProvider.logText.base64EncodedString()
-        XCTAssertTrue(
-            html.contains(expectedDataURI),
-            "the fixture's log bytes must be embedded verbatim, not merely referenced"
-        )
+    /// the log pane is not empty. This proves the *bytes* the fixture provides
+    /// are the bytes on the page.
+    ///
+    /// Asserted in **both** modes since A3b (#439). It used to be inline-only,
+    /// because inline was the one mode whose iframe carried the log's content
+    /// — a `data:` URI — while linking mode's carried a file name and nothing
+    /// in this synthetic pipeline ever wrote the file. Rendering the log in the
+    /// page removes that asymmetry: the same text reaches the same element
+    /// either way, and the mode now decides only whether a `.log` file is
+    /// written beside the report.
+    func testBothModesEmbedTheActualLogBytes() {
+        let expected = String(data: StubPayloadProvider.logText, encoding: .utf8) ?? ""
+        for mode in [Summary.RenderingMode.inline, .linking] {
+            let html = summary(renderingMode: mode).generatedHtmlReport()
+            XCTAssertTrue(
+                html.contains("<pre class=\"log-body\" tabindex=\"0\">\(expected)</pre>"),
+                "\(mode): the fixture's log bytes must be on the page verbatim, "
+                    + "not merely referenced"
+            )
+        }
     }
 
     func testRendersNoFaults() {

--- a/Tests/XCTestHTMLReportTests/Synthetic/SyntheticResult.swift
+++ b/Tests/XCTestHTMLReportTests/Synthetic/SyntheticResult.swift
@@ -84,12 +84,19 @@ enum SyntheticResult {
 
     static func testCase(
         name: String,
-        iterations: [ParsedIteration]
+        iterations: [ParsedIteration],
+        executionCount: Int = 1
     ) -> ParsedTestCase {
         ParsedTestCase(
             name: name,
             identifier: "Synthetic/\(name)",
+            // Left empty even for the parameterized case below: only the
+            // modern format names argument *values*, so a synthetic fixture
+            // that filled them would be modelling a shape the legacy backend
+            // cannot produce. The count is the part both backends carry, and
+            // it is what the report renders.
             arguments: [],
+            executionCount: max(executionCount, iterations.count),
             iterations: iterations
         )
     }
@@ -154,6 +161,21 @@ enum SyntheticResult {
                         iteration(number: 1, status: .failed, activities: [failureActivity]),
                         iteration(number: 2, status: .passed, activities: standardActivities),
                     ]
+                )),
+                // Three executions, one row — the parameterized shape (#439,
+                // A3b). Added so the synthetic render exercises the second of
+                // the toolbar's two numbers: without it every fixture has as
+                // many executions as tests, the counts agree by accident, and
+                // both the goldens and the browser suite would pass on a build
+                // that dropped `executionCount` entirely.
+                .testCase(testCase(
+                    name: "testParameterized()",
+                    iterations: [iteration(
+                        number: nil,
+                        status: .passed,
+                        activities: standardActivities
+                    )],
+                    executionCount: 3
                 )),
             ]
         )

--- a/Tests/XCTestHTMLReportTests/TruncationFaultTests.swift
+++ b/Tests/XCTestHTMLReportTests/TruncationFaultTests.swift
@@ -54,6 +54,7 @@ final class TruncationFaultTests: XCTestCase {
             name: name,
             identifier: "Synthetic/\(name)",
             arguments: [],
+            executionCount: 1,
             iterations: [ParsedIteration(
                 iterationNumber: nil, status: .passed, duration: 1, activities: []
             )]

--- a/visual/tests/a11y.spec.ts
+++ b/visual/tests/a11y.spec.ts
@@ -126,9 +126,38 @@ const states: [string, (page: import('@playwright/test').Page) => Promise<void>]
   ['the Logs view', async (page) => {
     await page.locator('#tab-logs').click();
     await expect(
-      page.locator('#view-logs .logs-iframe'),
+      page.locator('#view-logs .run-view.active .log-body'),
       'the log must be showing, or this state is the Tests view again',
     ).toBeVisible();
+  }],
+  // A3b's controls are in the layout from the start, so the opening state
+  // already analyses them. What it does not analyse is the page they *produce*:
+  // a tree narrowed to one bucket and one name, where rows and whole suites
+  // carry `display: none` and the live count has been rewritten by script.
+  // That is a different document, and axe only ever sees the one in front of
+  // it.
+  ['the Tests view, filtered', async (page) => {
+    await page.locator('.pill', { hasText: /^Expected failures \(\d+\)$/ }).click();
+    await page.locator('#view-tests .run-view.active .tests-filter').fill('test');
+    await expect(
+      page.locator('#view-tests .run-view.active .test-summary:visible'),
+      'the filters must have left rows showing, or this state is an empty pane',
+    ).not.toHaveCount(0);
+    const [shown, total] = await page.evaluate(() => {
+      const rows = [...document.querySelectorAll('#view-tests .run-view.active .test-summary')];
+      return [rows.filter((r) => (r as HTMLElement).offsetParent !== null).length, rows.length];
+    });
+    expect(shown, 'and must have hidden some, or nothing was filtered').toBeLessThan(total);
+  }],
+  ['the Logs view, filtered', async (page) => {
+    await page.locator('#tab-logs').click();
+    const body = page.locator('#view-logs .run-view.active .log-body');
+    const before = (await body.textContent())!.length;
+    await page.locator('#view-logs .run-view.active .log-filter').fill('line two');
+    expect(
+      (await body.textContent())!.length,
+      'the filter must have narrowed the log, or this state is the log entire',
+    ).toBeLessThan(before);
   }],
 ];
 

--- a/visual/tests/behaviour.spec.ts
+++ b/visual/tests/behaviour.spec.ts
@@ -178,25 +178,44 @@ test('a suite goes when its last visible row does', async ({ page }) => {
 // A test's tail screenshot is emitted between rows rather than inside one
 // (A2), which put it outside everything the filters ever touched: a hidden
 // test left a 200px picture behind in the tree with no row to belong to.
-test('a filtered-out test takes its screenshot with it', async ({ page }) => {
+test('a filtered-out test takes its screenshots with it', async ({ page }) => {
   await page.goto(reportURL);
 
   const scope = '#view-tests .run-view.active';
   const tails = page.locator(`${scope} img.screenshot-tail`);
-  expect(await tails.count(), 'the fixture must render tail screenshots')
-    .toBeGreaterThan(0);
-  await expect(tails.first()).toBeVisible();
+  const visibleTails = () => page.locator(`${scope} img.screenshot-tail:visible`).count();
+
+  const total = await tails.count();
+  expect(total, 'the fixture must render tail screenshots').toBeGreaterThan(0);
+  expect(await visibleTails()).toBe(total);
+
+  // The precondition that makes this more than a one-sibling check:
+  // `TestScreenshotFlow` emits a test's *last three* screenshots, so a test
+  // with several is preceded by several, and a fix that walked back one
+  // sibling would leave the outer ones on screen. The fixture must contain
+  // such a run or this gate cannot see that difference.
+  const longestRun = await page.evaluate((selector) => {
+    const rows = [...document.querySelectorAll(`${selector} .test-summary`)];
+    return Math.max(...rows.map((row) => {
+      let n = 0;
+      let sibling = row.previousElementSibling;
+      while (sibling?.classList.contains('screenshot-tail')) { n++; sibling = sibling.previousElementSibling; }
+      return n;
+    }));
+  }, scope);
+  expect(longestRun, 'some row must carry more than one tail screenshot')
+    .toBeGreaterThan(1);
 
   // Skipped, because the fixture's screenshots hang off tests that passed or
   // failed — so this hides every row that owns one.
   await page.locator('.pill', { hasText: /^Skipped \(\d+\)$/ }).click();
-  await expect(
-    tails.first(),
-    'the screenshot belongs to a row the reader asked not to see',
-  ).toBeHidden();
+  expect(
+    await visibleTails(),
+    'every screenshot belongs to a row the reader asked not to see',
+  ).toBe(0);
 
   await page.locator('.pill', { hasText: /^All \(\d+\)$/ }).click();
-  await expect(tails.first(), 'and comes back with it').toBeVisible();
+  expect(await visibleTails(), 'and they all come back').toBe(total);
 });
 
 // Xcode's second number, and the reason it is `aria-live`: it answers to the

--- a/visual/tests/behaviour.spec.ts
+++ b/visual/tests/behaviour.spec.ts
@@ -315,6 +315,48 @@ test('a digest jump reveals a row the filter has hidden', async ({ page }) => {
   await expect(row, 'the jump must reveal it anyway').toBeVisible();
 });
 
+// …and the toolbar has to say so. Revealing the row is half the answer: the
+// count beside the pills is `aria-live`, so it is the whole of the notice a
+// screen-reader user gets that the pane changed. Left at the figure the filter
+// wrote, it announces nothing while a row appears, and states a total the
+// reader beside them can disprove by counting the screen.
+//
+// Summed from the rows rather than pinned to a literal, because the claim is
+// an invariant — the toolbar answers for what is visible — and a literal would
+// be a second fixture-dependent number to maintain beside the pill labels.
+test('a digest jump keeps the executions count level with the rows on screen', async ({ page }) => {
+  await page.goto(reportURL);
+
+  const scope = '#view-tests .run-view.active';
+  const count = page.locator(`${scope} .view-toolbar-count`);
+  const label = (executions: number) =>
+    executions === 1 ? '1 execution' : `${executions} executions`;
+  const executionsOnScreen = () =>
+    page.locator(`${scope} .test-summary:visible`).evaluateAll((rows) =>
+      rows.reduce(
+        (sum, row) => sum + (parseInt(row.getAttribute('data-runs') ?? '', 10) || 1),
+        0,
+      ));
+
+  // "Passed" hides every failing row, which is every row the digest lists.
+  await page.locator('.pill', { hasText: /^Passed \(\d+\)$/ }).click();
+  const filtered = await executionsOnScreen();
+  expect(filtered, 'the fixture must leave passing rows on screen').toBeGreaterThan(0);
+  await expect(count, 'the filter states its own figure').toHaveText(label(filtered));
+
+  await page.locator('.digest-jump').first().click();
+
+  const revealed = await executionsOnScreen();
+  expect(
+    revealed,
+    'the jump must have put a row the filter hid back on screen, or this asserts nothing',
+  ).toBeGreaterThan(filtered);
+  await expect(
+    count,
+    'so the count must follow the pane, not the pills that no longer describe it',
+  ).toHaveText(label(revealed));
+});
+
 // The narrow layout's scroll lock (#439, A2). Below 700px `#container` is a
 // column, so the tree is sized on the block axis by a flex item's automatic
 // minimum — its content's height. Without `min-height: 0` the list grew to

--- a/visual/tests/behaviour.spec.ts
+++ b/visual/tests/behaviour.spec.ts
@@ -118,6 +118,34 @@ test('the name filter narrows the tree and composes with the pills', async ({ pa
   expect(passing, 'which still hides the failing rows').toBeLessThan(all);
 });
 
+// A filter over a tree has to read the tree, not only its leaves: typing the
+// name of a suite that is on screen must keep that suite and the tests inside
+// it, which is what the same query does in Xcode's outline. Matching leaves
+// alone would empty the pane on a name the reader can see.
+test('the name filter matches suite names too', async ({ page }) => {
+  await page.goto(reportURL);
+
+  const scope = '#view-tests .run-view.active';
+  const suite = page.locator(`${scope} .test-summary-group`).first();
+  const suiteName = (await suite.locator('.row-name').first().textContent())!.trim();
+  expect(suiteName.length, 'the fixture must name its suites').toBeGreaterThan(0);
+
+  const rowsUnderSuite = await suite.locator('.test-summary').count();
+  expect(rowsUnderSuite, 'and put tests inside them').toBeGreaterThan(0);
+  // The precondition that makes this a test of ancestry rather than of
+  // substring matching: no test row may carry the suite's name itself.
+  const selfNamed = await page.locator(`${scope} .test-summary > p.list-item > .row-name`)
+    .evaluateAll((els, name) => els.filter((el) => el.textContent!.includes(name)).length, suiteName);
+  expect(selfNamed, 'no row may match the suite name on its own').toBe(0);
+
+  await page.locator(`${scope} .tests-filter`).fill(suiteName);
+  await expect(suite, 'the suite the reader named must stay').toBeVisible();
+  expect(
+    await page.locator(`${scope} .test-summary:visible`).count(),
+    'and bring the tests inside it',
+  ).toBe(rowsUnderSuite);
+});
+
 // A suite whose every row a filter hid must go with them, however deep it is.
 // The pass A3b replaces bailed out on any group holding a sub-group, so the
 // legacy backend's two wrapper levels — "Selected tests" and

--- a/visual/tests/behaviour.spec.ts
+++ b/visual/tests/behaviour.spec.ts
@@ -19,6 +19,214 @@ test('the failed filter hides passing tests', async ({ page }) => {
   expect(failed, 'the fixture has failing tests, so some rows must remain').toBeGreaterThan(0);
 });
 
+// ---- #460: the expected-failure bucket ----------------------------------
+//
+// The defect, stated as the page saw it: an expected failure carries
+// `.expected-failure` and none of the four classes the old filters knew, so
+// "Passed" left it on screen — a reader asking for the tests that passed was
+// shown one that did not — and "All" could not put it back, because "All" only
+// ever set `display: block` on those same four. The group pass then read the
+// row as hidden, so a suite of nothing but expected failures vanished from the
+// tree the moment the reader touched any filter, "All" included.
+//
+// Three assertions, because each half fails differently: the pill exists, it
+// selects exactly its own rows, and every other pill hides them.
+test('expected failures have a filter of their own', async ({ page }) => {
+  await page.goto(reportURL);
+
+  const scope = '#view-tests .run-view.active';
+  const expected = page.locator(`${scope} .test-summary.expected-failure`);
+  const visible = () => page.locator(`${scope} .test-summary:visible`).count();
+
+  expect(
+    await expected.count(),
+    'the fixture must hold an expected failure, or nothing here is under test',
+  ).toBeGreaterThan(0);
+
+  const pill = page.locator('.pill', { hasText: /^Expected failures \(\d+\)$/ });
+  await expect(pill, '#460: the status must have a pill').toHaveCount(1);
+
+  await pill.click();
+  await expect(expected.first(), 'choosing it must show the expected failures').toBeVisible();
+  expect(
+    await visible(),
+    'and only those',
+  ).toBe(await expected.count());
+
+  // The half the old code could not do at all.
+  await page.locator('.pill', { hasText: /^Passed \(\d+\)$/ }).click();
+  await expect(
+    expected.first(),
+    'a reader asking for passing tests must not be shown an expected failure',
+  ).toBeHidden();
+
+  await page.locator('.pill', { hasText: /^All \(\d+\)$/ }).click();
+  await expect(expected.first(), 'and "All" must bring it back').toBeVisible();
+});
+
+// The consequence of the same defect one level up. A suite whose rows are all
+// expected failures had every row unfiltered and therefore, to the group pass,
+// no visible rows at all — so the suite was hidden while the reader was asking
+// to see everything.
+test('a suite of expected failures survives every filter that should show it', async ({ page }) => {
+  await page.goto(reportURL);
+
+  const groups = page.locator('#view-tests .run-view.active .test-summary-group');
+  const withExpected = groups.filter({ has: page.locator('.test-summary.expected-failure') });
+  expect(await withExpected.count(), 'the fixture must hold such a suite').toBeGreaterThan(0);
+
+  for (const label of [/^All \(\d+\)$/, /^Expected failures \(\d+\)$/]) {
+    await page.locator('.pill', { hasText: label }).click();
+    await expect(
+      withExpected.first(),
+      `the suite holding an expected failure must stay in the tree under ${label}`,
+    ).toBeVisible();
+  }
+});
+
+// ---- The name filter ----------------------------------------------------
+
+test('the name filter narrows the tree and composes with the pills', async ({ page }) => {
+  await page.goto(reportURL);
+
+  const scope = '#view-tests .run-view.active';
+  const visible = () => page.locator(`${scope} .test-summary:visible`).count();
+  const field = page.locator(`${scope} .tests-filter`);
+
+  const all = await visible();
+  expect(all, 'fixture must render test rows').toBeGreaterThan(1);
+
+  await field.fill('testFails');
+  const named = await visible();
+  expect(named, 'typing a name must hide the rows that do not match').toBeLessThan(all);
+  expect(named, 'and keep the one that does').toBeGreaterThan(0);
+  // `> p.list-item >`, because a retried row nests an iteration row inside it
+  // and every one of those carries a `.row-name` of its own.
+  await expect(page.locator(`${scope} .test-summary:visible > p.list-item > .row-name`))
+    .toHaveText([/testFails/]);
+
+  // Composed, not replaced: a status that excludes the named row must leave
+  // nothing, which is what "both filters apply" means and what a filter that
+  // reset its neighbour would get wrong.
+  await page.locator('.pill', { hasText: /^Passed \(\d+\)$/ }).click();
+  expect(await visible(), 'Passed + "testFails" selects nothing').toBe(0);
+
+  await field.fill('');
+  const passing = await visible();
+  expect(passing, 'clearing the field leaves the status filter in effect')
+    .toBeGreaterThan(0);
+  expect(passing, 'which still hides the failing rows').toBeLessThan(all);
+});
+
+// A suite whose every row a filter hid must go with them, however deep it is.
+// The pass A3b replaces bailed out on any group holding a sub-group, so the
+// legacy backend's two wrapper levels — "Selected tests" and
+// "<target>.xctest", which hold only other groups — survived every filter: two
+// selected rows sat under three empty headings.
+test('a suite goes when its last visible row does', async ({ page }) => {
+  await page.goto(reportURL);
+
+  const scope = '#view-tests .run-view.active';
+  const groups = page.locator(`${scope} .test-summary-group`);
+  expect(await groups.count(), 'the fixture must render suites').toBeGreaterThan(0);
+  await expect(groups.first()).toBeVisible();
+
+  // A name no test carries, so every row in every suite is hidden and no
+  // heading has anything left to head.
+  await page.locator(`${scope} .tests-filter`).fill('zzz-no-such-test');
+  await expect(
+    page.locator(`${scope} .test-summary:visible`),
+    'the precondition: the filter must have emptied the tree',
+  ).toHaveCount(0);
+  await expect(
+    page.locator(`${scope} .test-summary-group:visible`),
+    'so no suite heading may be left behind',
+  ).toHaveCount(0);
+
+  await page.locator(`${scope} .tests-filter`).fill('');
+  await expect(groups.first(), 'and they come back when the rows do').toBeVisible();
+});
+
+// A test's tail screenshot is emitted between rows rather than inside one
+// (A2), which put it outside everything the filters ever touched: a hidden
+// test left a 200px picture behind in the tree with no row to belong to.
+test('a filtered-out test takes its screenshot with it', async ({ page }) => {
+  await page.goto(reportURL);
+
+  const scope = '#view-tests .run-view.active';
+  const tails = page.locator(`${scope} img.screenshot-tail`);
+  expect(await tails.count(), 'the fixture must render tail screenshots')
+    .toBeGreaterThan(0);
+  await expect(tails.first()).toBeVisible();
+
+  // Skipped, because the fixture's screenshots hang off tests that passed or
+  // failed — so this hides every row that owns one.
+  await page.locator('.pill', { hasText: /^Skipped \(\d+\)$/ }).click();
+  await expect(
+    tails.first(),
+    'the screenshot belongs to a row the reader asked not to see',
+  ).toBeHidden();
+
+  await page.locator('.pill', { hasText: /^All \(\d+\)$/ }).click();
+  await expect(tails.first(), 'and comes back with it').toBeVisible();
+});
+
+// Xcode's second number, and the reason it is `aria-live`: it answers to the
+// filter, so a reader who cannot see the tree still learns what changed.
+test('the executions count answers to the filters', async ({ page }) => {
+  await page.goto(reportURL);
+
+  const scope = '#view-tests .run-view.active';
+  const count = page.locator(`${scope} .view-toolbar-count`);
+
+  // The fixture's parameterized row ran three times and its retried row twice,
+  // so the run holds more executions than tests — the case this figure exists
+  // for, asserted before it is filtered.
+  await expect(count).toHaveText('9 executions');
+  await expect(
+    page.locator(`${scope} .test-summary[data-runs]`),
+    'the rows that account for the difference must say so',
+  ).toHaveCount(2);
+
+  await page.locator('.pill', { hasText: /^Skipped \(\d+\)$/ }).click();
+  await expect(count, 'one skipped test that ran once').toHaveText('1 execution');
+
+  await page.locator(`${scope} .tests-filter`).fill('nothing matches this');
+  await expect(count, 'and a filter that selects nothing states nothing')
+    .toHaveText('0 executions');
+});
+
+// ---- The log filter -----------------------------------------------------
+//
+// Possible at all because A3b renders the log in the page. Behind the iframe
+// it replaces, the log was a `file://` sibling or a `data:` URI — a foreign
+// origin either way — so no control in this page could have read a line of it,
+// which is why A3a's Logs toolbar carried an inert label.
+test('the log filter narrows the log to matching lines', async ({ page }) => {
+  await page.goto(reportURL);
+  await page.locator('#tab-logs').click();
+
+  const body = page.locator('#view-logs .run-view.active .log-body');
+  const count = page.locator('#view-logs .run-view.active .view-toolbar-count');
+
+  const lines = (await body.textContent())!.replace(/\n$/, '').split('\n');
+  expect(lines.length, 'the fixture must render a log with lines in it')
+    .toBeGreaterThan(1);
+  await expect(count).toHaveText(`${lines.length} lines`);
+
+  await page.locator('#view-logs .run-view.active .log-filter').fill('line two');
+  await expect(body, 'only the matching line survives').toHaveText(/line two/);
+  expect((await body.textContent())!.split('\n').filter(Boolean))
+    .toHaveLength(1);
+  await expect(count, 'and the toolbar states the narrowing')
+    .toHaveText(`1 of ${lines.length} lines`);
+
+  await page.locator('#view-logs .run-view.active .log-filter').fill('');
+  expect((await body.textContent())!.replace(/\n$/, '').split('\n'))
+    .toHaveLength(lines.length);
+  await expect(count).toHaveText(`${lines.length} lines`);
+});
+
 // The failure digest (#439, A1). Its jump is the one piece of the summary
 // header that is behaviour rather than markup, and it has four things to undo
 // before the row is on screen — none of which a rendered-HTML assertion can

--- a/visual/tests/shell.spec.ts
+++ b/visual/tests/shell.spec.ts
@@ -41,7 +41,7 @@ test('the picker lists every destination with its own outcome', async ({ page })
     await expect(
       options.nth(index).locator('.device-row-tally'),
       'every option states its own run in words, since the bar is aria-hidden',
-    ).toHaveText('1 passed, 1 failed, 1 skipped, 1 mixed, 1 expected failure');
+    ).toHaveText('2 passed, 1 failed, 1 skipped, 1 mixed, 1 expected failure');
   }
 
   await expect(
@@ -184,21 +184,68 @@ test('each view owns its own toolbar and nothing else renders under it', async (
   ).toBeHidden();
 });
 
-test('the trailing toolbar slot A3b fills is laid out and empty', async ({ page }) => {
+// The slot A3a reserved, now filled (#439, A3b). Right-aligned is the half
+// that made it a slot rather than a div, and it is where Xcode's own test
+// report puts its Filter field — so this asserts the position as well as the
+// presence.
+test('both views carry a filter field at the far end of their toolbar', async ({ page }) => {
   await page.goto(reportURL);
 
-  const trailing = page.locator('#view-tests .run-view.active .view-toolbar-trailing');
-  await expect(trailing, 'the slot must exist for #460 to land in').toHaveCount(1);
-  await expect(trailing, 'and be empty until it does').toHaveText('');
+  for (const [view, tab] of [['#view-tests', '#tab-tests'], ['#view-logs', '#tab-logs']]) {
+    await page.locator(tab).click();
+    const field = page.locator(`${view} .run-view.active .view-toolbar-trailing input.view-filter`);
+    await expect(field, `${view} must carry a filter field`).toHaveCount(1);
+    await expect(field).toBeVisible();
 
-  // Right-aligned, which is the half that makes it a slot rather than a div:
-  // A3b's filter field lands at the far end of the toolbar, as Xcode's does.
-  const [toolbarRight, slotRight] = await page.evaluate(() => {
+    const gap = await page.evaluate((selector) => {
+      const toolbar = document.querySelector(`${selector} .run-view.active .view-toolbar`)!;
+      const slot = toolbar.querySelector('.view-toolbar-trailing')!;
+      return toolbar.getBoundingClientRect().right - slot.getBoundingClientRect().right;
+    }, view);
+    expect(Math.abs(gap), `${view}'s filter must sit at the trailing edge`)
+      .toBeLessThanOrEqual(12);
+  }
+});
+
+// 375px, where the toolbar has the most to fit and the least room: six pills,
+// a count and a field. The pills wrap and the field gives way — `max-width`
+// on the field, `flex-wrap` on the row — and what must not happen is the
+// toolbar pushing the page sideways, because `body` is `overflow: hidden` and
+// anything past the right edge is not merely unscrolled but unreachable (the
+// A3a title-band defect, in the row below it).
+test('the filled toolbar stays inside a 375px window', async ({ page }) => {
+  await page.setViewportSize({ width: 375, height: 812 });
+  await page.goto(reportURL);
+
+  const geometry = await page.evaluate(() => {
     const toolbar = document.querySelector('#view-tests .run-view.active .view-toolbar')!;
-    const slot = toolbar.querySelector('.view-toolbar-trailing')!;
-    return [toolbar.getBoundingClientRect().right, slot.getBoundingClientRect().right];
+    const field = toolbar.querySelector('.view-filter')!;
+    const pills = [...toolbar.querySelectorAll('.pill')];
+    return {
+      toolbarRight: toolbar.getBoundingClientRect().right,
+      fieldRight: field.getBoundingClientRect().right,
+      fieldWidth: field.getBoundingClientRect().width,
+      pillRows: new Set(pills.map((p) => Math.round(p.getBoundingClientRect().top))).size,
+      pills: pills.length,
+      viewport: document.documentElement.clientWidth,
+      bodyScroll: document.documentElement.scrollWidth,
+    };
   });
-  expect(Math.abs(toolbarRight - slotRight)).toBeLessThanOrEqual(12);
+
+  // Precondition, in the A2 pattern: a toolbar that fitted on one line would
+  // pass every assertion below while proving nothing about the case this
+  // exists for.
+  expect(geometry.pills, 'the fixture must offer enough pills to crowd the row')
+    .toBeGreaterThanOrEqual(5);
+  expect(geometry.pillRows, 'and they must actually have wrapped at this width')
+    .toBeGreaterThan(1);
+
+  expect(geometry.fieldRight, 'the filter field must not overhang the toolbar')
+    .toBeLessThanOrEqual(geometry.toolbarRight + 1);
+  expect(geometry.fieldWidth, 'and must still be wide enough to type in')
+    .toBeGreaterThan(60);
+  expect(geometry.bodyScroll, 'nothing may push the page sideways')
+    .toBeLessThanOrEqual(geometry.viewport + 1);
 });
 
 // ---- The attachment sheet ----------------------------------------------

--- a/visual/tests/tokens.spec.ts
+++ b/visual/tests/tokens.spec.ts
@@ -174,6 +174,27 @@ async function openEveryShellSurface(page: Page) {
   await expect(page.locator('#attachment-sheet')).toBeVisible();
 }
 
+/**
+ * The Logs view is a second document as far as this walk is concerned (#439,
+ * A3b), and it has to be measured as one.
+ *
+ * The two views are mutually exclusive — the inactive one is `display: none`,
+ * which is exactly what `textPairs` skips — so one pass can only ever see one
+ * of them. That cost nothing while the log was an iframe, since a foreign
+ * document has no pairings this stylesheet is answerable for. It renders in
+ * the page now, which means the log's own colours, its toolbar count and its
+ * filter field are this sheet's business and would otherwise go unmeasured on
+ * every run.
+ */
+async function pairsAcrossBothViews(page: Page) {
+  const tests = await textPairs(page);
+  await page.locator('#tab-logs').click();
+  await expect(page.locator('#view-logs .run-view.active .log-body')).toBeVisible();
+  const logs = await textPairs(page);
+  expect(logs.length, 'the Logs view must contribute text of its own').toBeGreaterThan(0);
+  return tests.concat(logs);
+}
+
 // Both fixtures, because one of them cannot show what the other does: the run
 // number an option carries is rendered only when a report holds several runs,
 // so the single-run fixture has no element to measure it on.
@@ -184,7 +205,7 @@ for (const [fixture, url] of [['single-run', reportURL], ['multi-run', multiURL]
       await page.goto(url);
       await openEveryShellSurface(page);
 
-      const pairs = await textPairs(page);
+      const pairs = await pairsAcrossBothViews(page);
       expect(pairs.length, 'no text elements found — the fixture rendered nothing').toBeGreaterThan(0);
 
       const failures: string[] = [];


### PR DESCRIPTION
The last of #439's redesign PRs. A1 gave the report a summary header, A2 gave
the tree Xcode's outline, A3a gave each view its own surface and reserved a
slot in each toolbar. This fills the slots.

## The expected-failure bucket (#460)

The model has named `.expectedFailure` since #443, and A1's tally has counted
it in a bucket of its own since the header landed. The filter row was the last
reading of a run that still had it in **no bucket at all**: five functions,
each naming the four row classes it shows or hides, and an expected failure
carries none of them.

Measured on this branch's build of the shipped code, that meant:

- **"Passed" left one on screen.** A reader asking for the tests that passed
  was shown one that did not.
- **"All" could not put it back**, because "All" only ever set
  `display: block` on those same four classes.
- **A suite of nothing but expected failures vanished.** The group pass reads
  a row as visible only when its `display` is `block`; an unfiltered row's
  never is. So the suite disappeared from the tree the moment the reader
  touched *any* filter, "All" included.

### The decision, and why nothing in the header moves

**Expected-failure rows leave `unknown` entirely — and they left it before this
PR.** `Status.expectedFailure` has had its own case, its own `cssClass`, its
own glyph (#459) and its own `Tally` bucket (A1) for some time; the ring, the
legend, the picker's spoken tally and `donut-center`'s total are all already
computed from that bucket. So the coordination A1's summary math needed here
was **not** to move a count. It was to make the toolbar agree with counts that
were already right.

Evidence that nothing moved: every A1 assertion passes unedited —
`RunSummaryTests.testExpectedFailuresAreCountedRatherThanDropped`,
`testRingArcsTileTheWholeCircle`,
`DifferentialSummaryHeaderTests.testSummaryHeaderNumbersAgreeAcrossBackends`,
and `CoreTests.testSummaryHeaderAccountsForExpectedFailures`. The header
assertions that *did* change (`testLegendCountsEveryStatusTheFixtureProduces`,
the duration total, the picker's spoken tally) changed because the synthetic
fixture gained a sixth test — a parameterized case, for the executions work
below — not because any bucket moved. Each edit is one number.

`CoreTests` has carried the disagreement as a comment since A1 — *"the two
readings disagree until A3 rebuilds the filters"* — and now asserts the
partition instead.

### The pills are the legend, made operable

Both are rendered from the run's `Tally`: same buckets, same order, same
drop-the-empty-ones rule. A leading "All", then one pill per outcome the run
produced.

| | Before | After |
| --- | --- | --- |
| `TestResults` | All (21) · Passed (12) · Skipped (1) · Failed (6) · Mixed (0) | All (21) · Passed (12) · Failed (6) · Skipped (1) · **Expected failures (2)** |
| `RetryResults` | All (4) · Passed (1) · Skipped (0) · Failed (1) · Mixed (1) | All (4) · Passed (1) · Failed (1) · Mixed (1) · **Expected failures (1)** |
| `SanityResults` | All (1) · Passed (1) · Skipped (0) · Failed (0) · Mixed (0) | All (1) · Passed (1) |

Xcode's own toolbar reads `All Tests (21)` on the same bundle, and its Log view
names the same bucket in words: *"14 tests total, 9 passed, 1 skipped, 2
expected failures"*.

Dropping the empty ones is the legend's rule, applied to the control that acts
on what the legend states — a permanent "Mixed (0)" in a report that never
retried a test is noise, and three pills reading `(0)` were three controls that
could only ever empty the pane. It is also what closes the *class* of defect
rather than the instance: a pill exists **because** the run produced that
outcome, so `unknown` — which had exactly the same gap as `expectedFailure` and
no issue filed against it — is filtered now for the same reason. `Status`
became the single mapping between an outcome and the report's vocabulary for
it, and moved into `Status.swift` to say so: `cssClass` is the row class the
stylesheet paints *and* the `data-filter` a pill carries, so adding a case adds
a glyph, a legend row, a pill and a filter with no list anywhere to keep in
step.

### Three more filters that did not finish

Each is the same defect in a different place, each found while building the
first one, each gated:

- **A suite goes when its last visible row does.** The pass this replaces
  bailed out on any group holding a sub-group, so the legacy backend's two
  wrapper levels — "Selected tests" and `<target>.xctest`, which hold only
  other groups — survived every filter. Two selected rows sat under three empty
  headings. Deciding deepest-first covers both cases with one rule. The digest
  jump now clears the whole ancestor chain rather than the nearest suite, since
  a wrapper can be hidden now and could not be before.
- **A filtered-out test takes its screenshot with it.** `.screenshot-tail` is
  emitted *between* rows rather than inside one (A2), so it sat outside
  everything the filters touched: a hidden test left a 200px picture in the
  tree with no row to belong to.
- **A childless suite is a row.** `Run.allTests` counts one as a leaf — the
  shape a crashed target leaves behind, which `TruncationFaultTests` is built
  from — so the pills count it, and it has to be filterable by them or the
  toolbar's own arithmetic is wrong.

## Tests and runs

Xcode states **21 tests and 23 runs** on `TestResults.xcresult`. Ours knew only
tests. The difference is `parameterizedAddition(value:)`, which ran once per
argument set.

Neither field already in the port could carry the second number. Both readers
*deliberately* collapse argument executions into one iteration — that is what
makes the two backends agree on the rows (migration answer 8) — and only the
modern format names the argument values at all. But the **count** is in both
bundles: legacy has one sibling metadata entry per execution, modern one
`Arguments` child. Legacy was throwing it away in `mergingArgumentExecutions`,
at the one point where it still knew.

So `ParsedTestCase` gains `executionCount`, and this **converges the readers
rather than reading anything new**:

| | legacy | modern |
| --- | --- | --- |
| source | sibling metadata entries, counted before the merge | `Repetition` children, or `Arguments` children when there are none |
| `parameterizedAddition` | 3 | 3 |
| a repeated test | N | N |
| everything else | 1 | 1 |

`DifferentialTests.testExecutionCountsAgreeAcrossBackends` holds them
converged — per test identifier, not just per run, so a disagreement names what
disagrees — with a non-vacuity check, because equality is free if nothing in
any fixture ever ran twice.

Corroborated from a source neither reader's test-tree parse touches: filtering
the run log to `Run test case` (`logs-filtered-1440-light.png`) lists
`-------- Run test case parameterizedAddition(value:) --------` **three
times**. The simulator really did run it three times; 23 is not an artefact of
how one backend counts.

The toolbar reads **`23 executions`**, not "23 runs": this report already
spends the word "run" on a destination, which A3a's picker labels `Run 1`,
`Run 2`. It is `aria-live`, because the filters change it — `Failed` gives
`6 executions`, exactly as Xcode's second dropdown relabels to `Failed Runs
(6)`. Each row that accounts for a difference says so with the option-A
mockup's own tag, `3 arguments`; only the count is stated, never the values,
which one backend cannot see. A repeated test gets no tag — its iterations are
rows already.

**No per-run rows in the tree.** Counts and filter semantics only; drawing a
row per argument set is a bigger feature and not this one.

## A Filter field, in both views

Xcode puts one at the trailing end of both toolbars. So does this, in the slot
A3a reserved — the mockup has no toolbar at all, so Xcode is the source here.
On Tests it is a name-substring filter that **composes** with the pills:
"Failed" and "one" together mean the failing tests whose names contain "one",
which is what a reader who set both is asking for. It matches the row *and
every suite above it*, because a filter over a tree that only reads its leaves
is one a reader finds out about the hard way — typing the name of a suite they
can see would empty the pane. The status filter stays a leaf question: a
suite's own status is folded from its children, so filtering on it would put
rows of every outcome under a heading claiming one.

On Logs it filters the log's lines, and the count reads `23 of 83 lines`.

### The log moves into the page, and that is what makes a log filter possible

It was an `<iframe src>` pointing at a `file://` sibling or a `data:` URI — a
foreign origin either way. Two things followed, both of which the report
shipped:

- **Nothing in the page could act on it.** No control the parent holds can
  filter, search or scroll across an origin boundary, which is why A3a's Logs
  toolbar carried an inert `All Messages` label where a control belongs. There
  was no better label to write; the delivery mechanism was the problem.
- **It could not see the token layer.** In dark mode the Logs view rendered as
  a **white slab with black text** — the same class of defect as the base64
  status PNGs #459 replaced with masks, and for the same reason.
  `logs-1440-dark.png` in A3a's evidence is that slab; the file of the same
  name here is the same view themed.

A single `<pre>` rather than an element per line: a filter that rebuilds one
text node is a string join, where a six-figure log would otherwise be a
six-figure DOM. `tabindex="0"` for the reason the tests list has one — axe's
`scrollable-region-focusable`.

The `.log` export is **untouched**: it is the artifact #480 fixed and
`DifferentialLogTests` compares, and it stays the signal `logFailedToResolve`
reads. Only linking mode pays anything for this — one extra read of the same
bytes, since it also writes the file. Inline mode gets *smaller*: escaped text
costs less than the same bytes base64'd into a URI.

## Substitution order, closed rather than ordered

`Run` fills its two templates from two ordered lists instead of one dictionary.
`HTML.html` reduces over a dictionary, so it fills placeholders in hash order,
and fills the ones an earlier replacement *inserted* as readily as the ones the
template author wrote — the hazard the A3a review found in the picker. Two
per-view templates make it **closable** rather than merely ordered: each list
holds only what its own template needs, so a test named `[[LOG_TEXT]]` is not
filled late but *unfillable*, and a log line reading `[[TEST_SUMMARIES]]`
likewise. Both directions pinned in `PlaceholderOrderTests`.

## Keyboard and accessibility

- The pills stay a roving radiogroup; the two Filter fields are ordinary
  `type="search"` inputs, so Tab still steps past a toolbar in three presses
  and Escape clears a field with nothing here re-implementing either.
- The axe gate runs in **six** states now, up from four. The two new ones are
  the pages the filters *produce* — a tree narrowed to one bucket and one name,
  with rows and suites carrying `display: none` and a live count rewritten by
  script, and a log narrowed to one line. Each asserts its own precondition, in
  A2's pattern: the filtered tree must have both visible and hidden rows, and
  the filtered log must be shorter than the whole one, or the state is not the
  state and axe would pass it trivially.
- The contrast walk now covers **both views**. It reads the live cascade, and
  the two views are mutually exclusive, so one pass could only ever see one of
  them — which cost nothing while the log was a foreign document and would have
  left its colours, its count and its field unmeasured now that it is not.

### Contrast

| Pairing | Floor | Light | Dark |
| --- | --- | --- | --- |
| Toolbar count — muted on chrome | 4.5:1 | 6.66:1 | 5.61:1 |
| Filter field — typed text | 4.5:1 | 18.88:1 | 14.76:1 |
| Filter field — placeholder | 4.5:1 | 7.46:1 | 6.46:1 |
| Filter field — border (graphic) | 3.0:1 | 3.24:1 | 3.48:1 |
| Log body — text on surface | 4.5:1 | 18.88:1 | 14.76:1 |

Tightest is the field's border at 3.24:1 against a 3.0:1 floor — the same
`--color-border-control` pairing A3a sized for the picker's summary. No new
token. The `3 arguments` tag reuses `.row-note`, the chip a retried row's
outcome breakdown already wore, so it introduces no pairing either.

## 375px

The toolbar has the most to fit and the least room: six pills, a count and a
field. The pills wrap, the field gives way first (`max-width`, `min-width: 0`),
and the gate asserts its own precondition — the pills must actually have
wrapped, or it is measuring a row that fitted on one line and proving nothing.
Then: the field may not overhang the toolbar, must stay wide enough to type in,
and nothing may push the page sideways, since `body` is `overflow: hidden` and
anything past the right edge is unreachable rather than merely unscrolled.

## Screenshots

1440 and 375, light and dark, in `orca-artifacts/a3b-filters/`: the Tests view,
the Expected-failures filter chosen, the name filter applied, the Logs view,
and the log filtered — twenty files, rendered from `TestResults.xcresult` so
the numbers in them are the 21/23 Xcode states for the same bundle.

### Deviations

- **The mockup has no toolbar**, so the filter field's shape and placement come
  from Xcode's test report rather than from option A. What the mockup does have
  is the `3 arguments` row tag, which is here verbatim.
- **The pills are a row, not two dropdowns.** Xcode has `All Tests (21) ▾` and
  `All Runs (23) ▾`; ours states the same two numbers side by side without
  making the reader open a menu to see the split. A dropdown that has to be
  opened to be read is a worse trade at 375px than a row that wraps.
- **No `Test Scheme Action` or `All Tags` filters.** Neither is in the port:
  the action is not modelled, and Swift Testing tags are not carried by either
  reader.
- **The log gets a text filter, not a section jump.** Both are honest now that
  #482 made the exported log identical across backends — its
  `-------- title --------` headers would index cleanly. The text filter is the
  one Xcode puts in this corner, it is the one that answers "where is the
  failure", and it subsumes the jump for a document this shape.

## Verification

- `swift test` — 193 tests, 0 failures, 3 skipped (the two env-gated capture
  tests and the standing JUnit drift skip from #378), on both legs
  (default/auto and `XCHR_RESULT_READER=modern`).
- `DifferentialTests` green on both legs; the **allow-list is untouched**.
- `visual` — 48 Playwright tests, 0 failures.
- Masked duration shapes untouched — `(N.NNs)` in the tree and
  `<span class="summary-duration">(10.50s)</span>` in the header, both still
  asserted against `KnownLossMasker`.
- `swiftformat --lint` clean; no new SwiftLint warnings (diffed against a
  baseline run on `main`, which is why `Status` moved to its own file and two
  real-fixture tests moved out of `CoreTests` — both files were at their length
  limits).

### A note on the fixtures

`TestResults.xcresult` on this machine was a stale 16-test bundle from before
the sample app gained `testExpectedFailure`, `knownIssue` and
`parameterizedAddition` — the exact partial-bundle condition `#478`'s gate
exists to catch, and it rejected it. Regenerated with `prepareTestResults.sh`;
`scripts/verify_fixtures.sh` now reports 21/1/4/1. Everything above is measured
against the regenerated set.

Fixes #460. Refs #439.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added combined status and name filtering for tests and logs, with per-run filter state.
  * Added searchable inline logs with monospace formatting, line counts, and accessible focus styling.
  * Added execution counts for repeated and parameterized tests, including toolbar totals.
  * Added expected-failure and unknown status filters.
* **Bug Fixes**
  * Improved visibility for nested suites, empty groups, screenshots, and digest navigation.
  * Preserved log content in inline and linked rendering modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->