### PR TITLE
Tolerate xcrun being absent, which it is on the Linux runner

### DIFF
--- a/scripts/capture_xcresult_schema.py
+++ b/scripts/capture_xcresult_schema.py
@@ -163,12 +163,20 @@ def materialise(bundle):
     learns nothing — which is exactly what the first run of this workflow did
     on both legs. Read once, then inspect.
     """
-    subprocess.run(
-        ["xcrun", "xcresulttool", "get", "test-results", "tests",
-         "--path", bundle, "--schema-version", "0.1.0"],
-        capture_output=True,
-        check=False,
-    )
+    try:
+        subprocess.run(
+            ["xcrun", "xcresulttool", "get", "test-results", "tests",
+             "--path", bundle, "--schema-version", "0.1.0"],
+            capture_output=True,
+            check=False,
+        )
+    except OSError:
+        # No `xcrun` here at all, which is the case on the Linux runner that
+        # runs these tests. A missing executable raises rather than returning
+        # non-zero, so `check=False` does not cover it. Nothing to materialise
+        # is a fact for the capture to record, not a reason to abort it — the
+        # same tolerance `probe` has.
+        pass
 
 
 def read_database(bundle, force=False):

--- a/scripts/test_capture_xcresult_schema.py
+++ b/scripts/test_capture_xcresult_schema.py
@@ -218,6 +218,24 @@ class CaptureTests(unittest.TestCase):
             self.assertTrue(report[0]["database"]["shippedWithBundle"])
             self.assertFalse(report[1]["database"]["shippedWithBundle"])
 
+    def test_materialising_without_xcrun_is_not_fatal(self):
+        """These tests run on Linux in CI, where `xcrun` does not exist at all.
+        A missing executable raises rather than returning non-zero, so
+        `check=False` does not cover it — the same tolerance `probe()` already
+        has. Reproduced here by emptying PATH, which fails the same way on macOS.
+        """
+        with tempfile.TemporaryDirectory() as root:
+            bundle = make_bundle(root, "A.xcresult", ddl=None)
+
+            result = subprocess.run(
+                [sys.executable, SCRIPT, "--materialise", bundle],
+                capture_output=True, text=True, check=False,
+                env={**os.environ, "PATH": root},
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertFalse(json.loads(result.stdout)["bundles"][0]["database"]["present"])
+
     def test_materialising_an_unreadable_bundle_is_not_fatal(self):
         """`--materialise` shells out to xcresulttool, which cannot read these
         synthetic bundles. That must degrade to "no database" rather than take


### PR DESCRIPTION
**`main` is red.** #496 merged before I pushed the follow-up fix, so the version
on `main` crashes the `Lint` workflow's Python test step. This is that fix,
cherry-picked onto `main`.

## What broke

The `shell` job runs the Python tests on ubuntu, where `xcrun` does not exist.
`materialise()` shells out to it with `check=False`, which covers a non-zero
exit but **not a missing executable** — that raises `FileNotFoundError`. So the
capture died and took the job with it.

`probe()` in the same file already had exactly this tolerance. I wrote the
guard once and did not carry it across to the new function.

Demonstrated against both versions with `xcrun` removed from `PATH`, which
reproduces the Linux condition on macOS:

```
main's version:   exit=1  FileNotFoundError: [Errno 2] No such file or directory: 'xcrun'
this branch:      exit=0
```

## Why the existing test missed it

`test_materialising_an_unreadable_bundle_is_not_fatal` runs on macOS, where
`xcrun` *is* present and merely fails to read a synthetic bundle. It exercised
"the command failed" — a different path from "the command does not exist". The
new test empties `PATH` so the failing condition is the one CI actually has.

Confirmed failing before the fix with the identical error, so it is a test that
can catch this rather than one that happens to agree with the code.

## Verification

- 40 Python tests pass.
- `--materialise` still genuinely works where `xcrun` exists — against a real
  bundle stripped of its database: `shippedWithBundle=False`, `present=True`,
  40 tables. The fix does not silently no-op the operation.

Scripts and tests only; no reader or workflow changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Schema capture now completes successfully when the `xcrun` tool is unavailable.
  * Failed external commands no longer interrupt materialisation, and affected bundles are reported without database information.

* **Tests**
  * Added coverage for schema capture in environments where `xcrun` cannot be found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->