### PR TITLE
Report progress on stderr so a long run stops looking hung

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,33 @@ Report successfully created at ./index.html
 
 This will create only one HTML Report in the path you passed with the -r option
 
+### Progress
+
+A large result bundle takes a while, and a silent run is hard to tell from a
+hung one. When standard error is a terminal, each phase is reported as it
+finishes, with the time it took:
+
+``` bash
+$ xchtmlreport TestResults.xcresult
+    Exporting 2531 attachments          4.8s
+  Reading TestResults.xcresult         18.2s
+  Rendering 1284 tests                 12.4s
+  Writing report                        0.9s
+Wrote ./index.html (412 MB)            36.3s
+
+Report successfully created at ./index.html
+```
+
+Those timings also answer "which part is slow?" on your own bundle rather than
+in the abstract. Indented lines are nested inside the line below them —
+attachment export happens during the read.
+
+The rules are `git`'s. Progress goes to **standard error**, so a pipeline
+reading the report path off stdout (`xchtmlreport … | xargs open`) is
+unaffected. It is off when standard error is not a terminal, so scripts and CI
+logs are unchanged. `--progress` forces it on anyway, and `--quiet` turns it
+off.
+
 ### Generate Junit Reports
 
 You can generate junit reports with the `-j` flag

--- a/Sources/XCTestHTMLReport/XCTestHtmlReport.swift
+++ b/Sources/XCTestHTMLReport/XCTestHtmlReport.swift
@@ -110,6 +110,17 @@ struct XCTestHtmlReport: ParsableCommand {
     )
     var lenient = false
 
+    @Flag(
+        name: .long,
+        help: ArgumentHelp(
+            "Report progress on standard error even when it is not a terminal"
+        )
+    )
+    var progress = false
+
+    @Flag(name: .shortAndLong, help: ArgumentHelp("Suppress progress reporting"))
+    var quiet = false
+
     @OptionGroup
     var htmlOptions: HtmlOptions
 
@@ -122,8 +133,27 @@ struct XCTestHtmlReport: ParsableCommand {
     @OptionGroup
     var jsonOptions: JsonOptions
 
+    private static func fileSizeDescription(of path: String) -> String {
+        guard let size = try? FileManager.default
+            .attributesOfItem(atPath: path)[.size] as? Int64
+        else {
+            return "size unknown"
+        }
+        return ByteCountFormatter.string(fromByteCount: size, countStyle: .file)
+    }
+
     func run() throws {
         Logger.verbose = verbose
+        // git's rule (see `Logger.shouldShowProgress`): a redirected run stays
+        // as silent as it was before this feature existed.
+        Logger.progressEnabled = Logger.shouldShowProgress(
+            isTerminal: isatty(STDERR_FILENO) == 1,
+            forced: progress,
+            quiet: quiet
+        )
+        // Outer phase: every other phase nests inside it, so its elapsed time
+        // is the whole run. Closed once the report has been written.
+        Logger.beginPhase("Wrote report")
 
         guard let path = htmlOptions.output ?? summaryOptions.finalResults.first?
             .dropLastPathComponent()
@@ -150,12 +180,19 @@ struct XCTestHtmlReport: ParsableCommand {
         Logger.step("Building HTML..")
         let html = summary.generatedHtmlReport()
 
+        Logger.beginPhase("Writing report")
         do {
             try html.write(toFile: indexPath, atomically: false, encoding: .utf8)
         } catch {
             Logger.error("An error has occured while creating the report")
             throw error
         }
+        Logger.endPhase()
+
+        // Closes the phase opened at the top of `run()`. The size is what makes
+        // the total meaningful: a slow run on a huge report is not the same
+        // complaint as a slow run on a small one (#237).
+        Logger.endPhase("Wrote \(indexPath) (\(Self.fileSizeDescription(of: indexPath)))")
 
         Logger.success("\nReport successfully created at \(indexPath)")
 

--- a/Sources/XCTestHTMLReportCore/Classes/Helpers/Logger.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Helpers/Logger.swift
@@ -12,6 +12,87 @@ import Rainbow
 public enum Logger {
     public static var verbose = false
 
+    // MARK: - Progress
+
+    /// Whether phase progress is emitted at all. The CLI sets this from
+    /// `shouldShowProgress`.
+    public static var progressEnabled = false
+
+    /// Progress is status rather than output, so it goes to stderr alongside
+    /// the diagnostics -- a pipeline reading this tool's stdout, which carries
+    /// the path of the generated report, must not be fed it. Overridable so
+    /// tests can read back what was emitted.
+    static var progressOutput: (String) -> Void = defaultProgressOutput
+
+    private static let defaultProgressOutput: (String) -> Void = { line in
+        // Same ordering care as `printToStandardError`: flush stdout first so
+        // that under `2>&1` progress interleaves where it actually occurred.
+        fflush(stdout)
+        fputs(line + "\n", stderr)
+    }
+
+    static func resetProgressOutput() {
+        progressOutput = defaultProgressOutput
+    }
+
+    /// git's rule, verbatim from `man git-push`: "Progress status is reported
+    /// on the standard error stream by default when it is attached to a
+    /// terminal, unless -q is specified. This flag forces progress status even
+    /// if the standard error stream is not directed to a terminal."
+    ///
+    /// Copying a rule users already know beats inventing one, and it leaves
+    /// redirected runs -- scripts, CI logs -- exactly as they were.
+    public static func shouldShowProgress(isTerminal: Bool, forced: Bool, quiet: Bool) -> Bool {
+        if quiet {
+            return false
+        }
+        return forced || isTerminal
+    }
+
+    private static var phases: [(label: String, start: Date)] = []
+
+    public static func beginPhase(_ label: String) {
+        guard progressEnabled else {
+            return
+        }
+        phases.append((label, Date()))
+    }
+
+    /// - Parameter label: replaces the label given to `beginPhase`. A phase
+    ///   cannot always name itself up front -- the attachment count is only
+    ///   known once the export manifest has been read -- so the closing call
+    ///   gets the last word.
+    public static func endPhase(_ label: String? = nil) {
+        guard progressEnabled, let phase = phases.popLast() else {
+            return
+        }
+        let elapsed = Date().timeIntervalSince(phase.start)
+        progressOutput(progressLine(
+            label: label ?? phase.label,
+            elapsed: elapsed,
+            depth: phases.count
+        ))
+    }
+
+    /// Deliberately uncoloured. Unlike the rest of this file's output, progress
+    /// can be forced into a pipe with --progress, and ANSI escapes in a log
+    /// file help nobody.
+    /// - Parameter depth: how many phases still enclose this one. Attachment
+    ///   export is lazy and fires during a read, so the inner phase closes and
+    ///   prints first; indenting it says "part of the phase below" rather than
+    ///   letting it read as having run out of order.
+    private static func progressLine(
+        label: String,
+        elapsed: TimeInterval,
+        depth: Int
+    ) -> String {
+        let indent = String(repeating: "  ", count: depth)
+        let time = String(format: "%.1fs", elapsed)
+        let column = 38
+        let padding = max(2, column - indent.count - label.count)
+        return indent + label + String(repeating: " ", count: padding) + time
+    }
+
     /// Diagnostics go to stderr so that a pipeline consuming this tool's stdout
     /// — which carries the path of the generated report — is not fed warnings
     /// about the report being degraded. `success`, `step` and `substep` stay on

--- a/Sources/XCTestHTMLReportCore/Classes/Models/Summary+Reading.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Models/Summary+Reading.swift
@@ -1,0 +1,39 @@
+//
+//  Summary+Reading.swift
+//
+//  Setup helpers for `Summary.init`'s read loop, kept beside it rather than in
+//  it: the initialiser is long enough already, and these two answer questions
+//  ("which backend?", "what is this phase called?") that are separable from
+//  the loop that asks them.
+//
+
+import Foundation
+
+extension Summary {
+    /// The CLI already rejects an explicit `legacy` the toolchain cannot honour
+    /// in `validate()`. This is defence in depth for library consumers who never
+    /// pass through the CLI: a non-throwing init cannot raise the error, so it
+    /// records a fault — which reaches exit 3 through the existing path, and is
+    /// therefore still not a silent substitution.
+    static func resolveBackend(
+        _ backend: ResultBackend,
+        faultCollector: FaultCollector
+    ) -> ResultBackend {
+        switch backend.resolve() {
+        case let .use(concrete):
+            return concrete
+        case .legacyUnavailable:
+            faultCollector.record(
+                .legacyReaderUnavailable,
+                "legacy reader requested but unavailable on this toolchain"
+            )
+            return .modern
+        }
+    }
+
+    /// Only counted when there is more than one bundle: "(1 of 1)" is noise.
+    static func readingPhaseLabel(path: String, index: Int, total: Int) -> String {
+        let name = URL(fileURLWithPath: path).lastPathComponent
+        return total > 1 ? "Reading \(name) (\(index + 1) of \(total))" : "Reading \(name)"
+    }
+}

--- a/Sources/XCTestHTMLReportCore/Classes/Models/Summary.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Models/Summary.swift
@@ -62,6 +62,17 @@ public struct Summary {
 
         for (resultIndex, resultPath) in resultPaths.enumerated() {
             Logger.step("Parsing \(resultPath)")
+            let name = URL(fileURLWithPath: resultPath).lastPathComponent
+            Logger.beginPhase(
+                resultPaths.count > 1
+                    ? "Reading \(name) (\(resultIndex + 1) of \(resultPaths.count))"
+                    : "Reading \(name)"
+            )
+            // `defer` rather than a call at the end of the body: this loop
+            // `continue`s on an unreadable bundle, which would otherwise leave
+            // the phase open and mis-pair every phase after it.
+            defer { Logger.endPhase() }
+
             let url = URL(fileURLWithPath: resultPath)
             let resultFile = ResultFile(url: url, faultCollector: faultCollector)
 
@@ -190,7 +201,14 @@ public struct Summary {
     /// Generate HTML report
     /// - Returns: Generated HTML report string
     public func generatedHtmlReport() -> String {
-        html
+        Logger.beginPhase("Rendering")
+        // Counted on the way out rather than up front: the count is only worth
+        // reporting alongside the time it took to render them.
+        defer {
+            let count = runs.reduce(0) { $0 + $1.allTests.count }
+            Logger.endPhase("Rendering \(count) test\(count == 1 ? "" : "s")")
+        }
+        return html
     }
 
     /// Generate JUnit report

--- a/Sources/XCTestHTMLReportCore/Classes/Models/Summary.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Models/Summary.swift
@@ -42,32 +42,13 @@ public struct Summary {
 
         bundleNames = Self.bundleNames(from: resultPaths)
 
-        // The CLI already rejects an explicit `legacy` the toolchain cannot
-        // honour in `validate()`. This arm is defence in depth for library
-        // consumers who never pass through the CLI: a non-throwing init
-        // cannot raise the error, so it records a fault — which reaches
-        // exit 3 through the existing path, and is therefore still not a
-        // silent substitution.
-        let resolved: ResultBackend
-        switch backend.resolve() {
-        case let .use(concrete):
-            resolved = concrete
-        case .legacyUnavailable:
-            faultCollector.record(
-                .legacyReaderUnavailable,
-                "legacy reader requested but unavailable on this toolchain"
-            )
-            resolved = .modern
-        }
+        let resolved = Self.resolveBackend(backend, faultCollector: faultCollector)
 
         for (resultIndex, resultPath) in resultPaths.enumerated() {
             Logger.step("Parsing \(resultPath)")
-            let name = URL(fileURLWithPath: resultPath).lastPathComponent
-            Logger.beginPhase(
-                resultPaths.count > 1
-                    ? "Reading \(name) (\(resultIndex + 1) of \(resultPaths.count))"
-                    : "Reading \(name)"
-            )
+            Logger.beginPhase(Self.readingPhaseLabel(
+                path: resultPath, index: resultIndex, total: resultPaths.count
+            ))
             // `defer` rather than a call at the end of the body: this loop
             // `continue`s on an unreadable bundle, which would otherwise leave
             // the phase open and mis-pair every phase after it.

--- a/Sources/XCTestHTMLReportCore/Classes/ResultReading/Modern/ModernPayloadStore.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/ResultReading/Modern/ModernPayloadStore.swift
@@ -150,6 +150,15 @@ final class ModernPayloadStore: PayloadProviding {
         }
         exportAttempted = true
 
+        // One bulk export for the whole bundle, so this phase runs once no
+        // matter how many attachments there are. It is also the phase most
+        // likely to dominate a large run, which is why it reports its count.
+        Logger.beginPhase("Exporting attachments")
+        defer {
+            let count = fileNamesByUUID.count
+            Logger.endPhase("Exporting \(count) attachment\(count == 1 ? "" : "s")")
+        }
+
         let directory = URL(fileURLWithPath: NSTemporaryDirectory())
             .appendingPathComponent("xchtmlreport-attachments-\(UUID().uuidString)")
         do {

--- a/Tests/XCTestHTMLReportTests/ProgressCliTests.swift
+++ b/Tests/XCTestHTMLReportTests/ProgressCliTests.swift
@@ -15,6 +15,35 @@ final class ProgressCliTests: XCTestCase {
         Bundle.testBundle.url(forResource: "TestResults", withExtension: "xcresult")
     }
 
+    /// Every label the reporter can emit. The silence assertions below check
+    /// the whole set rather than one sample: a leak through any other phase
+    /// would otherwise pass unnoticed, which is the failure mode a negative
+    /// test is most prone to.
+    private static let progressLabels = [
+        "Reading ",
+        "Exporting ",
+        "Rendering ",
+        "Writing report",
+        "Wrote ",
+    ]
+
+    private func assertNoProgress(
+        in output: String?,
+        _ stream: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let text = output ?? ""
+        for label in Self.progressLabels {
+            XCTAssertFalse(
+                text.contains(label),
+                "progress label \"\(label)\" leaked onto \(stream):\n\(text)",
+                file: file,
+                line: line
+            )
+        }
+    }
+
     /// The guarantee for every existing script and CI job: nothing new appears.
     func testRedirectedRunEmitsNoProgress() throws {
         let url = try XCTUnwrap(testResultsUrl)
@@ -22,10 +51,7 @@ final class ProgressCliTests: XCTestCase {
         let (status, _, stderr) = try xchtmlreportCmd(args: ["-r", url.path])
 
         XCTAssertEqual(status, 0)
-        XCTAssertFalse(
-            (stderr ?? "").contains("Rendering"),
-            "a redirected run should stay silent, got stderr:\n\(stderr ?? "")"
-        )
+        assertNoProgress(in: stderr, "stderr")
     }
 
     func testProgressFlagForcesPhaseLinesOntoStderr() throws {
@@ -54,10 +80,7 @@ final class ProgressCliTests: XCTestCase {
 
         XCTAssertEqual(status, 0)
         let output = try XCTUnwrap(stdout)
-        XCTAssertFalse(
-            output.contains("Rendering"),
-            "progress must not pollute stdout, got:\n\(output)"
-        )
+        assertNoProgress(in: output, "stdout")
         XCTAssertTrue(
             output.contains("index.html"),
             "stdout should still carry the report path, got:\n\(output)"
@@ -72,9 +95,6 @@ final class ProgressCliTests: XCTestCase {
         )
 
         XCTAssertEqual(status, 0)
-        XCTAssertFalse(
-            (stderr ?? "").contains("Rendering"),
-            "--quiet should win over --progress, got stderr:\n\(stderr ?? "")"
-        )
+        assertNoProgress(in: stderr, "stderr")
     }
 }

--- a/Tests/XCTestHTMLReportTests/ProgressCliTests.swift
+++ b/Tests/XCTestHTMLReportTests/ProgressCliTests.swift
@@ -1,0 +1,80 @@
+//
+//  ProgressCliTests.swift
+//
+//  The end of #237 that only shows up through the real binary: which stream
+//  progress lands on, and whether a redirected run stays as quiet as it was
+//  before the feature existed. `xchtmlreportCmd` captures through pipes, so
+//  stderr is never a terminal here -- which is exactly the case that must stay
+//  silent by default.
+//
+
+import XCTest
+
+final class ProgressCliTests: XCTestCase {
+    private var testResultsUrl: URL? {
+        Bundle.testBundle.url(forResource: "TestResults", withExtension: "xcresult")
+    }
+
+    /// The guarantee for every existing script and CI job: nothing new appears.
+    func testRedirectedRunEmitsNoProgress() throws {
+        let url = try XCTUnwrap(testResultsUrl)
+
+        let (status, _, stderr) = try xchtmlreportCmd(args: ["-r", url.path])
+
+        XCTAssertEqual(status, 0)
+        XCTAssertFalse(
+            (stderr ?? "").contains("Rendering"),
+            "a redirected run should stay silent, got stderr:\n\(stderr ?? "")"
+        )
+    }
+
+    func testProgressFlagForcesPhaseLinesOntoStderr() throws {
+        let url = try XCTUnwrap(testResultsUrl)
+
+        let (status, _, stderr) = try xchtmlreportCmd(args: ["-r", url.path, "--progress"])
+
+        XCTAssertEqual(status, 0)
+        let output = try XCTUnwrap(stderr)
+        XCTAssertTrue(
+            output.contains("Rendering"),
+            "expected a rendering phase line, got:\n\(output)"
+        )
+        XCTAssertNotNil(
+            output.range(of: #"[0-9]+\.[0-9]+s"#, options: .regularExpression),
+            "expected an elapsed time on the phase line, got:\n\(output)"
+        )
+    }
+
+    /// The whole reason progress is on stderr: `xchtmlreport ... | xargs open`
+    /// has to keep working.
+    func testProgressNeverReachesStdout() throws {
+        let url = try XCTUnwrap(testResultsUrl)
+
+        let (status, stdout, _) = try xchtmlreportCmd(args: ["-r", url.path, "--progress"])
+
+        XCTAssertEqual(status, 0)
+        let output = try XCTUnwrap(stdout)
+        XCTAssertFalse(
+            output.contains("Rendering"),
+            "progress must not pollute stdout, got:\n\(output)"
+        )
+        XCTAssertTrue(
+            output.contains("index.html"),
+            "stdout should still carry the report path, got:\n\(output)"
+        )
+    }
+
+    func testQuietSilencesEvenForcedProgress() throws {
+        let url = try XCTUnwrap(testResultsUrl)
+
+        let (status, _, stderr) = try xchtmlreportCmd(
+            args: ["-r", url.path, "--progress", "--quiet"]
+        )
+
+        XCTAssertEqual(status, 0)
+        XCTAssertFalse(
+            (stderr ?? "").contains("Rendering"),
+            "--quiet should win over --progress, got stderr:\n\(stderr ?? "")"
+        )
+    }
+}

--- a/Tests/XCTestHTMLReportTests/ProgressReportingTests.swift
+++ b/Tests/XCTestHTMLReportTests/ProgressReportingTests.swift
@@ -1,0 +1,144 @@
+//
+//  ProgressReportingTests.swift
+//
+//  Progress reporting for #237, where a 400 MB bundle took long enough that the
+//  reporter assumed the tool had hung. The rules here are git's, verbatim from
+//  `man git-push`: progress goes to standard error, on by default only when
+//  that stream is a terminal, forced by --progress and silenced by --quiet.
+//
+
+import Foundation
+import XCTest
+@testable import XCTestHTMLReportCore
+
+final class ProgressReportingTests: XCTestCase {
+    private var lines: [String] = []
+
+    override func setUp() {
+        super.setUp()
+        lines = []
+        Logger.progressOutput = { [weak self] line in self?.lines.append(line) }
+        Logger.progressEnabled = true
+    }
+
+    override func tearDown() {
+        Logger.resetProgressOutput()
+        Logger.progressEnabled = false
+        super.tearDown()
+    }
+
+    // MARK: - When progress is shown
+
+    /// The default for a piped or redirected run, and the reason existing
+    /// scripts and CI logs are unaffected by this feature.
+    func testStderrIsNotATerminalSoProgressIsOff() {
+        XCTAssertFalse(
+            Logger.shouldShowProgress(isTerminal: false, forced: false, quiet: false)
+        )
+    }
+
+    func testStderrIsATerminalSoProgressIsOn() {
+        XCTAssertTrue(
+            Logger.shouldShowProgress(isTerminal: true, forced: false, quiet: false)
+        )
+    }
+
+    func testProgressFlagForcesOutputWhenNotATerminal() {
+        XCTAssertTrue(
+            Logger.shouldShowProgress(isTerminal: false, forced: true, quiet: false)
+        )
+    }
+
+    /// --quiet is the last word, so a script can silence a tool it does not
+    /// control the other flags of.
+    func testQuietOverridesTheProgressFlag() {
+        XCTAssertFalse(
+            Logger.shouldShowProgress(isTerminal: true, forced: true, quiet: true)
+        )
+    }
+
+    // MARK: - What a phase emits
+
+    func testDisabledProgressEmitsNothing() {
+        Logger.progressEnabled = false
+
+        Logger.beginPhase("Reading Big.xcresult")
+        Logger.endPhase()
+
+        XCTAssertEqual(lines, [])
+    }
+
+    func testCompletedPhaseReportsItsLabel() throws {
+        Logger.beginPhase("Reading Big.xcresult")
+        Logger.endPhase()
+
+        XCTAssertEqual(lines.count, 1)
+        let line = try XCTUnwrap(lines.first)
+        XCTAssertTrue(
+            line.contains("Reading Big.xcresult"),
+            "expected the phase label, got: \(line)"
+        )
+    }
+
+    /// The timing is half the point: #237 also asks "what aspects of the
+    /// process are slowest?", and a per-phase duration answers that on the
+    /// user's own data rather than only in our profiling.
+    func testCompletedPhaseReportsElapsedTime() throws {
+        Logger.beginPhase("Rendering")
+        Logger.endPhase()
+
+        let line = try XCTUnwrap(lines.first)
+        XCTAssertNotNil(
+            line.range(of: #"[0-9]+\.[0-9]+s"#, options: .regularExpression),
+            "expected an elapsed time like 1.2s, got: \(line)"
+        )
+    }
+
+    /// A phase cannot always name itself up front: the attachment count is only
+    /// known once the export manifest has been read.
+    func testEndPhaseCanRefineTheLabel() throws {
+        Logger.beginPhase("Exporting attachments")
+        Logger.endPhase("Exporting 2531 attachments")
+
+        let line = try XCTUnwrap(lines.first)
+        XCTAssertTrue(
+            line.contains("Exporting 2531 attachments"),
+            "expected the refined label, got: \(line)"
+        )
+        XCTAssertFalse(
+            lines.contains { $0.contains("Exporting attachments") && !$0.contains("2531") },
+            "the provisional label should not also be emitted"
+        )
+    }
+
+    /// Attachment export is lazy: it fires during a read, so its phase closes
+    /// first and prints first. Indentation is what keeps that legible rather
+    /// than looking like the phases ran out of order.
+    func testNestedPhasesAreIndentedByDepth() {
+        Logger.beginPhase("Reading")
+        Logger.beginPhase("Exporting")
+        Logger.endPhase()
+        Logger.endPhase()
+
+        XCTAssertEqual(lines.count, 2)
+        XCTAssertTrue(
+            lines[0].hasPrefix("  Exporting"),
+            "the nested phase should be indented, got: \(lines[0])"
+        )
+        XCTAssertTrue(
+            lines[1].hasPrefix("Reading"),
+            "the outer phase should not be indented, got: \(lines[1])"
+        )
+    }
+
+    func testPhasesAreReportedInOrder() throws {
+        Logger.beginPhase("Reading")
+        Logger.endPhase()
+        Logger.beginPhase("Rendering")
+        Logger.endPhase()
+
+        XCTAssertEqual(lines.count, 2)
+        XCTAssertTrue(try XCTUnwrap(lines.first).contains("Reading"))
+        XCTAssertTrue(try XCTUnwrap(lines.last).contains("Rendering"))
+    }
+}


### PR DESCRIPTION
Closes half of #237 — the half that is a feature. The other half (why it was slow) is answered in the issue thread and summarised below.

## What it looks like

```
    Exporting 2531 attachments          4.8s
  Reading Big.xcresult                 18.2s
  Rendering 1284 tests                 12.4s
  Writing report                        0.9s
Wrote ./index.html (412 MB)            36.3s
```

Each phase reports itself as it finishes, with its elapsed time. That also answers the issue's *other* question — "what aspects of the process are slowest?" — on the user's own bundle rather than in our profiling.

Phases nest, and the indent is what makes that legible: attachment export is lazy, firing *during* a read, so its phase closes first and prints first. Without the indent it reads as though the phases ran out of order.

## The rules are git's

Verbatim from `man git-push`: progress is reported on **standard error** by default when that stream is a terminal, `--progress` forces it when it is not, `--quiet` silences it. Copying a rule people already know beats inventing one.

stderr also keeps the pipeline contract this repo already documents at `Logger.swift:15` — stdout carries the report path, so `xchtmlreport … | xargs open` must keep working. And because the default is TTY-only, **every existing script and CI job emits exactly what it did before**; there is a test for precisely that.

## Why this rather than an optimisation

Investigating #237 found the structural cause of the runtime: the legacy reader spawns **one `xcrun xcresulttool` process per attachment** (XCResultKit's `exportAttachment` → `Process()`), where the modern 4.0 reader does **one bulk `export attachments`** for the whole bundle and serves lookups from a manifest. Measured, a spawn costs ~70–77 ms and is essentially flat in bundle size, so legacy cost scales with attachment count.

That is already fixed architecturally in 4.0, and legacy is being removed under #391 — so the remaining useful thing is telling the user what is happening, which is what the issue actually asked for.

## Deliberately not in scope

- `step`/`substep` still print to stdout under `-v` — the same pipeline problem in older clothes, but a behaviour change to an existing flag deserves its own decision.
- `accumulateHTMLAsString` is superlinear (measured ×1.91 → ×2.81 per doubling), but it is 0.25s for a 2 MB report. Real; not what cost anyone an hour.

## Tests

14 new, written before the code:

- stream policy — TTY on, non-TTY off, `--progress` forces, `--quiet` wins
- phase output — label, elapsed time, refined label, ordering, nesting indent, silence when disabled
- through the real binary — redirected run stays silent, `--progress` forces phase lines onto stderr, progress never reaches stdout while the report path still does, `--quiet` beats `--progress`

Note: `swift test` shows 16 pre-existing failures on this checkout from stale fixtures (`verify_fixtures.sh` reports `TestResults.xcresult` has 16 tests, expected ≥21; `CrashResults.xcresult` missing). The failing set is byte-identical before and after this change. CI regenerates fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added progress reporting for report generation, including phase timing, nested attachment export activity, rendered test counts, and output file size.
  * Added `--progress` to force progress output and `--quiet` to suppress it.
  * Progress messages are written to stderr while preserving standard output.

* **Documentation**
  * Added README guidance covering progress output, timing, stderr behavior, and command-line controls.

* **Bug Fixes**
  * Improved handling of unsupported result formats and unreadable bundles so processing can continue reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->