### PR TITLE
Index the runnable scripts as mise tasks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,6 +130,10 @@ mise trust && mise install
 That is opt-in on purpose: nothing installs it for you, and `mise trust` is where
 you agree to let the repository run its own setup.
 
+The same file indexes the repository's runnable scripts: `mise tasks` lists
+them (fixture generation and both comparison harnesses), and
+`mise run <task> -- <flags>` runs one with its flags passed through.
+
 The hook is defined in [`hk.pkl`](hk.pkl). It only checks files you are actually
 committing, and reports problems rather than rewriting your files, so a commit
 never contains changes you have not read. To skip it for one commit:

--- a/mise.toml
+++ b/mise.toml
@@ -1,4 +1,5 @@
-# Pinned versions of every tool the lint gate runs, locally and in CI alike.
+# Pinned versions of every tool the lint gate runs, locally and in CI alike —
+# plus, at the bottom, a [tasks] index of the repository's runnable scripts.
 #
 # Before this file, lint.yml installed SwiftFormat and SwiftLint with a bare
 # `brew install` -- whatever version Homebrew had that morning -- while
@@ -42,3 +43,21 @@ HK_MISE = "1"
 # one, and CONTRIBUTING.md carries the one-time fix. Silently rewriting git
 # config someone set by hand is the overreach the old hook argued against.
 postinstall = "hk install --mise"
+
+# The repository's runnable scripts, indexed so `mise tasks` is the menu and
+# nobody has to remember paths. Each entry is a thin pointer: the scripts stay
+# independently runnable by path, own their flags, and document themselves in
+# their READMEs. Flags pass through: `mise run version-compare -- --head`.
+# Tasks run from the repository root, which is what all three scripts expect.
+
+[tasks.fixtures]
+description = "Generate the .xcresult fixture bundles from the sample app"
+run = "./prepareTestResults.sh"
+
+[tasks.viewer-compare]
+description = "Xcode's own report viewer vs ours, side by side over one bundle"
+run = "./scripts/viewer-compare/viewer_compare.sh"
+
+[tasks.version-compare]
+description = "Render fixtures through released versions and diff what each reports"
+run = "./scripts/version-compare/version_compare.sh"


### PR DESCRIPTION
Registers the three run-by-path scripts in `mise.toml`'s new `[tasks]` section — `fixtures` (prepareTestResults.sh), `viewer-compare`, and `version-compare` — so `mise tasks` is the discoverable menu and `mise run <task> -- <flags>` forwards flags. mise is already the one tool every contributor installs, which is why this lives there rather than in a new Justfile. The scripts stay independently runnable by path; each still owns its flags and README. CONTRIBUTING gains a two-line pointer.

Verified locally: `mise tasks` lists all three; `mise run version-compare -- --help` prints the script's usage and exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance for discovering and running repository checks through the project’s task runner.
  - Documented how to pass flags to individual tasks.

- **Chores**
  - Added runnable tasks for generating fixtures and running viewer and version comparison checks.
  - Tasks include descriptions and execute from the repository root.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->