### PR TITLE
The bundle does not ship a database — xcresulttool builds it on first read

### DIFF
--- a/.github/workflows/xcresult-schema-probe.yml
+++ b/.github/workflows/xcresult-schema-probe.yml
@@ -67,7 +67,11 @@ jobs:
 
     - name: Capture schema
       run: |
-        python3 scripts/capture_xcresult_schema.py \
+        # --materialise, because `xcodebuild test` does not write
+        # database.sqlite3: xcresulttool builds it on first read. Without this
+        # the probe inspects bundles nothing has read yet, finds no database on
+        # any leg, and learns nothing — which is what run 32057054934 did.
+        python3 scripts/capture_xcresult_schema.py --materialise \
           Tests/XCTestHTMLReportTests/Resources/*.xcresult \
           -o "schema-xcode-${{ matrix.xcode_version }}.json"
 
@@ -82,12 +86,12 @@ jobs:
         tool = report["toolchain"]
         print(f"## Xcode `{tool['xcode']}` (`{tool['xcodeBuild']}`)\n")
         print(f"`{tool['xcresulttool']}`\n")
-        print("| bundle | Info.plist version | backend | tables | schema | read tables | DeveloperTools |")
-        print("| --- | --- | --- | ---: | --- | --- | --- |")
+        print("| bundle | Info.plist version | backend | tables | schema | read tables | shipped | DeveloperTools |")
+        print("| --- | --- | --- | ---: | --- | --- | --- | --- |")
         for bundle in report["bundles"]:
             info, db = bundle["infoPlist"], bundle["database"]
             if not db.get("present"):
-                print(f"| {bundle['name']} | {info.get('version')} | {info.get('storageBackend')} | — | **no database** | — | — |")
+                print(f"| {bundle['name']} | {info.get('version')} | {info.get('storageBackend')} | — | **no database** | — | — | — |")
                 continue
             developer_tools = db.get("developerTools")
             populated = "absent" if developer_tools is None else (
@@ -96,7 +100,8 @@ jobs:
             print(
                 f"| {bundle['name']} | {info.get('version')} | {info.get('storageBackend')} "
                 f"| {db['tableCount']} | `{db['schemaFingerprint'][7:19]}` "
-                f"| `{db['readTablesFingerprint'][7:19]}` | {populated} |"
+                f"| `{db['readTablesFingerprint'][7:19]}` "
+                f"| {'yes' if db.get('shippedWithBundle') else 'built on read'} | {populated} |"
             )
         missing = sorted({m for b in report["bundles"] for m in b["database"].get("readTablesMissing", [])})
         if missing:

--- a/docs/reader-performance.md
+++ b/docs/reader-performance.md
@@ -269,7 +269,8 @@ real bundle.
 
 ### 4. Read `database.sqlite3` directly
 
-Every `.xcresult` inspected carries one, holding a straightforward relational
+Every `.xcresult` that has been *read at least once* carries one (see "The
+database is not shipped" below), holding a straightforward relational
 schema — 40 tables including `TestCases`, `TestSuites`, `TestCaseRuns`,
 `Activities`, `Attachments`, `TestIssues`, `ExpectedFailures`,
 `RepetitionPolicies`, `RunDestinations`, `Devices` — with foreign keys and
@@ -342,9 +343,11 @@ Three things follow:
   third-party Swift package of the same name), it is not shipped as a library,
   and a Mach-O executable cannot be linked or `dlopen`ed. In-process use is not
   available at any risk level, only reimplementation.
-- `libsqlite3` being its *only* non-system dependency is direct evidence that
-  the database is the actual storage engine, not a cache or secondary index —
-  reading it means reading the same source of truth Apple reads.
+- `libsqlite3` being its *only* non-system dependency shows `xcresulttool` uses
+  sqlite. An earlier draft of this document read that as evidence the database
+  *is* the storage engine rather than a cache. **That was wrong** — the linkage
+  cannot distinguish the two, and the probe since established it is derived.
+  See "The database is not shipped" below.
 - `XCResultTypesV3` matches the bundle's `version.major = 3`, which suggests the
   stamped version tracks that types module.
 
@@ -389,6 +392,46 @@ correctly it is over-sensitive (an added index or an unread table trips it) and
 under-sensitive (a change in what an existing column *means* leaves it
 identical). Over-sensitivity is safe — it degrades to correct-but-slow — so it
 composes as defence in depth, not as a gate on its own.
+
+### The database is not shipped — it is built on first read
+
+The first probe run ([32057054934](https://github.com/XCTestHTMLReport/XCTestHTMLReport/actions/runs/32057054934))
+reported **no database on either leg**, against local bundles that plainly had
+one. `Info.plist` read fine on both, so the paths were right.
+
+The explanation is that `xcodebuild test` does not write `database.sqlite3` at
+all. A bundle fresh off a test run contains only `Info.plist` and the
+content-addressed `Data/` store. `xcresulttool` builds the database on its
+**first read** of the bundle and leaves it behind. Demonstrated directly:
+
+```text
+after deleting database.sqlite3:            ABSENT
+after `xcresulttool get test-results tests`: PRESENT
+```
+
+The rebuilt database carries an identical schema fingerprint
+(`c4a11812ff3f…`), so it is deterministically derived from the CAS store. The
+probe saw nothing because it inspected bundles nothing had read yet; local
+bundles had been read dozens of times.
+
+This changes lead 4 in three ways, none of them fatal but none of them small:
+
+- **It is a cache, not the source of truth.** The `Data/` store is. A reader
+  built on the database is reading Apple's derived index, which they are freer
+  to change, relocate, or rebuild than a storage format — and there is no
+  documented contract for either.
+- **A reader cannot start from a fresh bundle.** It would have to invoke
+  `xcresulttool` once to materialise the database, then query it. That is still
+  a good trade — one subprocess for the whole run instead of one per test — but
+  it means depending on an undocumented *side effect* of an unrelated command,
+  which is a worse dependency than reading a file that is simply there.
+- **The performance case survives.** One materialising call plus ~0.5 ms of SQL
+  for every test still beats one ~35 ms subprocess per test at any realistic
+  test count.
+
+`--materialise` now reads each bundle once before inspecting it, and
+`shippedWithBundle` records whether one was there beforehand, so the two facts
+stay distinguishable.
 
 ### The probe
 

--- a/scripts/capture_xcresult_schema.py
+++ b/scripts/capture_xcresult_schema.py
@@ -19,18 +19,27 @@ and is empty. That leaves `Info.plist`'s `version` (3.56 on Xcode 26.2) — the
 only producer-written stamp in the bundle — whose documented meaning is the
 *legacy commands* format version, and the legacy commands are being removed.
 
-So this captures, per bundle: that version, whether the database exists at all
-(older bundles may predate the sqlite backend), and a fingerprint of the schema
-itself. Run it under several Xcode versions and the answer falls out of diffing
-the JSON: if the fingerprint moves and the version does not, there is nothing to
-gate on and the lead needs a different safety story.
+So this captures, per bundle: that version, whether a database exists, and a
+fingerprint of the schema. Run it under several Xcode versions and the answer
+falls out of diffing the JSON: if the fingerprint moves and the version does
+not, there is nothing to gate on and the lead needs a different safety story.
 
-The fingerprint is computed from each table's ordered (column, declared type)
-pairs, not from the DDL text, so it is insensitive to formatting by
-construction and sensitive to anything a reader could depend on.
+**The database is derived, not shipped.** `xcodebuild test` writes only
+`Info.plist` and the content-addressed `Data/` store; `xcresulttool` builds
+`database.sqlite3` on its first read of the bundle and leaves it behind. Delete
+it and the next query recreates it with an identical schema fingerprint. A
+freshly generated bundle therefore has none, which is what the first run of the
+probe workflow found on both legs — so `--materialise` reads each bundle once
+before inspecting it, and `shippedWithBundle` records whether one was there
+beforehand.
+
+The fingerprint is computed from each table's sorted (column, declared type)
+pairs, not from the DDL text, so it is insensitive to formatting and to Apple's
+nondeterministic column order, while remaining sensitive to anything a reader
+could depend on.
 
 Usage:
-    capture_xcresult_schema.py BUNDLE [BUNDLE ...] [-o OUT.json]
+    capture_xcresult_schema.py BUNDLE [BUNDLE ...] [--materialise] [-o OUT.json]
 """
 
 import argparse
@@ -142,10 +151,35 @@ def fingerprint(schema):
     return "sha256:" + hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
 
-def read_database(bundle):
+def materialise(bundle):
+    """Force the derived database into existence by reading the bundle once.
+
+    `database.sqlite3` is **not** written by `xcodebuild test`. A bundle fresh
+    off a test run contains only `Info.plist` and the content-addressed `Data/`
+    store; `xcresulttool` builds the database on its first read and leaves it
+    behind. Delete it and any query recreates it, with an identical schema.
+
+    So a probe that inspects a freshly generated bundle finds no database and
+    learns nothing — which is exactly what the first run of this workflow did
+    on both legs. Read once, then inspect.
+    """
+    subprocess.run(
+        ["xcrun", "xcresulttool", "get", "test-results", "tests",
+         "--path", bundle, "--schema-version", "0.1.0"],
+        capture_output=True,
+        check=False,
+    )
+
+
+def read_database(bundle, force=False):
     path = os.path.join(bundle, "database.sqlite3")
+    # Whether Apple ships it, recorded before anything can create it. Distinct
+    # from `present`, which after `--materialise` says only that a read worked.
+    shipped = os.path.exists(path)
+    if force and not shipped:
+        materialise(bundle)
     if not os.path.exists(path):
-        return {"present": False}
+        return {"present": False, "shippedWithBundle": shipped}
 
     connection = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
     try:
@@ -160,6 +194,7 @@ def read_database(bundle):
         read_schema = {name: schema[name] for name in READ_TABLES if name in schema}
         report = {
             "present": True,
+            "shippedWithBundle": shipped,
             "userVersion": connection.execute("PRAGMA user_version").fetchone()[0],
             "applicationId": connection.execute("PRAGMA application_id").fetchone()[0],
             "tableCount": len(names),
@@ -174,11 +209,11 @@ def read_database(bundle):
     return report
 
 
-def capture_bundle(bundle):
+def capture_bundle(bundle, force=False):
     return {
         "name": os.path.basename(bundle),
         "infoPlist": read_info_plist(bundle),
-        "database": read_database(bundle),
+        "database": read_database(bundle, force=force),
     }
 
 
@@ -186,6 +221,12 @@ def main(argv=None):
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("bundles", nargs="+", help=".xcresult bundles to inspect")
     parser.add_argument("-o", "--output", help="write JSON here instead of stdout")
+    parser.add_argument(
+        "--materialise",
+        action="store_true",
+        help="read each bundle once first, so the derived database exists "
+             "(a freshly generated bundle does not carry one)",
+    )
     args = parser.parse_args(argv)
 
     missing = [bundle for bundle in args.bundles if not os.path.isdir(bundle)]
@@ -194,7 +235,9 @@ def main(argv=None):
 
     report = {
         "toolchain": toolchain(),
-        "bundles": [capture_bundle(bundle) for bundle in args.bundles],
+        "bundles": [
+            capture_bundle(bundle, force=args.materialise) for bundle in args.bundles
+        ],
     }
     text = json.dumps(report, indent=2, sort_keys=True)
     if args.output:

--- a/scripts/test_capture_xcresult_schema.py
+++ b/scripts/test_capture_xcresult_schema.py
@@ -204,6 +204,37 @@ class CaptureTests(unittest.TestCase):
                 {"xcodeBuildVersion": "17C52", "xcodeVersion": "26.2"}
             ])
 
+    def test_records_whether_the_database_was_shipped_with_the_bundle(self):
+        """`xcodebuild test` writes only Info.plist and the content-addressed
+        `Data/` store; `xcresulttool` builds the database on first read. The two
+        facts are different — "Apple ships a database" versus "a read produced
+        one" — and conflating them is what made the probe's first run report
+        `no database` on both legs and learn nothing."""
+        with tempfile.TemporaryDirectory() as root:
+            with_db = make_bundle(root, "A.xcresult", ddl=["CREATE TABLE T (x TEXT)"])
+            without = make_bundle(root, "B.xcresult", ddl=None)
+            report = capture(with_db, without)["bundles"]
+
+            self.assertTrue(report[0]["database"]["shippedWithBundle"])
+            self.assertFalse(report[1]["database"]["shippedWithBundle"])
+
+    def test_materialising_an_unreadable_bundle_is_not_fatal(self):
+        """`--materialise` shells out to xcresulttool, which cannot read these
+        synthetic bundles. That must degrade to "no database" rather than take
+        the whole capture down — the same tolerance the toolchain probes have."""
+        with tempfile.TemporaryDirectory() as root:
+            bundle = make_bundle(root, "A.xcresult", ddl=None)
+
+            result = subprocess.run(
+                [sys.executable, SCRIPT, "--materialise", bundle],
+                capture_output=True, text=True, check=False,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            database = json.loads(result.stdout)["bundles"][0]["database"]
+            self.assertFalse(database["present"])
+            self.assertFalse(database["shippedWithBundle"])
+
     def test_reports_the_toolchain_it_ran_against(self):
         """A fingerprint with no toolchain attached cannot be compared to
         anything."""


### PR DESCRIPTION
The probe ran, and its first real result was that **neither leg had a database
at all** — against local bundles that plainly did, with `Info.plist` reading
fine on both. That turned out not to be a bug in the capture but a fact about
the format, and it retracts something #495 asserted.

## `xcodebuild test` does not write `database.sqlite3`

A bundle fresh off a test run holds only `Info.plist` and the content-addressed
`Data/` store. `xcresulttool` builds the database on its **first read** and
leaves it behind:

```
after deleting database.sqlite3:              ABSENT
after `xcresulttool get test-results tests`:  PRESENT
```

The rebuilt database carries an identical schema fingerprint (`c4a11812ff3f…`),
so it is deterministically derived from the CAS store. The probe saw nothing
because it inspected bundles nothing had read yet — my local ones had been read
dozens of times during this work, which is exactly the sampling bias a
CI-generated fixture was supposed to remove.

## Retracting a claim from #495

That PR said `libsqlite3` being xcresulttool's only non-system dependency was
"direct evidence that the database is the actual storage engine, not a cache or
secondary index — reading it means reading the same source of truth Apple
reads."

**That was wrong.** The linkage shows only that xcresulttool *uses* sqlite; it
cannot distinguish a storage engine from a derived index, and the probe has now
settled it the other way. The doc says so in place rather than quietly
rewording, since the mistaken version is what a reader would have been working
from.

## What it means for lead 4

Not fatal, but not small either — all three recorded in the doc:

- **It is Apple's derived index, not the source of truth.** The `Data/` store
  is. They are freer to change, relocate or rebuild a cache than a storage
  format, and neither carries a documented contract.
- **A reader cannot start from a fresh bundle.** It would have to invoke
  `xcresulttool` once to materialise the database first — so it would depend on
  an undocumented *side effect* of an unrelated command, which is a worse
  dependency than reading a file that is simply there.
- **The performance case survives.** One materialising call plus ~0.5 ms of SQL
  per test still beats one ~35 ms subprocess per test at any realistic size.

## Changes

- `--materialise` reads each bundle once before inspecting, so the probe can
  actually observe a schema; the workflow passes it.
- The capture records `shippedWithBundle` separately from `present`, keeping
  "Apple ships one" and "a read produced one" distinguishable — conflating them
  is what made the first run answer nothing. Summary table gains a column.
- Two tests: that the shipped/derived distinction is recorded, and that
  `--materialise` against a bundle xcresulttool cannot read degrades to "no
  database" rather than taking the capture down.

39 Python tests pass; `zizmor` clean. Docs and probe tooling only — no reader
changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
