### PR TITLE
Tell the release notes the redesign has landed (refs #439)

### DIFF
--- a/docs/release-notes/4.0.0.md
+++ b/docs/release-notes/4.0.0.md
@@ -23,18 +23,19 @@ mint install XCTestHTMLReport/XCTestHTMLReport@<candidate-tag>
 Each candidate's release page names its own tag and attaches a signed,
 notarized universal binary built from it.
 
-**The first candidate is the migration plus a conservative refresh.**
-Everything below — the `xcresulttool` migration, the `--json` schema,
-`--result-reader`, and the report changes both readers now share — is in it,
-and is what we are asking for soak time on. The report's own markup and
-styling are deliberately left close to 3.x there, so that any regression you
-hit points at the reader rewrite rather than at a redesign landing on top of
-it.
+**The first candidate is the migration plus a conservative refresh.** The
+`xcresulttool` migration, the `--json` schema, `--result-reader`, and the
+report changes both readers now share are all in it, and were the first thing
+we asked for soak time on. The report's own markup and styling are
+deliberately left close to 3.x there, so that any regression you hit points at
+the reader rewrite rather than at a redesign landing on top of it.
 
-**The Xcode-native report redesign lands later in the RC line**, with its own
-notes appended to this document as it arrives. The candidate line ends when
-the reader rewrite has gone a full cycle without a parity or correctness
-report against it.
+**The Xcode-native report redesign has landed**, from the second candidate on:
+the summary header, the restyled tests tree, the per-view shell and its device
+picker, the filters, and a Logs view that can actually be read and searched. It
+has its own section below, and it is the second thing we are asking for soak
+time on. The candidate line ends when the reader rewrite and the redesign have
+both gone a full cycle without a parity or correctness report against them.
 
 Please file anything you find against
 [the 4.0 milestone](https://github.com/XCTestHTMLReport/XCTestHTMLReport/milestone/2);
@@ -162,6 +163,9 @@ is not a log document no longer decodes into an empty one and ships as this
 run's log. It is reported as `logExportFailed` and exits 3, like every other
 log that cannot be read (#386).
 
+The view that shows it is rebuilt too — see *The Xcode-native report redesign*
+below.
+
 ### Parameterized Swift Testing cases render as one test
 
 A Swift Testing `@Test(arguments:)` case used to render as N
@@ -213,6 +217,156 @@ if one of these four quietly disappears:
 `--json` output additionally carries `testCase.arguments`, which only the
 modern reader can populate (the legacy format has no counterpart) — see the
 contract document.
+
+## The Xcode-native report redesign
+
+The report you got from 3.x was a three-pane frame — a device sidebar on the
+left, a flat test list in the middle, an attachment pane on the right — and it
+told you nothing about the run until you started expanding rows. It is now
+rebuilt around the vocabulary Xcode's own test report uses: a summary you can
+triage from, an outline that reads like Xcode's, and one surface per view
+(#439).
+
+This is presentation, not content. It renders identically on both readers, and
+nothing in it reads a field the parity guarantee above does not already cover.
+
+### A summary header you can triage from
+
+At the top of the report: a ring showing every outcome's share of the run, a
+legend naming each bucket with its count, the total, and the run's duration.
+All six outcomes get a bucket, so the legend partitions the run rather than
+leaving tests uncounted.
+
+Under it sits a **failure digest** — one row per failed test with its assertion
+message and its suite, readable without expanding anything. Each test name is a
+button: clicking it switches to the run that owns the failure, clears whatever
+the current filter was hiding, expands the test, selects it and scrolls it into
+view. On a run with many failures the digest scrolls in place rather than
+pushing the tree off the screen, and on a run where nothing failed it is not
+there at all.
+
+The per-device breakdown — a proportional bar and the same tally in words, one
+per run — lives in the device picker described below, where it is something you
+can act on rather than only read.
+
+### The tests tree reads like Xcode's outline
+
+- **Every row is one line** — disclosure triangle, status badge, name, and the
+  duration in a right-hand column of its own instead of trailing the name as
+  more text.
+- **Xcode's rounded status badge in all six states, and suite rows have one
+  too.** A suite's badge folds its children's outcomes, so a subtree's result
+  is readable without opening it.
+- **Nesting is visible.** Suites, cases and iterations indent by level; the
+  tree used to be flat, so a suite began at the same pixel as the target
+  containing it.
+- Hover and selection states; an inset activities panel with failure steps on
+  their own tint; attachment rows carrying their type icon, their name and a
+  preview control; and screenshots bounded like a player instead of the
+  fixed-height slab that was the tallest thing in the tree by a factor of
+  eight.
+- **The list is keyboard-scrollable.** It takes focus now, so Page Up/Down,
+  Home and End scroll it; it previously had no focusable descendant at all,
+  which is to say a keyboard user could not scroll it. The arrow keys still
+  move the selection.
+- Status is never carried by colour alone: the badge's *shape* carries the
+  outcome. That is also what let the selected row's badge be fixed — against
+  the selection fill the old glyph measured 1.36:1, which is to say no badge at
+  all on precisely the row you were looking at.
+
+### Each view owns its surface, and the report has one device picker
+
+Tests and Logs each own the whole content area below the tabs, toolbar
+included. The three-pane frame is gone, and with it two panes that spent window
+on nothing.
+
+- **The device sidebar becomes a picker in the title band.** Every option
+  carries the run's outcome glyph, its destination and model, a proportional
+  pass/fail bar and the same tally in words. It does everything the sidebar did
+  and two things it could not: it switches the tests tree **and** the log
+  together, and it is reachable from the Logs view and operable from a
+  keyboard. When a report holds more than one run each option is numbered, so
+  two runs recorded on the same simulator can be told apart.
+- **Behaviour change: the sidebar's `Identifier:` line is gone.** Since #430 it
+  carried the report's own element handle — a path digest — rather than the
+  destination's identifier, so it named nothing you could use or match against
+  anything outside the page. The handle is still in the markup, as machinery
+  rather than as content.
+- The old sidebar's per-run status cell was hardcoded to "unknown" and drew
+  nothing for that case, so **every device card in every report ever rendered
+  showed a blank status**. The picker states the real outcome.
+- **The attachment pane becomes a sheet inside the Tests view, with no empty
+  state.** A sheet holding nothing is not in the layout, so the report stops
+  spending 400px of a 1440px window on the words "No Selected Attachment".
+  Measured on a single-device run at 1440px, the sidebar and the pane together
+  were about 42% of the window; that is back.
+- **Behaviour change: the narrow layout is redesigned.** Below 700px the views
+  stack and the test list scrolls inside its own share of the height. It did
+  not before: the list grew to hold every row, and because the page itself does
+  not scroll, that overflow was not merely unscrolled but **unreachable** — on
+  a long run the last test in the report could not be brought on screen at all.
+- The tabs, the filter pills and the attachment preview control are real
+  controls now — a tablist, a radiogroup, and a button. None of the three had a
+  keyboard path before.
+
+### Filters that cover every outcome, in both views
+
+- **Expected failures have a filter pill (#460).** They had no bucket in the
+  filter row at all, so "Passed" left an expected failure on screen, "All"
+  could not put one back once hidden, and a suite made only of expected
+  failures vanished from the tree the moment you touched any filter — "All"
+  included.
+- **The pills are the legend, made operable**: same buckets, same order, and
+  only the outcomes the run actually produced. A permanent "Mixed (0)" on a
+  report that never retried a test was a control that could only ever empty the
+  pane.
+- **Tests and executions are counted separately.** Xcode reads 21 tests and 23
+  runs on our sample bundle, where the difference is a parameterized case that
+  ran once per argument set; the toolbar now states `23 executions` beside the
+  pills, updates it as you filter, and tags the rows that account for the
+  difference with the number of argument sets they ran.
+- **A free-text Filter field in both views.** On Tests it filters by name and
+  composes with the pills — "Failed" plus "one" means the failing tests whose
+  names contain "one" — and it matches a row *and the suites above it*, so
+  typing the name of a suite you can see does not empty the pane. On Logs it
+  filters the log's lines and says how many of how many are showing.
+- Filtering a test now takes its screenshot with it, and a suite disappears
+  when its last visible row does — including the wrapper levels the legacy
+  reader nests, which used to survive every filter and leave rows sitting under
+  empty headings.
+
+### The Logs view is a view, not an iframe
+
+The Logs tab has an actual log to show now (see above). This is what gives it
+somewhere to show it: the log is rendered **into the page** rather than loaded
+into an iframe from a separate origin.
+
+That boundary is why the Logs toolbar could only ever carry an inert label —
+nothing in the page can filter, search or scroll across it — so removing it is
+what makes the Filter field above possible. It also fixes dark mode, where the
+log rendered as a white slab with black text whatever the theme, because the
+frame could not see the report's colours. The summary header stands down while
+Logs is up, since it describes the test run and not the log. The exported
+`.log` file is untouched.
+
+### Dark mode, contrast and accessibility
+
+The sheet is drawn from a single token layer, so dark mode is a set of value
+overrides rather than a second stylesheet, and every glyph is inline SVG taking
+its colour from a token — no base64 images that ignore the theme, and
+single-file reports (`-i`) keep working byte for byte.
+
+Contrast is measured out of the live cascade in both themes rather than
+asserted: text is held to 4.5:1 and non-text — badges, ring arcs, bars — to
+3:1, and the text floor is enforced automatically on every CI run, in both
+views. The tightest non-text pairing in the tree is a status badge on a hovered
+row, at 3.69:1 against a 3:1 floor.
+
+The axe-core audit #462 made a CI gate now runs over six states of the page
+rather than one — as opened, with the device picker open, with an attachment
+sheet open, on Logs, and with each view filtered — each proving it is in the
+state it claims before the audit runs, so a surface that only exists
+transiently cannot pass by never being looked at.
 
 ## Fixes
 


### PR DESCRIPTION
Refs #439. Notes only — no code, no workflow, no template. One file:
`docs/release-notes/4.0.0.md`.

The RC preamble has been writing a cheque since #474:

> **The Xcode-native report redesign lands later in the RC line**, with its own
> notes appended to this document as it arrives.

It has arrived — #476, #483, #484, #486 are all on `main`, and #482 gave the
Logs tab something to show. The document still said it was coming. This cashes
the cheque.

## What changed

**1. The preamble's tense.** "lands later in the RC line" → "has landed", plus
what landed and that it is the second thing we are asking for soak time on. The
paragraph above it moves to the past tense for the same reason ("were the first
thing we asked for soak time on"), and the closing sentence now ends the
candidate line on *both* the reader rewrite and the redesign going a cycle
clean, not just the reader rewrite.

**2. A new `## The Xcode-native report redesign` section**, six subsections:
the summary header and the failure digest; the tests tree; the per-view shell
and the device picker; the filters; the Logs view; and dark mode, contrast and
accessibility as one.

**3. A pointer** from the existing *The Logs tab actually contains the log*
section down to it. That section says the log exists; the new one says where
you read it.

## Where the section sits, and why

Between *What still differs between the two readers* and *Fixes*.

Everything above it is the migration: why a major release, the `--json` break,
the reader flag, the content deltas both readers share, and what could not be
converged. The redesign is a different axis — presentation, independent of
either reader — so it reads best as "…and the report itself now looks like
this" **after** the reader has the content story, not interleaved into it.

It also has to come after *The Logs tab actually contains the log*, because the
Logs subsection is written as a callback to it: that log is the thing the
rebuilt Logs view now has to show. Putting the redesign higher would have made
that a forward reference to a section explaining a bug the reader had not met
yet.

## Nothing rc2-specific is hardcoded

The #474 discipline holds: this document is looked up per `X.Y.Z`, so `4.0.0rc1`,
`4.0.0rc2`, … and `4.0.0` final all resolve to *this file*, and the per-tag
banner `release.yml` generates is what carries the tag, the install line and the
asset name.

So the preamble names the candidate **ordinally** — "from the second candidate
on" — matching the "The first candidate is…" sentence already there. No tag
string, no install command, no archive name is added, and every sentence stays
true verbatim when 4.0.0 final publishes the same file.

`grep -nE 'rc[0-9]|xchtmlreport-4' docs/release-notes/4.0.0.md` matches exactly
one line, and it is the pre-existing `` `4.0.0rc1`, `4.0.0rc2`, … `` that
explains the scheme.

## The F7 item is not due yet

F7 asks for the RC framing to come out. **It stays**, and this PR does not
touch it beyond tense. The framing is what tells a reader the tag they are
looking at is a pre-release, that Homebrew and Mint still resolve to 3.x, and
that a candidate is opt-in — all of which is true of every candidate including
this one. It is due at **4.0.0 final**, when the same document publishes behind
no banner at all and "4.0 ships as a release-candidate line" would be the first
false sentence on the page.

Flagging one thing: I could not find F7's own text. #474 carries a single
CodeRabbit review (the hardcoded-rc1 finding, which is the discipline applied
above) and no numbered findings on the PR, in its comments, or anywhere in the
tree. The paragraph above is my reading of the item as the task described it,
not a quote — if F7 says something else, say so and I will redo this part.

## Sourcing, and one correction to the brief

Every claim is from a merged PR body and then **checked against `main`**, not
transcribed. Spot-checks that changed the copy:

- **The header does not have device bars.** #476 added a "Devices &
  Configurations" card; #484 dissolved it into the picker
  (`RunSummary+HTML.swift`: *"the picker the header's device bars became"*). A
  first draft described both, which would have documented a card that no longer
  renders. The section now has the header state the ring, the legend, the total,
  the duration and the digest, and hands the per-device bar and tally to the
  picker subsection, where it is something you can act on.
- **"The arrow keys were the only way down a long run"** — wrong, and cut. The
  list took no focus, so *Page Up/Down, Home and End* did nothing in it; arrow
  keys ran off a document-level handler and worked, as did the wheel. The bullet
  now says what was actually broken.
- `23 executions`, `N of M lines`, `tabindex="0"` on both the tests list and the
  log body, and the absent "No Selected Attachment" placeholder are each grepped
  out of `HTMLTemplates.swift` rather than taken from a PR body.

Internal vocabulary is out by construction: no A1/A2/A3 labels, no
`KnownLossMasker`, no allow-list, no test names, no byte-region tables. Issue
numbers stay, because the document already cites them (#430 and #462 were
already in it; #439 and #460 are new).

## The two behaviour changes, called out as behaviour changes

Asked for explicitly, and both are bolded **Behaviour change:** bullets rather
than left inside a feature list:

- **The sidebar's `Identifier:` line is gone.** Since #430 it carried the
  report's own path digest rather than the destination's identifier, so it named
  nothing a reader could match against anything outside the page.
- **The narrow layout is redesigned.** Below 700px the views stack and the test
  list scrolls inside its own share of the height — it did not before, and
  because the page itself does not scroll, the overflow was *unreachable*: on a
  long run the last test in the report could not be brought on screen at all.

## Verification

- Markdown only; no Swift, no workflow, no template touched. `swift test` is not
  affected and was not run.
- `.githooks/pre-commit` run manually: exit 0 (nothing staged that it lints).
  The commit is signed.
- Rendered the file as GitHub Markdown to confirm the new headings and the two
  cross-references read correctly in a release body.
- Branched off a fresh `main` at 611f78e, so the section describes the merged
  state of all five PRs rather than any one branch's.
